### PR TITLE
[refactor] 경매 상품 등록시 이미지 업로드 후 삭제 기능 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ out/
 *.log
 nginx/logs/*
 !nginx/logs/.gitkeep
+uploads/
 
 ### OS files ###
 .DS_Store

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,8 +57,12 @@ services:
       JWT_ACCESS_TOKEN_EXPIRATION_MS: ${JWT_ACCESS_TOKEN_EXPIRATION_MS:-3600000}
       JWT_ISSUER: ${JWT_ISSUER:-dealit}
       APP_CORS_ALLOWED_ORIGINS: ${APP_CORS_ALLOWED_ORIGINS:-http://localhost:3000,http://127.0.0.1:3000,http://localhost:${NGINX_PORT:-80}}
+      APP_IMAGES_PUBLIC_BASE_URL: ${APP_IMAGES_PUBLIC_BASE_URL:-http://localhost}
+      APP_IMAGES_STORAGE_ROOT: ${APP_IMAGES_STORAGE_ROOT:-/app/uploads}
     ports:
       - "${SERVER_PORT:-8080}:8080"
+    volumes:
+      - auction-image-data:/app/uploads
     healthcheck:
       test: ["CMD-SHELL", "curl --fail --silent http://localhost:8080/actuator/health || exit 1"]
       interval: 15s
@@ -78,5 +82,6 @@ services:
       - ./nginx/logs:/var/log/nginx
 
 volumes:
+  auction-image-data:
   postgres-data:
   redis-data:

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -125,6 +125,27 @@ paths:
             '*/*':
               schema:
                 $ref: "#/components/schemas/UploadAuctionImageResponse"
+  /api/v1/auction/image/{imageId}:
+    delete:
+      tags:
+      - Auction
+      summary: 상품 이미지 삭제
+      description: 등록 전에 업로드된 임시 이미지를 imageId 기준으로 삭제한다.
+      operationId: deleteImage
+      parameters:
+      - name: imageId
+        in: path
+        required: true
+        schema:
+          type: integer
+          format: int64
+      responses:
+        "200":
+          description: 이미지 삭제 성공
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/DeleteAuctionImageResponse"
   /api/v1/auction/draft:
     post:
       tags:
@@ -371,7 +392,7 @@ components:
         imageUrl:
           type: string
           description: 이미지 URL
-          example: https://cdn.dealit.local/auction/images/1.jpg
+          example: http://localhost:8080/auction/images/1-sample.jpg
           minLength: 1
         sortOrder:
           type: integer
@@ -458,7 +479,23 @@ components:
         imageUrl:
           type: string
           description: 업로드된 이미지 URL
-          example: https://cdn.dealit.local/auction/images/301-sample.jpg
+          example: http://localhost:8080/auction/images/301-sample.jpg
+    DeleteAuctionImageResponse:
+      type: object
+      description: 상품 이미지 삭제 응답
+      properties:
+        imageId:
+          type: integer
+          format: int64
+          description: 삭제된 이미지 ID
+          example: 5
+        deleted:
+          type: boolean
+          description: 삭제 성공 여부
+          example: true
+      required:
+      - imageId
+      - deleted
     SaveAuctionDraftRequest:
       type: object
       description: 경매 상품 임시저장 요청

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -23,6 +23,10 @@ server {
         proxy_pass http://backend:8080;
     }
 
+    location /auction/images/ {
+        proxy_pass http://backend:8080;
+    }
+
     location /swagger-ui/ {
         proxy_pass http://backend:8080;
     }

--- a/src/main/java/com/dealit/dealit/DealitApplication.java
+++ b/src/main/java/com/dealit/dealit/DealitApplication.java
@@ -2,8 +2,10 @@ package com.dealit.dealit;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 
 @SpringBootApplication
+@ConfigurationPropertiesScan
 public class DealitApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/dealit/dealit/domain/auction/AuctionStatus.java
+++ b/src/main/java/com/dealit/dealit/domain/auction/AuctionStatus.java
@@ -4,5 +4,6 @@ public enum AuctionStatus {
 	DRAFT,
 	ON_SALE,
 	AUCTION_SCHEDULED,
-	AUCTION_LIVE
+	AUCTION_LIVE,
+	ENDED
 }

--- a/src/main/java/com/dealit/dealit/domain/auction/controller/AuctionController.java
+++ b/src/main/java/com/dealit/dealit/domain/auction/controller/AuctionController.java
@@ -2,6 +2,7 @@ package com.dealit.dealit.domain.auction.controller;
 
 import com.dealit.dealit.domain.auction.dto.CreateAuctionRequest;
 import com.dealit.dealit.domain.auction.dto.CreateAuctionResponse;
+import com.dealit.dealit.domain.auction.dto.DeleteAuctionImageResponse;
 import com.dealit.dealit.domain.auction.dto.RecommendCategoryRequest;
 import com.dealit.dealit.domain.auction.dto.RecommendCategoryResponse;
 import com.dealit.dealit.domain.auction.dto.RecommendPriceRequest;
@@ -19,6 +20,8 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -41,6 +44,14 @@ public class AuctionController {
 	@PostMapping(value = "/image", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
 	public UploadAuctionImageResponse uploadImage(@RequestPart("file") MultipartFile file) {
 		return auctionService.uploadImage(file);
+	}
+
+	@Operation(summary = "상품 이미지 삭제", description = "등록 전에 업로드된 임시 이미지를 imageId 기준으로 삭제한다.")
+	@ApiResponse(responseCode = "200", description = "이미지 삭제 성공",
+		content = @Content(schema = @Schema(implementation = DeleteAuctionImageResponse.class)))
+	@DeleteMapping("/image/{imageId}")
+	public DeleteAuctionImageResponse deleteImage(@PathVariable Long imageId) {
+		return auctionService.deleteImage(imageId);
 	}
 
 	@Operation(summary = "경매 상품 임시저장", description = "등록 직전 폼 데이터를 draft 상태로 저장한다.")

--- a/src/main/java/com/dealit/dealit/domain/auction/dto/CreateAuctionResponse.java
+++ b/src/main/java/com/dealit/dealit/domain/auction/dto/CreateAuctionResponse.java
@@ -4,6 +4,9 @@ import com.dealit.dealit.domain.auction.AuctionStatus;
 import com.dealit.dealit.domain.auction.ProductSaleType;
 import io.swagger.v3.oas.annotations.media.Schema;
 
+import java.time.OffsetDateTime;
+import java.util.Objects;
+
 @Schema(description = "경매 상품 등록 응답")
 public record CreateAuctionResponse(
 	@Schema(description = "등록된 상품 ID", example = "1001")
@@ -13,6 +16,27 @@ public record CreateAuctionResponse(
 	ProductSaleType saleType,
 
 	@Schema(description = "상품 상태", example = "AUCTION_LIVE")
-	AuctionStatus status
+	AuctionStatus status,
+
+	@Schema(description = "경매 메타 정보")
+	AuctionScheduleResponse auction
 ) {
+
+	@Schema(description = "경매 일정 및 상태 정보")
+	public record AuctionScheduleResponse(
+		@Schema(description = "경매 상태", example = "AUCTION_SCHEDULED")
+		AuctionStatus status,
+
+		@Schema(description = "경매 시작 시각", example = "2026-04-15T10:00:00Z")
+		OffsetDateTime startAt,
+
+		@Schema(description = "경매 종료 시각", example = "2026-04-15T12:00:00Z")
+		OffsetDateTime endAt
+	) {
+		public AuctionScheduleResponse {
+			Objects.requireNonNull(status, "auction.status must not be null");
+			Objects.requireNonNull(startAt, "auction.startAt must not be null");
+			Objects.requireNonNull(endAt, "auction.endAt must not be null");
+		}
+	}
 }

--- a/src/main/java/com/dealit/dealit/domain/auction/dto/DeleteAuctionImageResponse.java
+++ b/src/main/java/com/dealit/dealit/domain/auction/dto/DeleteAuctionImageResponse.java
@@ -1,0 +1,13 @@
+package com.dealit.dealit.domain.auction.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "상품 이미지 삭제 응답")
+public record DeleteAuctionImageResponse(
+	@Schema(description = "삭제된 이미지 ID", example = "5")
+	Long imageId,
+
+	@Schema(description = "삭제 성공 여부", example = "true")
+	boolean deleted
+) {
+}

--- a/src/main/java/com/dealit/dealit/domain/auction/dto/ProductImagePayload.java
+++ b/src/main/java/com/dealit/dealit/domain/auction/dto/ProductImagePayload.java
@@ -12,7 +12,7 @@ public record ProductImagePayload(
 	@Positive(message = "이미지 ID는 1 이상이어야 합니다.")
 	Long imageId,
 
-	@Schema(description = "이미지 URL", example = "https://cdn.dealit.local/auction/images/1.jpg")
+	@Schema(description = "이미지 URL", example = "http://localhost:8080/auction/images/1-sample.jpg")
 	@NotBlank(message = "이미지 URL은 필수입니다.")
 	String imageUrl,
 

--- a/src/main/java/com/dealit/dealit/domain/auction/dto/UploadAuctionImageResponse.java
+++ b/src/main/java/com/dealit/dealit/domain/auction/dto/UploadAuctionImageResponse.java
@@ -7,7 +7,7 @@ public record UploadAuctionImageResponse(
 	@Schema(description = "업로드된 이미지 ID", example = "301")
 	Long imageId,
 
-	@Schema(description = "업로드된 이미지 URL", example = "https://cdn.dealit.local/auction/images/301-sample.jpg")
+	@Schema(description = "업로드된 이미지 URL", example = "http://localhost:8080/auction/images/301-sample.jpg")
 	String imageUrl
 ) {
 }

--- a/src/main/java/com/dealit/dealit/domain/auction/repository/AuctionProductImageRepository.java
+++ b/src/main/java/com/dealit/dealit/domain/auction/repository/AuctionProductImageRepository.java
@@ -5,8 +5,11 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 
 public interface AuctionProductImageRepository extends JpaRepository<AuctionProductImage, Long> {
 
 	List<AuctionProductImage> findAllByImageIdInAndDeletedAtIsNull(Collection<Long> imageIds);
+
+	Optional<AuctionProductImage> findByImageIdAndDeletedAtIsNull(Long imageId);
 }

--- a/src/main/java/com/dealit/dealit/domain/auction/service/AuctionImageStorage.java
+++ b/src/main/java/com/dealit/dealit/domain/auction/service/AuctionImageStorage.java
@@ -1,0 +1,58 @@
+package com.dealit.dealit.domain.auction.service;
+
+import com.dealit.dealit.domain.auction.exception.InvalidAuctionRequestException;
+import com.dealit.dealit.global.config.ImageProperties;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+@Component
+@RequiredArgsConstructor
+public class AuctionImageStorage {
+
+	private final ImageProperties imageProperties;
+
+	public String store(Long imageId, MultipartFile file, String originalFilename) {
+		String storedFileName = imageId + "-" + sanitizeFilename(originalFilename);
+		Path directory = imageProperties.auctionImageDirectory();
+		Path targetFile = directory.resolve(storedFileName);
+
+		try {
+			Files.createDirectories(directory);
+			file.transferTo(targetFile);
+		} catch (IOException exception) {
+			throw new InvalidAuctionRequestException("이미지 파일 저장에 실패했습니다.");
+		}
+
+		return storedFileName;
+	}
+
+	public void delete(String imagePath) {
+		Path relativePath = Path.of(imagePath.replaceFirst("^/+", ""));
+		Path targetFile = imageProperties.auctionImageDirectory().getParent().getParent().resolve(relativePath);
+
+		try {
+			Files.deleteIfExists(targetFile);
+		} catch (IOException exception) {
+			throw new InvalidAuctionRequestException("이미지 파일 삭제에 실패했습니다.");
+		}
+	}
+
+	private String sanitizeFilename(String originalFilename) {
+		String fileNameOnly = Path.of(originalFilename).getFileName().toString().trim();
+		String normalized = fileNameOnly
+			.replaceAll("\\s+", "-")
+			.replaceAll("[^\\p{L}\\p{N}._()-]", "-")
+			.replaceAll("-{2,}", "-");
+
+		if (normalized.isBlank()) {
+			return "image.jpg";
+		}
+
+		return normalized;
+	}
+}

--- a/src/main/java/com/dealit/dealit/domain/auction/service/AuctionService.java
+++ b/src/main/java/com/dealit/dealit/domain/auction/service/AuctionService.java
@@ -4,6 +4,7 @@ import com.dealit.dealit.domain.auction.AuctionStatus;
 import com.dealit.dealit.domain.auction.ProductSaleType;
 import com.dealit.dealit.domain.auction.dto.CreateAuctionRequest;
 import com.dealit.dealit.domain.auction.dto.CreateAuctionResponse;
+import com.dealit.dealit.domain.auction.dto.DeleteAuctionImageResponse;
 import com.dealit.dealit.domain.auction.dto.ProductImagePayload;
 import com.dealit.dealit.domain.auction.dto.RecommendCategoryRequest;
 import com.dealit.dealit.domain.auction.dto.RecommendCategoryResponse;
@@ -20,6 +21,7 @@ import com.dealit.dealit.domain.auction.exception.InvalidAuctionRequestException
 import com.dealit.dealit.domain.auction.repository.AuctionDraftRepository;
 import com.dealit.dealit.domain.auction.repository.AuctionProductImageRepository;
 import com.dealit.dealit.domain.auction.repository.AuctionProductRepository;
+import com.dealit.dealit.global.service.ImageUrlService;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
@@ -40,11 +42,11 @@ import java.util.Map;
 @RequiredArgsConstructor
 public class AuctionService {
 
-	private static final String IMAGE_BASE_URL = "https://cdn.dealit.local/auction/images/";
-
 	private final AuctionProductRepository auctionProductRepository;
 	private final AuctionProductImageRepository auctionProductImageRepository;
 	private final AuctionDraftRepository auctionDraftRepository;
+	private final AuctionImageStorage auctionImageStorage;
+	private final ImageUrlService imageUrlService;
 	private final ObjectMapper objectMapper;
 
 	@Transactional
@@ -54,14 +56,30 @@ public class AuctionService {
 		}
 
 		String originalFilename = file.getOriginalFilename() == null ? "image.jpg" : file.getOriginalFilename().trim();
-		String sanitizedFilename = originalFilename.replaceAll("\\s+", "-");
 		AuctionProductImage savedImage = auctionProductImageRepository.save(
-			AuctionProductImage.createTemporary(IMAGE_BASE_URL + sanitizedFilename, originalFilename)
+			AuctionProductImage.createTemporary("", originalFilename)
 		);
 
-		String imageUrl = IMAGE_BASE_URL + savedImage.getImageId() + "-" + sanitizedFilename;
-		savedImage.updateImageUrl(imageUrl);
-		return new UploadAuctionImageResponse(savedImage.getImageId(), imageUrl);
+		String storedFileName = auctionImageStorage.store(savedImage.getImageId(), file, originalFilename);
+		savedImage.updateImageUrl(imageUrlService.toAuctionImagePath(storedFileName));
+		return new UploadAuctionImageResponse(
+			savedImage.getImageId(),
+			imageUrlService.toPublicUrl(savedImage.getImageUrl())
+		);
+	}
+
+	@Transactional
+	public DeleteAuctionImageResponse deleteImage(Long imageId) {
+		AuctionProductImage image = auctionProductImageRepository.findByImageIdAndDeletedAtIsNull(imageId)
+			.orElseThrow(() -> new AuctionImageNotFoundException("존재하지 않는 이미지입니다."));
+
+		if (image.getProduct() != null) {
+			throw new InvalidAuctionRequestException("이미 상품에 연결된 이미지는 삭제할 수 없습니다.");
+		}
+
+		auctionImageStorage.delete(image.getImageUrl());
+		image.softDelete();
+		return new DeleteAuctionImageResponse(image.getImageId(), true);
 	}
 
 	@Transactional
@@ -175,7 +193,16 @@ public class AuctionService {
 		}
 		auctionProductImageRepository.saveAll(imagesById.values());
 
-		return new CreateAuctionResponse(product.getProductId(), product.getSaleType(), product.getStatus());
+		CreateAuctionResponse.AuctionScheduleResponse auction = product.getSaleType() == ProductSaleType.AUCTION
+			? buildAuctionScheduleResponse(product)
+			: null;
+
+		return new CreateAuctionResponse(
+			product.getProductId(),
+			product.getSaleType(),
+			product.getStatus(),
+			auction
+		);
 	}
 
 	private Map<Long, AuctionProductImage> loadRequestedImages(List<ProductImagePayload> imagePayloads) {
@@ -198,6 +225,18 @@ public class AuctionService {
 
 		validateDuplicateImageIds(imageIds, imagesById.keySet());
 		return imagesById;
+	}
+
+	private CreateAuctionResponse.AuctionScheduleResponse buildAuctionScheduleResponse(AuctionProduct product) {
+		if (product.getAuctionStartAt() == null || product.getAuctionEndAt() == null) {
+			throw new InvalidAuctionRequestException("경매 응답에는 시작 시각과 종료 시각이 반드시 포함되어야 합니다.");
+		}
+
+		return new CreateAuctionResponse.AuctionScheduleResponse(
+			product.getStatus(),
+			product.getAuctionStartAt(),
+			product.getAuctionEndAt()
+		);
 	}
 
 	private void validateDuplicateImageIds(List<Long> imageIds, Collection<Long> storedImageIds) {

--- a/src/main/java/com/dealit/dealit/global/config/ImageProperties.java
+++ b/src/main/java/com/dealit/dealit/global/config/ImageProperties.java
@@ -1,0 +1,33 @@
+package com.dealit.dealit.global.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+@ConfigurationProperties(prefix = "app.images")
+public record ImageProperties(
+	String publicBaseUrl,
+	String storageRoot
+) {
+
+	public static final String AUCTION_IMAGE_PATH_PREFIX = "/auction/images/";
+
+	public Path auctionImageDirectory() {
+		return Paths.get(storageRoot).resolve("auction").resolve("images");
+	}
+
+	public String auctionImagePath(String storedFileName) {
+		return AUCTION_IMAGE_PATH_PREFIX + storedFileName;
+	}
+
+	public String normalizedPublicBaseUrl() {
+		if (publicBaseUrl == null || publicBaseUrl.isBlank()) {
+			throw new IllegalStateException("app.images.public-base-url must not be blank");
+		}
+
+		return publicBaseUrl.endsWith("/")
+			? publicBaseUrl.substring(0, publicBaseUrl.length() - 1)
+			: publicBaseUrl;
+	}
+}

--- a/src/main/java/com/dealit/dealit/global/config/SecurityConfig.java
+++ b/src/main/java/com/dealit/dealit/global/config/SecurityConfig.java
@@ -41,6 +41,7 @@ public class SecurityConfig {
 				.requestMatchers(
 					"/",
 					"/error",
+					"/auction/images/**",
 					"/api/v1/health",
 					"/api/v1/members/signup",
 					"/api/v1/auth/login",

--- a/src/main/java/com/dealit/dealit/global/config/StaticResourceConfig.java
+++ b/src/main/java/com/dealit/dealit/global/config/StaticResourceConfig.java
@@ -1,0 +1,21 @@
+package com.dealit.dealit.global.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+@RequiredArgsConstructor
+public class StaticResourceConfig implements WebMvcConfigurer {
+
+	private final ImageProperties imageProperties;
+
+	@Override
+	public void addResourceHandlers(ResourceHandlerRegistry registry) {
+		String location = imageProperties.auctionImageDirectory().toUri().toString();
+
+		registry.addResourceHandler(ImageProperties.AUCTION_IMAGE_PATH_PREFIX + "**")
+			.addResourceLocations(location);
+	}
+}

--- a/src/main/java/com/dealit/dealit/global/service/ImageUrlService.java
+++ b/src/main/java/com/dealit/dealit/global/service/ImageUrlService.java
@@ -1,0 +1,48 @@
+package com.dealit.dealit.global.service;
+
+import com.dealit.dealit.global.config.ImageProperties;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.util.UriUtils;
+
+import java.nio.charset.StandardCharsets;
+
+@Service
+@RequiredArgsConstructor
+public class ImageUrlService {
+
+	private static final String LEGACY_CDN_BASE_URL = "https://cdn.dealit.local";
+
+	private final ImageProperties imageProperties;
+
+	public String toAuctionImagePath(String storedFileName) {
+		return imageProperties.auctionImagePath(storedFileName);
+	}
+
+	public String toAuctionImageUrl(String storedFileName) {
+		return toPublicUrl(toAuctionImagePath(storedFileName));
+	}
+
+	public String toPublicUrl(String imagePathOrUrl) {
+		String normalizedPath = normalizePath(imagePathOrUrl);
+		if (normalizedPath.startsWith("http://") || normalizedPath.startsWith("https://")) {
+			return normalizedPath;
+		}
+		return imageProperties.normalizedPublicBaseUrl() + UriUtils.encodePath(normalizedPath, StandardCharsets.UTF_8);
+	}
+
+	private String normalizePath(String imagePathOrUrl) {
+		if (imagePathOrUrl == null || imagePathOrUrl.isBlank()) {
+			throw new IllegalArgumentException("imagePathOrUrl must not be blank");
+		}
+
+		if (imagePathOrUrl.startsWith("http://") || imagePathOrUrl.startsWith("https://")) {
+			if (imagePathOrUrl.startsWith(LEGACY_CDN_BASE_URL)) {
+				return imagePathOrUrl.substring(LEGACY_CDN_BASE_URL.length());
+			}
+			return imagePathOrUrl;
+		}
+
+		return imagePathOrUrl.startsWith("/") ? imagePathOrUrl : "/" + imagePathOrUrl;
+	}
+}

--- a/src/main/resources/application-docker.yml
+++ b/src/main/resources/application-docker.yml
@@ -15,3 +15,7 @@ spring:
       hibernate:
         format_sql: ${JPA_FORMAT_SQL:true}
     show-sql: ${JPA_SHOW_SQL:false}
+
+app:
+  images:
+    public-base-url: ${APP_IMAGES_PUBLIC_BASE_URL:http://localhost}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,6 +13,9 @@ server:
 app:
   cors:
     allowed-origins: ${APP_CORS_ALLOWED_ORIGINS:http://localhost:3000,http://127.0.0.1:3000,http://localhost:80}
+  images:
+    public-base-url: ${APP_IMAGES_PUBLIC_BASE_URL:http://localhost:${SERVER_PORT:8080}}
+    storage-root: ${APP_IMAGES_STORAGE_ROOT:${user.dir}/uploads}
 
 jwt:
   secret: ${JWT_SECRET:dealit-local-secret-key-dealit-local-secret-key}

--- a/src/test/java/com/dealit/dealit/domain/auction/AuctionIntegrationTest.java
+++ b/src/test/java/com/dealit/dealit/domain/auction/AuctionIntegrationTest.java
@@ -2,17 +2,33 @@ package com.dealit.dealit.domain.auction;
 
 import com.dealit.dealit.domain.auction.entity.AuctionProductImage;
 import com.dealit.dealit.domain.auction.repository.AuctionProductImageRepository;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Comparator;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.startsWith;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -27,17 +43,87 @@ class AuctionIntegrationTest {
 	@Autowired
 	private AuctionProductImageRepository auctionProductImageRepository;
 
+	@Value("${app.images.storage-root}")
+	private String imageStorageRoot;
+
 	private AuctionProductImage uploadedImage;
 
 	@BeforeEach
-	void setUp() {
+	void setUp() throws IOException {
 		auctionProductImageRepository.deleteAll();
+		deleteStoredImages();
 		uploadedImage = auctionProductImageRepository.save(
 			AuctionProductImage.createTemporary(
-				"https://cdn.dealit.local/auction/images/test-image.jpg",
+				"/auction/images/test-image.jpg",
 				"test-image.jpg"
 			)
 		);
+	}
+
+	@AfterEach
+	void tearDown() throws IOException {
+		deleteStoredImages();
+	}
+
+	@Test
+	@DisplayName("이미지 업로드 응답은 브라우저에서 접근 가능한 절대 URL을 반환하고 정적 서빙된다")
+	void uploadAuctionImageReturnsAccessibleUrl() throws Exception {
+		byte[] imageBytes = "test-image".getBytes();
+		MockMultipartFile file = new MockMultipartFile(
+			"file",
+			"스크린샷 2026-04-14 오전 11.28.49.png",
+			MediaType.IMAGE_PNG_VALUE,
+			imageBytes
+		);
+
+		mockMvc.perform(multipart("/api/v1/auction/image").file(file))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.imageId").isNumber())
+			.andExpect(jsonPath("$.imageUrl").value(startsWith("http://localhost:8080/auction/images/")))
+			.andExpect(jsonPath("$.imageUrl").value(containsString("%EC%8A%A4%ED%81%AC")))
+			.andReturn();
+
+		AuctionProductImage savedImage = auctionProductImageRepository.findAll().stream()
+			.filter(image -> image.getOriginalFileName().equals("스크린샷 2026-04-14 오전 11.28.49.png"))
+			.findFirst()
+			.orElseThrow();
+
+		mockMvc.perform(get(savedImage.getImageUrl()))
+			.andExpect(status().isOk())
+			.andExpect(content().bytes(imageBytes));
+	}
+
+	@Test
+	@DisplayName("임시 업로드 이미지는 imageId 기준으로 삭제할 수 있다")
+	void deleteAuctionImageSuccess() throws Exception {
+		byte[] imageBytes = "delete-me".getBytes();
+		MockMultipartFile file = new MockMultipartFile(
+			"file",
+			"delete-target.png",
+			MediaType.IMAGE_PNG_VALUE,
+			imageBytes
+		);
+
+		mockMvc.perform(multipart("/api/v1/auction/image").file(file))
+			.andExpect(status().isOk());
+
+		AuctionProductImage savedImage = auctionProductImageRepository.findAll().stream()
+			.filter(image -> image.getOriginalFileName().equals("delete-target.png"))
+			.findFirst()
+			.orElseThrow();
+
+		mockMvc.perform(delete("/api/v1/auction/image/{imageId}", savedImage.getImageId()))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.imageId", is(savedImage.getImageId().intValue())))
+			.andExpect(jsonPath("$.deleted").value(true));
+
+		mockMvc.perform(delete("/api/v1/auction/image/{imageId}", savedImage.getImageId()))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.code").value("AUCTION_IMAGE_NOT_FOUND"));
+
+		Path deletedFilePath = Path.of(imageStorageRoot)
+			.resolve(savedImage.getImageUrl().replaceFirst("^/auction/images/", "auction/images/"));
+		org.assertj.core.api.Assertions.assertThat(Files.exists(deletedFilePath)).isFalse();
 	}
 
 	@Test
@@ -57,7 +143,7 @@ class AuctionIntegrationTest {
 					  "images": [
 					    {
 					      "imageId": %d,
-					      "imageUrl": "https://cdn.dealit.local/auction/images/test-image.jpg",
+					      "imageUrl": "http://localhost:8080/auction/images/test-image.jpg",
 					      "sortOrder": 1
 					    }
 					  ],
@@ -68,7 +154,8 @@ class AuctionIntegrationTest {
 			.andExpect(status().isCreated())
 			.andExpect(jsonPath("$.productId").isNumber())
 			.andExpect(jsonPath("$.saleType").value("REGULAR"))
-			.andExpect(jsonPath("$.status").value("ON_SALE"));
+			.andExpect(jsonPath("$.status").value("ON_SALE"))
+			.andExpect(jsonPath("$.auction").value(nullValue()));
 	}
 
 	@Test
@@ -89,7 +176,7 @@ class AuctionIntegrationTest {
 					  "images": [
 					    {
 					      "imageId": %d,
-					      "imageUrl": "https://cdn.dealit.local/auction/images/test-image.jpg",
+					      "imageUrl": "http://localhost:8080/auction/images/test-image.jpg",
 					      "sortOrder": 1
 					    }
 					  ],
@@ -100,7 +187,10 @@ class AuctionIntegrationTest {
 			.andExpect(status().isCreated())
 			.andExpect(jsonPath("$.productId").isNumber())
 			.andExpect(jsonPath("$.saleType").value("AUCTION"))
-			.andExpect(jsonPath("$.status").value("AUCTION_SCHEDULED"));
+			.andExpect(jsonPath("$.status").value("AUCTION_SCHEDULED"))
+			.andExpect(jsonPath("$.auction.status").value("AUCTION_SCHEDULED"))
+			.andExpect(jsonPath("$.auction.startAt").value("2099-04-15T10:00:00Z"))
+			.andExpect(jsonPath("$.auction.endAt").value("2099-04-15T12:00:00Z"));
 	}
 
 	@Test
@@ -121,7 +211,7 @@ class AuctionIntegrationTest {
 					  "images": [
 					    {
 					      "imageId": %d,
-					      "imageUrl": "https://cdn.dealit.local/auction/images/test-image.jpg",
+					      "imageUrl": "http://localhost:8080/auction/images/test-image.jpg",
 					      "sortOrder": 1
 					    }
 					  ],
@@ -132,5 +222,23 @@ class AuctionIntegrationTest {
 			.andExpect(status().isBadRequest())
 			.andExpect(jsonPath("$.code").value("INVALID_AUCTION_REQUEST"))
 			.andExpect(jsonPath("$.message").value("경매 판매에서는 시작 시각이 필수입니다."));
+	}
+
+	private void deleteStoredImages() throws IOException {
+		Path storageRoot = Path.of(imageStorageRoot);
+		if (!Files.exists(storageRoot)) {
+			return;
+		}
+
+		try (var paths = Files.walk(storageRoot)) {
+			paths.sorted(Comparator.reverseOrder())
+				.forEach(path -> {
+					try {
+						Files.deleteIfExists(path);
+					} catch (IOException exception) {
+						throw new RuntimeException(exception);
+					}
+				});
+		}
 	}
 }

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -22,3 +22,8 @@ management:
   health:
     redis:
       enabled: false
+
+app:
+  images:
+    public-base-url: http://localhost:8080
+    storage-root: ${java.io.tmpdir}/dealit-test-uploads


### PR DESCRIPTION
### 🚀 Summary

<!-- 작업 내용에 대한 간략한 설명을 써주세요. -->
- 업로드 후 삭제 기능을 추가.
- 우선 이미지 원본파일은 로컬에서 저장, 추후 s3로 리팩토링 할 예정.
- 현재는 로컬상황이기에 url경로를 로컬위주로 수정
---

### ✨ Description
추가
<img width="954" height="606" alt="스크린샷 2026-04-14 오후 3 24 56" src="https://github.com/user-attachments/assets/d606c90d-752d-4908-ba92-0450fbd91804" />

삭제 (현재 이미지 id :10)
<!-- 상세한 설명, 기능의 사용법, 주의 사항 실행 결과(이미지 첨부 가능) 등을 보여주세요. -->
<img width="1012" height="503" alt="스크린샷 2026-04-14 오후 3 25 47" src="https://github.com/user-attachments/assets/a451eee4-c8e3-4863-b084-9cc1f6e1e856" />

삭제성공
<img width="995" height="569" alt="스크린샷 2026-04-14 오후 3 26 03" src="https://github.com/user-attachments/assets/0ed5fb43-9be9-4597-a188-09714ecd20ea" />

DB반영
<img width="610" height="351" alt="스크린샷 2026-04-14 오후 3 03 05" src="https://github.com/user-attachments/assets/721a9e5b-66ad-4ba8-b340-73b0dc285ec5" />


---

### 🎲 Issue Number

<!-- Please enter {Issue Number} below to automatically close the connected issue. -->

close #14 