### PR TITLE
[Feat] 상품 상세 페이지 API 작업

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -11,10 +11,14 @@ servers:
 security:
 - bearerAuth: []
 tags:
+- name: Events
+  description: 앱 전역 실시간 이벤트 API
 - name: Health
   description: 애플리케이션 상태 확인 API
 - name: Product
   description: 일반 상품 등록 API
+- name: Product Detail
+  description: 상품 상세 조회 API
 - name: Location
   description: 위치 보조 API
 - name: Email Verification
@@ -23,193 +27,16 @@ tags:
   description: 경매 상품 등록 API
 - name: Member
   description: 회원 API
+- name: Auction
+  description: 경매 상품 관리 API
+- name: Chats
+  description: 채팅 API
 - name: Profile
   description: 마이페이지 프로필 API
 - name: Auth
   description: 인증 API
-- name: Chats
-  description: 채팅 API
-- name: Events
-  description: 앱 전역 실시간 이벤트 API
 paths:
-  "/api/v1/events/stream":
-    get:
-      tags:
-      - Events
-      summary: 앱 전역 SSE 구독
-      operationId: subscribeEventStream
-      responses:
-        '200':
-          description: SSE stream connected
-          content:
-            text/event-stream:
-              schema:
-                "$ref": "#/components/schemas/EventStreamConnectedEvent"
-  "/api/v1/chats/rooms":
-    get:
-      tags:
-      - Chats
-      summary: 채팅방 목록 조회
-      operationId: getChatRooms
-      responses:
-        '200':
-          description: OK
-          content:
-            "*/*":
-              schema:
-                "$ref": "#/components/schemas/ChatRoomListResponse"
-    post:
-      tags:
-      - Chats
-      summary: 채팅방 생성
-      operationId: createChatRoom
-      requestBody:
-        content:
-          application/json:
-            schema:
-              "$ref": "#/components/schemas/CreateChatRoomRequest"
-      responses:
-        '200':
-          description: OK
-          content:
-            "*/*":
-              schema:
-                "$ref": "#/components/schemas/CreateChatRoomResponse"
-  "/api/v1/chats/rooms/{roomId}/messages":
-    get:
-      tags:
-      - Chats
-      summary: 채팅 메시지 목록 조회
-      operationId: getChatMessages
-      parameters:
-      - name: roomId
-        in: path
-        required: true
-        schema:
-          type: integer
-          format: int64
-      responses:
-        '200':
-          description: OK
-          content:
-            "*/*":
-              schema:
-                "$ref": "#/components/schemas/ChatMessageListResponse"
-    post:
-      tags:
-      - Chats
-      summary: 채팅 메시지 전송
-      operationId: sendMessage
-      parameters:
-      - name: roomId
-        in: path
-        required: true
-        schema:
-          type: integer
-          format: int64
-      requestBody:
-        content:
-          application/json:
-            schema:
-              "$ref": "#/components/schemas/SendChatMessageRequest"
-      responses:
-        '200':
-          description: OK
-          content:
-            "*/*":
-              schema:
-                "$ref": "#/components/schemas/SendChatMessageResponse"
-  "/api/v1/chats/rooms/{roomId}/read":
-    patch:
-      tags:
-      - Chats
-      summary: 채팅방 읽음 처리
-      operationId: markAsRead
-      parameters:
-      - name: roomId
-        in: path
-        required: true
-        schema:
-          type: integer
-          format: int64
-      responses:
-        '200':
-          description: OK
-          content:
-            "*/*":
-              schema:
-                "$ref": "#/components/schemas/MarkChatRoomAsReadResponse"
-  "/api/v1/chats/rooms/{roomId}/unread-count":
-    get:
-      tags:
-      - Chats
-      summary: 채팅방 안읽음 개수 조회
-      operationId: getRoomUnreadCount
-      parameters:
-      - name: roomId
-        in: path
-        required: true
-        schema:
-          type: integer
-          format: int64
-      responses:
-        '200':
-          description: OK
-          content:
-            "*/*":
-              schema:
-                "$ref": "#/components/schemas/RoomUnreadCountResponse"
-  "/api/v1/chats/unread-count":
-    get:
-      tags:
-      - Chats
-      summary: 전체 안읽음 개수 조회
-      operationId: getUnreadCount
-      responses:
-        '200':
-          description: OK
-          content:
-            "*/*":
-              schema:
-                "$ref": "#/components/schemas/UnreadCountResponse"
-  "/api/v1/chats/messages/{messageId}":
-    delete:
-      tags:
-      - Chats
-      summary: 채팅 메시지 삭제
-      operationId: deleteChatMessage
-      parameters:
-      - name: messageId
-        in: path
-        required: true
-        schema:
-          type: integer
-          format: int64
-      responses:
-        '200':
-          description: OK
-  "/api/v1/chats/messages/{messageId}/reports":
-    post:
-      tags:
-      - Chats
-      summary: 채팅 메시지 신고
-      operationId: reportMessage
-      parameters:
-      - name: messageId
-        in: path
-        required: true
-        schema:
-          type: integer
-          format: int64
-      requestBody:
-        content:
-          application/json:
-            schema:
-              "$ref": "#/components/schemas/ReportChatMessageRequest"
-      responses:
-        '200':
-          description: OK
-  "/api/v1/users/me/profile-image":
+  /api/v1/users/me/profile-image:
     post:
       tags:
       - Profile
@@ -228,13 +55,37 @@ paths:
               required:
               - file
       responses:
-        '200':
+        "400":
+          description: Bad Request
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: Not Found
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "409":
+          description: Conflict
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "200":
           description: OK
           content:
-            "*/*":
+            '*/*':
               schema:
-                "$ref": "#/components/schemas/UploadProfileImageResponse"
-  "/api/v1/products":
+                $ref: "#/components/schemas/UploadProfileImageResponse"
+  /api/v1/products:
     post:
       tags:
       - Product
@@ -244,16 +95,40 @@ paths:
         content:
           application/json:
             schema:
-              "$ref": "#/components/schemas/CreateProductRequest"
+              $ref: "#/components/schemas/CreateProductRequest"
         required: true
       responses:
-        '201':
+        "400":
+          description: Bad Request
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: Not Found
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "409":
+          description: Conflict
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "201":
           description: 상품 등록 성공
           content:
-            "*/*":
+            '*/*':
               schema:
-                "$ref": "#/components/schemas/CreateProductResponse"
-  "/api/v1/products/price/recommend":
+                $ref: "#/components/schemas/CreateProductResponse"
+  /api/v1/products/price/recommend:
     post:
       tags:
       - Product
@@ -263,16 +138,40 @@ paths:
         content:
           application/json:
             schema:
-              "$ref": "#/components/schemas/RecommendPriceRequest"
+              $ref: "#/components/schemas/RecommendPriceRequest"
         required: true
       responses:
-        '200':
+        "400":
+          description: Bad Request
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: Not Found
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "409":
+          description: Conflict
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "200":
           description: 가격 추천 성공
           content:
-            "*/*":
+            '*/*':
               schema:
-                "$ref": "#/components/schemas/RecommendPriceResponse"
-  "/api/v1/products/image":
+                $ref: "#/components/schemas/RecommendPriceResponse"
+  /api/v1/products/image:
     post:
       tags:
       - Product
@@ -290,13 +189,37 @@ paths:
               required:
               - file
       responses:
-        '200':
+        "400":
+          description: Bad Request
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: Not Found
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "409":
+          description: Conflict
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "200":
           description: 이미지 업로드 성공
           content:
-            "*/*":
+            '*/*':
               schema:
-                "$ref": "#/components/schemas/UploadProductImageResponse"
-  "/api/v1/products/draft":
+                $ref: "#/components/schemas/UploadProductImageResponse"
+  /api/v1/products/draft:
     post:
       tags:
       - Product
@@ -306,16 +229,40 @@ paths:
         content:
           application/json:
             schema:
-              "$ref": "#/components/schemas/SaveProductDraftRequest"
+              $ref: "#/components/schemas/SaveProductDraftRequest"
         required: true
       responses:
-        '200':
+        "400":
+          description: Bad Request
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: Not Found
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "409":
+          description: Conflict
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "200":
           description: 임시저장 성공
           content:
-            "*/*":
+            '*/*':
               schema:
-                "$ref": "#/components/schemas/SaveProductDraftResponse"
-  "/api/v1/products/category/recommend":
+                $ref: "#/components/schemas/SaveProductDraftResponse"
+  /api/v1/products/category/recommend:
     post:
       tags:
       - Product
@@ -325,16 +272,40 @@ paths:
         content:
           application/json:
             schema:
-              "$ref": "#/components/schemas/RecommendCategoryRequest"
+              $ref: "#/components/schemas/RecommendCategoryRequest"
         required: true
       responses:
-        '200':
+        "400":
+          description: Bad Request
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: Not Found
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "409":
+          description: Conflict
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "200":
           description: 카테고리 추천 성공
           content:
-            "*/*":
+            '*/*':
               schema:
-                "$ref": "#/components/schemas/RecommendCategoryResponse"
-  "/api/v1/members/signup":
+                $ref: "#/components/schemas/RecommendCategoryResponse"
+  /api/v1/members/signup:
     post:
       tags:
       - Member
@@ -345,16 +316,40 @@ paths:
         content:
           application/json:
             schema:
-              "$ref": "#/components/schemas/SignUpRequest"
+              $ref: "#/components/schemas/SignUpRequest"
         required: true
       responses:
-        '201':
+        "400":
+          description: Bad Request
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: Not Found
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "409":
+          description: Conflict
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "201":
           description: Created
           content:
-            "*/*":
+            '*/*':
               schema:
-                "$ref": "#/components/schemas/SignUpResponse"
-  "/api/v1/locations/resolve":
+                $ref: "#/components/schemas/SignUpResponse"
+  /api/v1/locations/resolve:
     post:
       tags:
       - Location
@@ -365,16 +360,40 @@ paths:
         content:
           application/json:
             schema:
-              "$ref": "#/components/schemas/ResolveLocationRequest"
+              $ref: "#/components/schemas/ResolveLocationRequest"
         required: true
       responses:
-        '200':
+        "400":
+          description: Bad Request
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: Not Found
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "409":
+          description: Conflict
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "200":
           description: OK
           content:
-            "*/*":
+            '*/*':
               schema:
-                "$ref": "#/components/schemas/ResolvedLocationResponse"
-  "/api/v1/email/verification/send":
+                $ref: "#/components/schemas/ResolvedLocationResponse"
+  /api/v1/email/verification/send:
     post:
       tags:
       - Email Verification
@@ -385,16 +404,40 @@ paths:
         content:
           application/json:
             schema:
-              "$ref": "#/components/schemas/SendEmailVerificationRequest"
+              $ref: "#/components/schemas/SendEmailVerificationRequest"
         required: true
       responses:
-        '201':
+        "400":
+          description: Bad Request
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: Not Found
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "409":
+          description: Conflict
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "201":
           description: Created
           content:
-            "*/*":
+            '*/*':
               schema:
-                "$ref": "#/components/schemas/SendEmailVerificationResponse"
-  "/api/v1/email/verification/confirm":
+                $ref: "#/components/schemas/SendEmailVerificationResponse"
+  /api/v1/email/verification/confirm:
     post:
       tags:
       - Email Verification
@@ -405,62 +448,45 @@ paths:
         content:
           application/json:
             schema:
-              "$ref": "#/components/schemas/ConfirmEmailVerificationRequest"
+              $ref: "#/components/schemas/ConfirmEmailVerificationRequest"
         required: true
       responses:
-        '200':
+        "400":
+          description: Bad Request
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: Not Found
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "409":
+          description: Conflict
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "200":
           description: OK
           content:
-            "*/*":
+            '*/*':
               schema:
-                "$ref": "#/components/schemas/ConfirmEmailVerificationResponse"
-  "/api/v1/auth/login":
-    post:
-      tags:
-      - Auth
-      summary: 로그인
-      description: 로그인 성공 시 JWT Access Token을 발급합니다.
-      operationId: login
-      requestBody:
-        content:
-          application/json:
-            schema:
-              "$ref": "#/components/schemas/LoginRequest"
-        required: true
-      responses:
-        '200':
-          description: OK
-          content:
-            "*/*":
-              schema:
-                "$ref": "#/components/schemas/LoginResponse"
-  "/api/v1/auction":
-    post:
-      tags:
-      - Auction
-      summary: 경매 상품 등록
-      description: 프론트가 가공한 최종 payload로 상품을 등록한다.
-      operationId: createAuction
-      requestBody:
-        content:
-          application/json:
-            schema:
-              "$ref": "#/components/schemas/CreateAuctionRequest"
-        required: true
-      responses:
-        '201':
-          description: 상품 등록 성공
-          content:
-            "*/*":
-              schema:
-                $ref: "#/components/schemas/CreateAuctionResponse"
-  /api/v1/mypage/auctions/selling:
+                $ref: "#/components/schemas/ConfirmEmailVerificationResponse"
+  /api/v1/chats/rooms:
     get:
       tags:
-      - Auction
-      summary: 내 판매중 경매 목록
-      description: 마이페이지 판매중 화면에서 현재 사용자의 진행중 경매 목록을 페이징 조회한다.
-      operationId: getMySellingAuctionProducts
+      - Chats
+      summary: 채팅방 목록 조회
+      operationId: getChatRooms
       parameters:
       - name: page
         in: query
@@ -477,13 +503,714 @@ paths:
           format: int32
           default: 20
       responses:
-        "200":
-          description: 내 판매중 경매 목록 조회 성공
+        "400":
+          description: Bad Request
           content:
             '*/*':
               schema:
-                $ref: "#/components/schemas/MySellingAuctionListResponse"
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: Not Found
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "409":
+          description: Conflict
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "200":
+          description: OK
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ChatRoomListResponse"
+    post:
+      tags:
+      - Chats
+      summary: 채팅방 생성
+      operationId: createChatRoom
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateChatRoomRequest"
+        required: true
+      responses:
+        "400":
+          description: Bad Request
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: Not Found
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "409":
+          description: Conflict
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "200":
+          description: OK
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/CreateChatRoomResponse"
+  /api/v1/chats/rooms/{roomId}/messages:
+    get:
+      tags:
+      - Chats
+      summary: 채팅 메시지 목록 조회
+      operationId: getChatMessages
+      parameters:
+      - name: roomId
+        in: path
+        required: true
+        schema:
+          type: integer
+          format: int64
+      - name: page
+        in: query
+        required: false
+        schema:
+          type: integer
+          format: int32
+          default: 0
+      - name: size
+        in: query
+        required: false
+        schema:
+          type: integer
+          format: int32
+          default: 50
+      responses:
+        "400":
+          description: Bad Request
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: Not Found
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "409":
+          description: Conflict
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "200":
+          description: OK
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ChatMessageListResponse"
+    post:
+      tags:
+      - Chats
+      summary: 채팅 메시지 전송
+      operationId: sendMessage
+      parameters:
+      - name: roomId
+        in: path
+        required: true
+        schema:
+          type: integer
+          format: int64
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SendChatMessageRequest"
+        required: true
+      responses:
+        "400":
+          description: Bad Request
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: Not Found
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "409":
+          description: Conflict
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "200":
+          description: OK
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/SendChatMessageResponse"
+  /api/v1/chats/messages/{messageId}/reports:
+    post:
+      tags:
+      - Chats
+      summary: 채팅 메시지 신고
+      operationId: reportMessage
+      parameters:
+      - name: messageId
+        in: path
+        required: true
+        schema:
+          type: integer
+          format: int64
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ReportChatMessageRequest"
+        required: true
+      responses:
+        "400":
+          description: Bad Request
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: Not Found
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "409":
+          description: Conflict
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "200":
+          description: OK
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ReportChatMessageResponse"
+  /api/v1/auth/login:
+    post:
+      tags:
+      - Auth
+      summary: 로그인
+      description: 로그인 성공 시 JWT Access Token을 발급합니다.
+      operationId: login
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/LoginRequest"
+        required: true
+      responses:
+        "400":
+          description: Bad Request
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: Not Found
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "409":
+          description: Conflict
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "200":
+          description: OK
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/LoginResponse"
+  /api/v1/auction:
+    post:
+      tags:
+      - Auction
+      summary: 경매 상품 등록
+      description: 프론트가 가공한 최종 payload로 상품을 등록한다.
+      operationId: createAuction
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateAuctionRequest"
+        required: true
+      responses:
+        "400":
+          description: Bad Request
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: Not Found
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "409":
+          description: Conflict
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "201":
+          description: 상품 등록 성공
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/CreateAuctionResponse"
+  /api/v1/auction/price/recommend:
+    post:
+      tags:
+      - Auction
+      summary: 가격 추천
+      description: 상품 정보와 판매 유형을 기반으로 추천 가격을 반환한다.
+      operationId: recommendPrice_1
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RecommendPriceRequest"
+        required: true
+      responses:
+        "400":
+          description: Bad Request
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: Not Found
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "409":
+          description: Conflict
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "200":
+          description: 가격 추천 성공
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/RecommendPriceResponse"
+  /api/v1/auction/image:
+    post:
+      tags:
+      - Auction
+      summary: 상품 이미지 업로드
+      description: 경매 상품 등록 전 이미지를 업로드하고 임시 URL을 반환한다.
+      operationId: uploadImage_1
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                file:
+                  type: string
+                  format: binary
+              required:
+              - file
+      responses:
+        "400":
+          description: Bad Request
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: Not Found
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "409":
+          description: Conflict
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "200":
+          description: 이미지 업로드 성공
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/UploadAuctionImageResponse"
+  /api/v1/auction/draft:
+    post:
+      tags:
+      - Auction
+      summary: 경매 상품 임시저장
+      description: 등록 직전 폼 데이터를 draft 상태로 저장한다.
+      operationId: saveDraft_1
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SaveAuctionDraftRequest"
+        required: true
+      responses:
+        "400":
+          description: Bad Request
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: Not Found
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "409":
+          description: Conflict
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "200":
+          description: 임시저장 성공
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/SaveAuctionDraftResponse"
+  /api/v1/auction/category/recommend:
+    post:
+      tags:
+      - Auction
+      summary: 카테고리 추천
+      description: 입력된 상품명과 설명을 기준으로 추천 카테고리를 반환한다.
+      operationId: recommendCategory_1
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RecommendCategoryRequest"
+        required: true
+      responses:
+        "400":
+          description: Bad Request
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: Not Found
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "409":
+          description: Conflict
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "200":
+          description: 카테고리 추천 성공
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/RecommendCategoryResponse"
+  /api/v1/users/me/profile:
+    patch:
+      tags:
+      - Profile
+      summary: 프로필 수정
+      description: "현재 로그인한 사용자의 닉네임, 소개글, 프로필 이미지를 수정합니다."
+      operationId: updateProfile
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UpdateMyProfileRequest"
+        required: true
+      responses:
+        "400":
+          description: Bad Request
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: Not Found
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "409":
+          description: Conflict
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "200":
+          description: OK
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/MyPageProfileResponse"
+  /api/v1/users/me/location:
+    get:
+      tags:
+      - Profile
+      summary: 내 지역 조회
+      description: 현재 로그인한 사용자의 지역 및 구조화된 위치 정보를 조회합니다.
+      operationId: getMyLocation
+      responses:
+        "400":
+          description: Bad Request
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: Not Found
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "409":
+          description: Conflict
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "200":
+          description: OK
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/MyLocationResponse"
+    patch:
+      tags:
+      - Profile
+      summary: 지역 수정
+      description: 현재 로그인한 사용자의 대표 지역과 상세 위치 정보를 수정합니다.
+      operationId: updateLocation
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UpdateMyLocationRequest"
+        required: true
+      responses:
+        "400":
+          description: Bad Request
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: Not Found
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "409":
+          description: Conflict
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "200":
+          description: OK
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/UpdateMyLocationResponse"
+  /api/v1/chats/rooms/{roomId}/read:
+    patch:
+      tags:
+      - Chats
+      summary: 채팅방 읽음 처리
+      operationId: markAsRead
+      parameters:
+      - name: roomId
+        in: path
+        required: true
+        schema:
+          type: integer
+          format: int64
+      responses:
+        "400":
+          description: Bad Request
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: Not Found
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "409":
+          description: Conflict
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "200":
+          description: OK
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/MarkChatRoomAsReadResponse"
   /api/v1/auctions/{auctionId}:
+    delete:
+      tags:
+      - Auction
+      summary: 경매 삭제
+      description: 입찰이 없는 현재 사용자의 경매를 삭제한다.
+      operationId: deleteAuction
+      parameters:
+      - name: auctionId
+        in: path
+        required: true
+        schema:
+          type: integer
+          format: int64
+      responses:
+        "400":
+          description: Bad Request
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: Not Found
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "409":
+          description: 입찰자가 있는 경매는 삭제 불가
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "204":
+          description: 경매 삭제 성공
     patch:
       tags:
       - Auction
@@ -504,192 +1231,37 @@ paths:
               $ref: "#/components/schemas/UpdateAuctionRequest"
         required: true
       responses:
+        "400":
+          description: Bad Request
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: Not Found
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "409":
+          description: 입찰자가 있는 경매는 수정 불가
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         "200":
           description: 경매 수정 성공
           content:
             '*/*':
               schema:
                 $ref: "#/components/schemas/AuctionEditDetailResponse"
-        "409":
-          description: 입찰자가 있는 경매는 수정 불가
-    delete:
-      tags:
-      - Auction
-      summary: 경매 삭제
-      description: 입찰이 없는 현재 사용자의 경매를 삭제한다.
-      operationId: deleteAuction
-      parameters:
-      - name: auctionId
-        in: path
-        required: true
-        schema:
-          type: integer
-          format: int64
-      responses:
-        "204":
-          description: 경매 삭제 성공
-        "409":
-          description: 입찰자가 있는 경매는 삭제 불가
-  /api/v1/auctions/{auctionId}/edit:
-    get:
-      tags:
-      - Auction
-      summary: 경매 수정용 상세 조회
-      description: 현재 사용자가 등록한 경매의 수정 화면 데이터를 조회한다.
-      operationId: getAuctionEditDetail
-      parameters:
-      - name: auctionId
-        in: path
-        required: true
-        schema:
-          type: integer
-          format: int64
-      responses:
-        "200":
-          description: 경매 수정용 상세 조회 성공
-          content:
-            '*/*':
-              schema:
-                $ref: "#/components/schemas/AuctionEditDetailResponse"
-  /api/v1/auction/price/recommend:
-    post:
-      tags:
-      - Auction
-      summary: 가격 추천
-      description: 상품 정보와 판매 유형을 기반으로 추천 가격을 반환한다.
-      operationId: recommendPrice_1
-      requestBody:
-        content:
-          application/json:
-            schema:
-              "$ref": "#/components/schemas/RecommendPriceRequest"
-        required: true
-      responses:
-        '200':
-          description: 가격 추천 성공
-          content:
-            "*/*":
-              schema:
-                "$ref": "#/components/schemas/RecommendPriceResponse"
-  "/api/v1/auction/image":
-    post:
-      tags:
-      - Auction
-      summary: 상품 이미지 업로드
-      description: 경매 상품 등록 전 이미지를 업로드하고 임시 URL을 반환한다.
-      operationId: uploadImage_1
-      requestBody:
-        content:
-          multipart/form-data:
-            schema:
-              type: object
-              properties:
-                file:
-                  type: string
-                  format: binary
-              required:
-              - file
-      responses:
-        '200':
-          description: 이미지 업로드 성공
-          content:
-            "*/*":
-              schema:
-                "$ref": "#/components/schemas/UploadAuctionImageResponse"
-  "/api/v1/auction/draft":
-    post:
-      tags:
-      - Auction
-      summary: 경매 상품 임시저장
-      description: 등록 직전 폼 데이터를 draft 상태로 저장한다.
-      operationId: saveDraft_1
-      requestBody:
-        content:
-          application/json:
-            schema:
-              "$ref": "#/components/schemas/SaveAuctionDraftRequest"
-        required: true
-      responses:
-        '200':
-          description: 임시저장 성공
-          content:
-            "*/*":
-              schema:
-                "$ref": "#/components/schemas/SaveAuctionDraftResponse"
-  "/api/v1/auction/category/recommend":
-    post:
-      tags:
-      - Auction
-      summary: 카테고리 추천
-      description: 입력된 상품명과 설명을 기준으로 추천 카테고리를 반환한다.
-      operationId: recommendCategory_1
-      requestBody:
-        content:
-          application/json:
-            schema:
-              "$ref": "#/components/schemas/RecommendCategoryRequest"
-        required: true
-      responses:
-        '200':
-          description: 카테고리 추천 성공
-          content:
-            "*/*":
-              schema:
-                "$ref": "#/components/schemas/RecommendCategoryResponse"
-  "/api/v1/users/me/profile":
-    patch:
-      tags:
-      - Profile
-      summary: 프로필 수정
-      description: 현재 로그인한 사용자의 닉네임, 소개글, 프로필 이미지를 수정합니다.
-      operationId: updateProfile
-      requestBody:
-        content:
-          application/json:
-            schema:
-              "$ref": "#/components/schemas/UpdateMyProfileRequest"
-        required: true
-      responses:
-        '200':
-          description: OK
-          content:
-            "*/*":
-              schema:
-                "$ref": "#/components/schemas/MyPageProfileResponse"
-  "/api/v1/users/me/location":
-    get:
-      tags:
-      - Profile
-      summary: 내 지역 조회
-      description: 현재 로그인한 사용자의 지역 및 구조화된 위치 정보를 조회합니다.
-      operationId: getMyLocation
-      responses:
-        '200':
-          description: OK
-          content:
-            "*/*":
-              schema:
-                "$ref": "#/components/schemas/MyLocationResponse"
-    patch:
-      tags:
-      - Profile
-      summary: 지역 수정
-      description: 현재 로그인한 사용자의 대표 지역과 상세 위치 정보를 수정합니다.
-      operationId: updateLocation
-      requestBody:
-        content:
-          application/json:
-            schema:
-              "$ref": "#/components/schemas/UpdateMyLocationRequest"
-        required: true
-      responses:
-        '200':
-          description: OK
-          content:
-            "*/*":
-              schema:
-                "$ref": "#/components/schemas/UpdateMyLocationResponse"
-  "/api/v1/users/me/mypage":
+  /api/v1/users/me/mypage:
     get:
       tags:
       - Profile
@@ -697,26 +1269,179 @@ paths:
       description: 현재 로그인한 사용자의 마이페이지 프로필 정보를 조회합니다.
       operationId: getMyPageProfile
       responses:
-        '200':
+        "400":
+          description: Bad Request
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: Not Found
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "409":
+          description: Conflict
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "200":
           description: OK
           content:
-            "*/*":
+            '*/*':
               schema:
-                "$ref": "#/components/schemas/MyPageProfileResponse"
-  "/api/v1/products/categories":
+                $ref: "#/components/schemas/MyPageProfileResponse"
+  /api/v1/products/{productId}:
+    get:
+      tags:
+      - Product Detail
+      summary: 상품 상세 조회
+      description: productId로 일반 상품 또는 경매 상품의 상세 정보를 조회합니다. 로그인 사용자는 이메일 인증 여부와 관계없이
+        조회할 수 있습니다.
+      operationId: getProductDetail
+      parameters:
+      - name: productId
+        in: path
+        required: true
+        schema:
+          type: integer
+          format: int64
+      responses:
+        "400":
+          description: Bad Request
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: 상품 없음
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "409":
+          description: Conflict
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "200":
+          description: 상품 상세 조회 성공
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ProductDetailResponse"
+        "401":
+          description: 인증 실패
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ProductDetailResponse"
+  /api/v1/products/categories:
     get:
       tags:
       - Product
       summary: 카테고리 목록 조회
       operationId: getCategories
       responses:
-        '200':
+        "400":
+          description: Bad Request
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: Not Found
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "409":
+          description: Conflict
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "200":
           description: 카테고리 조회 성공
           content:
-            "*/*":
+            '*/*':
               schema:
-                "$ref": "#/components/schemas/CategoryOptionResponse"
-  "/api/v1/members/nickname/check":
+                $ref: "#/components/schemas/CategoryOptionResponse"
+  /api/v1/mypage/auctions/selling:
+    get:
+      tags:
+      - Auction
+      summary: 내 판매중 경매 목록
+      description: 마이페이지 판매중 화면에서 현재 사용자의 진행중 경매 목록을 페이징 조회한다.
+      operationId: getMySellingAuctions
+      parameters:
+      - name: page
+        in: query
+        required: false
+        schema:
+          type: integer
+          format: int32
+          default: 0
+      - name: size
+        in: query
+        required: false
+        schema:
+          type: integer
+          format: int32
+          default: 20
+      responses:
+        "400":
+          description: Bad Request
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: Not Found
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "409":
+          description: Conflict
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "200":
+          description: 내 판매중 경매 목록 조회 성공
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/MySellingAuctionListResponse"
+  /api/v1/members/nickname/check:
     get:
       tags:
       - Member
@@ -732,13 +1457,37 @@ paths:
           maxLength: 30
           minLength: 2
       responses:
-        '200':
+        "400":
+          description: Bad Request
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: Not Found
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "409":
+          description: Conflict
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "200":
           description: OK
           content:
-            "*/*":
+            '*/*':
               schema:
-                "$ref": "#/components/schemas/NicknameCheckResponse"
-  "/api/v1/members/login-id/check":
+                $ref: "#/components/schemas/NicknameCheckResponse"
+  /api/v1/members/login-id/check:
     get:
       tags:
       - Member
@@ -754,13 +1503,37 @@ paths:
           maxLength: 30
           minLength: 0
       responses:
-        '200':
+        "400":
+          description: Bad Request
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: Not Found
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "409":
+          description: Conflict
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "200":
           description: OK
           content:
-            "*/*":
+            '*/*':
               schema:
-                "$ref": "#/components/schemas/LoginIdCheckResponse"
-  "/api/v1/health":
+                $ref: "#/components/schemas/LoginIdCheckResponse"
+  /api/v1/health:
     get:
       tags:
       - Health
@@ -768,14 +1541,156 @@ paths:
       description: 애플리케이션의 기본 상태 정보를 반환합니다.
       operationId: health
       responses:
-        '200':
+        "400":
+          description: Bad Request
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: Not Found
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "409":
+          description: Conflict
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "200":
           description: OK
           content:
-            "*/*":
+            '*/*':
               schema:
                 type: object
                 additionalProperties: {}
-  "/api/v1/auth/me":
+  /api/v1/events/stream:
+    get:
+      tags:
+      - Events
+      summary: 앱 전역 SSE 구독
+      operationId: subscribe
+      responses:
+        "400":
+          description: Bad Request
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: Not Found
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "409":
+          description: Conflict
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "200":
+          description: OK
+          content:
+            text/event-stream:
+              schema:
+                $ref: "#/components/schemas/SseEmitter"
+  /api/v1/chats/unread-count:
+    get:
+      tags:
+      - Chats
+      summary: 전체 안읽음 개수 조회
+      operationId: getUnreadCount
+      responses:
+        "400":
+          description: Bad Request
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: Not Found
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "409":
+          description: Conflict
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "200":
+          description: OK
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/UnreadCountResponse"
+  /api/v1/chats/rooms/{roomId}/unread-count:
+    get:
+      tags:
+      - Chats
+      summary: 채팅방 안읽음 개수 조회
+      operationId: getRoomUnreadCount
+      parameters:
+      - name: roomId
+        in: path
+        required: true
+        schema:
+          type: integer
+          format: int64
+      responses:
+        "400":
+          description: Bad Request
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: Not Found
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "409":
+          description: Conflict
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "200":
+          description: OK
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/RoomUnreadCountResponse"
+  /api/v1/auth/me:
     get:
       tags:
       - Auth
@@ -783,13 +1698,82 @@ paths:
       description: 현재 인증된 회원의 기본 정보를 조회합니다.
       operationId: me
       responses:
-        '200':
+        "400":
+          description: Bad Request
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: Not Found
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "409":
+          description: Conflict
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "200":
           description: OK
           content:
-            "*/*":
+            '*/*':
               schema:
-                "$ref": "#/components/schemas/CurrentMemberResponse"
-  "/api/v1/auction/categories":
+                $ref: "#/components/schemas/CurrentMemberResponse"
+  /api/v1/auctions/{auctionId}/edit:
+    get:
+      tags:
+      - Auction
+      summary: 경매 수정용 상세 조회
+      description: 현재 사용자가 등록한 경매의 수정 화면 데이터를 조회한다.
+      operationId: getAuctionEditDetail
+      parameters:
+      - name: auctionId
+        in: path
+        required: true
+        schema:
+          type: integer
+          format: int64
+      responses:
+        "400":
+          description: Bad Request
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: Not Found
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "409":
+          description: Conflict
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "200":
+          description: 경매 수정용 상세 조회 성공
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/AuctionEditDetailResponse"
+  /api/v1/auction/categories:
     get:
       tags:
       - Auction
@@ -797,13 +1781,37 @@ paths:
       description: 상품 등록 화면에서 사용할 계층형 카테고리 목록을 반환한다.
       operationId: getCategories_1
       responses:
-        '200':
+        "400":
+          description: Bad Request
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: Not Found
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "409":
+          description: Conflict
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "200":
           description: 카테고리 조회 성공
           content:
-            "*/*":
+            '*/*':
               schema:
-                "$ref": "#/components/schemas/CategoryOptionResponse"
-  "/api/v1/products/image/{imageId}":
+                $ref: "#/components/schemas/CategoryOptionResponse"
+  /api/v1/products/image/{imageId}:
     delete:
       tags:
       - Product
@@ -817,13 +1825,77 @@ paths:
           type: integer
           format: int64
       responses:
-        '200':
+        "400":
+          description: Bad Request
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: Not Found
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "409":
+          description: Conflict
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "200":
           description: 이미지 삭제 성공
           content:
-            "*/*":
+            '*/*':
               schema:
-                "$ref": "#/components/schemas/DeleteProductImageResponse"
-  "/api/v1/auction/image/{imageId}":
+                $ref: "#/components/schemas/DeleteProductImageResponse"
+  /api/v1/chats/messages/{messageId}:
+    delete:
+      tags:
+      - Chats
+      summary: 채팅 메시지 삭제
+      operationId: deleteMessage
+      parameters:
+      - name: messageId
+        in: path
+        required: true
+        schema:
+          type: integer
+          format: int64
+      responses:
+        "400":
+          description: Bad Request
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: Not Found
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "409":
+          description: Conflict
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "200":
+          description: OK
+  /api/v1/auction/image/{imageId}:
     delete:
       tags:
       - Auction
@@ -838,133 +1910,63 @@ paths:
           type: integer
           format: int64
       responses:
-        '200':
+        "400":
+          description: Bad Request
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: Not Found
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "409":
+          description: Conflict
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "200":
           description: 이미지 삭제 성공
           content:
-            "*/*":
+            '*/*':
               schema:
-                "$ref": "#/components/schemas/DeleteAuctionImageResponse"
+                $ref: "#/components/schemas/DeleteAuctionImageResponse"
 components:
   schemas:
-    CreateChatRoomRequest:
-      type: object
-      required:
-      - productId
-      - receiverId
-      properties:
-        productId:
-          type: integer
-          format: int64
-        receiverId:
-          type: integer
-          format: int64
-    EventStreamConnectedEvent:
+    ErrorResponse:
       type: object
       properties:
-        type:
-          type: string
-          example: event.stream.connected
-        userId:
-          type: integer
-          format: int64
-        connectedAt:
+        timestamp:
           type: string
           format: date-time
-    CreateChatRoomResponse:
-      type: object
-      properties:
-        roomId:
+        status:
           type: integer
-          format: int64
-        chatType:
+          format: int32
+        code:
           type: string
-          enum:
-          - GENERAL
-          - AUCTION
-    ChatRoomListResponse:
-      type: object
-      properties:
-        content:
+        message:
+          type: string
+        errors:
           type: array
           items:
-            "$ref": "#/components/schemas/ChatRoomListItemResponse"
-    ChatRoomListItemResponse:
+            $ref: "#/components/schemas/FieldErrorDetail"
+    FieldErrorDetail:
       type: object
       properties:
-        roomId:
-          type: integer
-          format: int64
-        unreadCount:
-          type: integer
-    ChatMessageListResponse:
-      type: object
-      properties:
-        content:
-          type: array
-          items:
-            "$ref": "#/components/schemas/ChatMessageResponse"
-    ChatMessageResponse:
-      type: object
-      properties:
-        messageId:
-          type: integer
-          format: int64
-        content:
+        field:
           type: string
-        senderNickname:
-          type: string
-        sentAt:
-          type: string
-          format: date-time
-    SendChatMessageRequest:
-      type: object
-      required:
-      - content
-      - messageType
-      properties:
-        content:
-          type: string
-        messageType:
-          type: string
-          enum:
-          - TEXT
-          - IMAGE
-          - SYSTEM
-          - TALK
-    SendChatMessageResponse:
-      "$ref": "#/components/schemas/ChatMessageResponse"
-    MarkChatRoomAsReadResponse:
-      type: object
-      properties:
-        roomId:
-          type: integer
-          format: int64
-        unreadCount:
-          type: integer
-    RoomUnreadCountResponse:
-      type: object
-      properties:
-        roomId:
-          type: integer
-          format: int64
-        unreadCount:
-          type: integer
-        updatedAt:
-          type: string
-          format: date-time
-    UnreadCountResponse:
-      type: object
-      properties:
-        totalUnreadCount:
-          type: integer
-    ReportChatMessageRequest:
-      type: object
-      required:
-      - reason
-      properties:
+        rejectedValue: {}
         reason:
           type: string
-          maxLength: 255
     UploadProfileImageResponse:
       type: object
       properties:
@@ -1009,7 +2011,7 @@ components:
         images:
           type: array
           items:
-            "$ref": "#/components/schemas/ProductImagePayload"
+            $ref: "#/components/schemas/ProductImagePayload"
             minItems: 1
           minItems: 1
         location:
@@ -1054,7 +2056,45 @@ components:
       required:
       - imageId
       - imageUrl
-    AuctionResponse: {}
+    AuctionResponse:
+      type: object
+      properties:
+        auctionId:
+          type: integer
+          format: int64
+          description: 경매 ID
+          example: 5
+        startPrice:
+          type: number
+          description: 경매 시작가
+          example: 70000
+        currentPrice:
+          type: number
+          description: 현재가. 입찰 내역이 없으면 시작가와 동일
+          example: 70000
+        minimumNextBidPrice:
+          type: number
+          description: 최소 다음 입찰가
+          example: 70700
+        bidCount:
+          type: integer
+          format: int64
+          description: 입찰 수
+          example: 0
+        endAt:
+          type: string
+          format: date-time
+          description: 경매 종료 시각
+          example: 2026-05-05T10:30:00+09:00
+        status:
+          type: string
+          description: 경매 상태
+          enum:
+          - DRAFT
+          - ON_SALE
+          - AUCTION_LIVE
+          - ENDED
+          example: AUCTION_LIVE
     CreateProductResponse:
       type: object
       description: 일반 상품 등록 응답
@@ -1081,18 +2121,42 @@ components:
           - ENDED
           example: ON_SALE
         auction:
-          "$ref": "#/components/schemas/AuctionResponse"
+          $ref: "#/components/schemas/AuctionResponse"
           description: 경매 메타 정보
         generalSale:
-          "$ref": "#/components/schemas/GeneralSaleResponse"
+          $ref: "#/components/schemas/GeneralSaleResponse"
           description: 일반 판매 정보
     GeneralSaleResponse:
       type: object
       properties:
         price:
           type: number
-          description: 일반 판매가
+          description: 일반 판매 가격
           example: 12000
+        viewCount:
+          type: integer
+          format: int64
+          description: 조회수
+          example: 10
+        favoriteCount:
+          type: integer
+          format: int64
+          description: 찜 수
+          example: 2
+        chatCount:
+          type: integer
+          format: int64
+          description: 채팅 수
+          example: 1
+        status:
+          type: string
+          description: 일반 판매 상태
+          enum:
+          - DRAFT
+          - ON_SALE
+          - SOLD
+          - ENDED
+          example: ON_SALE
     RecommendPriceRequest:
       type: object
       description: 일반 상품 가격 추천 요청
@@ -1185,7 +2249,7 @@ components:
           type: array
           description: 상품 이미지 목록
           items:
-            "$ref": "#/components/schemas/ProductImagePayload"
+            $ref: "#/components/schemas/ProductImagePayload"
         location:
           type: string
           description: 거래 위치
@@ -1209,7 +2273,7 @@ components:
           type: string
           format: date-time
           description: 저장 시각
-          example: 2026-04-12 20:00:00.000000000 Z
+          example: 2026-04-12T20:00:00Z
     RecommendCategoryRequest:
       type: object
       description: 일반 상품 카테고리 추천 요청
@@ -1326,6 +2390,10 @@ components:
           type: string
         detailAddress:
           type: string
+        latitude:
+          type: number
+        longitude:
+          type: number
         locationSource:
           type: string
           enum:
@@ -1378,6 +2446,143 @@ components:
           type: string
         verified:
           type: boolean
+    CreateChatRoomRequest:
+      type: object
+      properties:
+        productId:
+          type: integer
+          format: int64
+      required:
+      - productId
+    ActionButtons:
+      type: object
+      properties:
+        canPay:
+          type: boolean
+        canCompleteTrade:
+          type: boolean
+        payButtonType:
+          type: string
+        completeTradeButtonType:
+          type: string
+    CreateChatRoomResponse:
+      type: object
+      properties:
+        roomId:
+          type: integer
+          format: int64
+        chatType:
+          type: string
+          enum:
+          - GENERAL
+          - AUCTION
+        product:
+          $ref: "#/components/schemas/ProductInfo"
+        participants:
+          type: array
+          items:
+            $ref: "#/components/schemas/ParticipantInfo"
+        isWinner:
+          type: boolean
+        actionButtons:
+          $ref: "#/components/schemas/ActionButtons"
+        createdAt:
+          type: string
+          format: date-time
+    ParticipantInfo:
+      type: object
+      properties:
+        userId:
+          type: integer
+          format: int64
+        nickname:
+          type: string
+        role:
+          type: string
+    ProductInfo:
+      type: object
+      properties:
+        productId:
+          type: integer
+          format: int64
+        name:
+          type: string
+        thumbnailUrl:
+          type: string
+        saleType:
+          type: string
+        status:
+          type: string
+    SendChatMessageRequest:
+      type: object
+      properties:
+        messageType:
+          type: string
+          enum:
+          - TEXT
+          - IMAGE
+          - SYSTEM
+          - TALK
+        content:
+          type: string
+          maxLength: 1000
+          minLength: 1
+      required:
+      - content
+      - messageType
+    SendChatMessageResponse:
+      type: object
+      properties:
+        messageId:
+          type: integer
+          format: int64
+        roomId:
+          type: integer
+          format: int64
+        senderId:
+          type: integer
+          format: int64
+        messageType:
+          type: string
+          enum:
+          - TEXT
+          - IMAGE
+          - SYSTEM
+          - TALK
+        content:
+          type: string
+        isRead:
+          type: boolean
+        sentAt:
+          type: string
+          format: date-time
+    ReportChatMessageRequest:
+      type: object
+      properties:
+        reason:
+          type: string
+          maxLength: 255
+          minLength: 1
+        description:
+          type: string
+          maxLength: 1000
+          minLength: 0
+      required:
+      - reason
+    ReportChatMessageResponse:
+      type: object
+      properties:
+        reportId:
+          type: integer
+          format: int64
+        messageId:
+          type: integer
+          format: int64
+        reason:
+          type: string
+        reportedAt:
+          type: string
+          format: date-time
     LoginRequest:
       type: object
       description: 로그인 요청
@@ -1433,6 +2638,7 @@ components:
           type: string
           description: 판매 유형
           enum:
+          - REGULAR
           - AUCTION
           example: AUCTION
         categoryId:
@@ -1456,7 +2662,7 @@ components:
         images:
           type: array
           items:
-            "$ref": "#/components/schemas/ProductImagePayload"
+            $ref: "#/components/schemas/ProductImagePayload"
             minItems: 1
           minItems: 1
         location:
@@ -1477,257 +2683,6 @@ components:
       - location
       - name
       - saleType
-    MySellingAuctionListResponse:
-      type: object
-      description: 내 판매중 경매 목록 응답
-      properties:
-        content:
-          type: array
-          description: 판매중 경매 목록
-          items:
-            $ref: "#/components/schemas/MySellingAuctionItemResponse"
-        page:
-          type: integer
-          format: int32
-          description: 현재 페이지 번호(0부터 시작)
-          example: 0
-        size:
-          type: integer
-          format: int32
-          description: 페이지 크기
-          example: 20
-        totalElements:
-          type: integer
-          format: int64
-          description: 전체 상품 수
-          example: 1
-        hasNext:
-          type: boolean
-          description: 다음 페이지 존재 여부
-          example: false
-    MySellingAuctionItemResponse:
-      type: object
-      description: 내 판매중 경매 항목
-      properties:
-        productId:
-          type: integer
-          format: int64
-          description: 상품 ID
-          example: 10
-        auctionId:
-          type: integer
-          format: int64
-          description: 경매 ID. 별도 경매 테이블 도입 전까지 상품 ID와 동일
-          example: 10
-        name:
-          type: string
-          description: 상품명
-          example: 아이폰 14 Pro
-        description:
-          type: string
-          description: 상품 설명
-          example: 거의 새것입니다.
-        categoryName:
-          type: string
-          description: 카테고리명
-          example: 전자기기
-        thumbnailUrl:
-          type: string
-          description: 썸네일 이미지 URL
-          nullable: true
-          example: https://example.com/auction/images/10.jpg
-        auctionStatus:
-          type: string
-          description: 경매 상태
-          enum:
-          - AUCTION_LIVE
-          example: AUCTION_LIVE
-        startPrice:
-          type: number
-          description: 경매 시작가
-          example: 700000
-        currentPrice:
-          type: number
-          description: 현재가
-          example: 700000
-        minimumNextBidPrice:
-          type: number
-          description: 최소 다음 입찰가
-          example: 700000
-        bidCount:
-          type: integer
-          format: int32
-          description: 입찰 수
-          example: 0
-        bidderCount:
-          type: integer
-          format: int32
-          description: 입찰자 수
-          example: 0
-        startAt:
-          type: string
-          format: date-time
-          description: 경매 시작 시각
-          example: 2026-04-30T09:00:00+09:00
-        endAt:
-          type: string
-          format: date-time
-          description: 경매 종료 시각
-          example: 2026-05-03T09:00:00+09:00
-        canEdit:
-          type: boolean
-          description: 수정 가능 여부
-          example: true
-        canDelete:
-          type: boolean
-          description: 삭제 가능 여부
-          example: true
-        createdAt:
-          type: string
-          format: date-time
-          description: 생성 시각
-          example: 2026-04-30T08:40:00+09:00
-        updatedAt:
-          type: string
-          format: date-time
-          description: 수정 시각
-          example: 2026-04-30T10:12:00+09:00
-    AuctionEditDetailResponse:
-      type: object
-      description: 경매 수정용 상세 응답
-      properties:
-        productId:
-          type: integer
-          format: int64
-          description: 상품 ID
-          example: 10
-        auctionId:
-          type: integer
-          format: int64
-          description: 경매 ID. 별도 경매 테이블 도입 전까지 상품 ID와 동일
-          example: 10
-        name:
-          type: string
-          description: 상품명
-          example: 아이폰 14 Pro
-        description:
-          type: string
-          description: 상품 설명
-          example: 거의 새것입니다.
-        categoryId:
-          type: integer
-          format: int64
-          description: 카테고리 ID
-          example: 19
-        categoryName:
-          type: string
-          description: 카테고리명
-          example: 전자기기
-        location:
-          type: string
-          description: 거래 위치
-          example: 서울 강남구
-        images:
-          type: array
-          description: 상품 이미지 목록
-          items:
-            $ref: "#/components/schemas/AuctionEditImageResponse"
-        startPrice:
-          type: number
-          description: 경매 시작가
-          example: 700000
-        auctionDurationDays:
-          type: integer
-          format: int64
-          description: 경매 진행 기간(일)
-          example: 3
-        auctionStatus:
-          type: string
-          description: 경매 상태
-          enum:
-          - AUCTION_LIVE
-          example: AUCTION_LIVE
-        bidCount:
-          type: integer
-          format: int32
-          description: 입찰 수
-          example: 0
-        bidderCount:
-          type: integer
-          format: int32
-          description: 입찰자 수
-          example: 0
-        canEdit:
-          type: boolean
-          description: 수정 가능 여부
-          example: true
-    AuctionEditImageResponse:
-      type: object
-      description: 경매 수정용 이미지
-      properties:
-        imageId:
-          type: integer
-          format: int64
-          description: 이미지 ID
-          example: 1
-        imageUrl:
-          type: string
-          description: 이미지 URL
-          example: https://example.com/auction/images/10.jpg
-        sortOrder:
-          type: integer
-          format: int32
-          description: 정렬 순서
-          example: 1
-    UpdateAuctionRequest:
-      type: object
-      description: 경매 상품 수정 요청
-      properties:
-        name:
-          type: string
-          description: 상품명
-          example: 맥북에어입니다
-          maxLength: 100
-          minLength: 0
-        description:
-          type: string
-          description: 상품 설명
-          example: 맥북입니다!!! 에어이고 많이안써서 깨끗해용
-          maxLength: 2000
-          minLength: 0
-        categoryId:
-          type: integer
-          format: int64
-          description: 카테고리 ID
-          example: 19
-        startPrice:
-          type: number
-          description: 경매 시작가
-          example: 400000
-        auctionDurationDays:
-          type: integer
-          format: int32
-          description: 경매 진행 기간(일 단위)
-          example: 1
-        location:
-          type: string
-          description: 거래 위치
-          example: 경기도 부천시 소사구 소사동로72번길 32
-          maxLength: 100
-          minLength: 0
-        images:
-          type: array
-          items:
-            $ref: "#/components/schemas/ProductImagePayload"
-          minItems: 1
-      required:
-      - auctionDurationDays
-      - categoryId
-      - description
-      - images
-      - location
-      - name
-      - startPrice
     AuctionScheduleResponse:
       type: object
       description: 경매 일정 및 상태 정보
@@ -1737,6 +2692,7 @@ components:
           description: 경매 상태
           enum:
           - DRAFT
+          - ON_SALE
           - AUCTION_LIVE
           - ENDED
           example: AUCTION_LIVE
@@ -1744,12 +2700,12 @@ components:
           type: string
           format: date-time
           description: 경매 시작 시각
-          example: 2026-04-15 10:00:00.000000000 Z
+          example: 2026-04-15T10:00:00Z
         endAt:
           type: string
           format: date-time
           description: 경매 종료 시각
-          example: 2026-04-15 12:00:00.000000000 Z
+          example: 2026-04-15T12:00:00Z
     CreateAuctionResponse:
       type: object
       description: 경매 상품 등록 응답
@@ -1763,6 +2719,7 @@ components:
           type: string
           description: 판매 유형
           enum:
+          - REGULAR
           - AUCTION
           example: AUCTION
         status:
@@ -1770,11 +2727,12 @@ components:
           description: 상품 상태
           enum:
           - DRAFT
+          - ON_SALE
           - AUCTION_LIVE
           - ENDED
           example: AUCTION_LIVE
         auction:
-          "$ref": "#/components/schemas/AuctionScheduleResponse"
+          $ref: "#/components/schemas/AuctionScheduleResponse"
           description: 경매 메타 정보
     UploadAuctionImageResponse:
       type: object
@@ -1834,7 +2792,7 @@ components:
           type: array
           description: 상품 이미지 목록
           items:
-            "$ref": "#/components/schemas/ProductImagePayload"
+            $ref: "#/components/schemas/ProductImagePayload"
         location:
           type: string
           description: 거래 위치
@@ -1859,7 +2817,7 @@ components:
           type: string
           format: date-time
           description: 저장 시각
-          example: 2026-04-12 20:00:00.000000000 Z
+          example: 2026-04-12T20:00:00Z
     UpdateMyProfileRequest:
       type: object
       properties:
@@ -1939,6 +2897,14 @@ components:
           type: string
           maxLength: 255
           minLength: 0
+        latitude:
+          type: number
+          maximum: 90.0
+          minimum: -90.0
+        longitude:
+          type: number
+          maximum: 180.0
+          minimum: -180.0
         locationSource:
           type: string
           enum:
@@ -1958,12 +2924,170 @@ components:
           type: string
         detailAddress:
           type: string
+        latitude:
+          type: number
+        longitude:
+          type: number
         locationSource:
           type: string
           enum:
           - MANUAL
           - POSTCODE
           - GPS
+    MarkChatRoomAsReadResponse:
+      type: object
+      properties:
+        roomId:
+          type: integer
+          format: int64
+        message:
+          type: string
+        unreadCount:
+          type: integer
+          format: int32
+        readAt:
+          type: string
+          format: date-time
+    UpdateAuctionRequest:
+      type: object
+      description: 경매 상품 수정 요청
+      properties:
+        name:
+          type: string
+          description: 상품명
+          example: 맥북에어입니다
+          maxLength: 100
+          minLength: 0
+        description:
+          type: string
+          description: 상품 설명
+          example: 맥북입니다!!! 에어이고 많이안써서 깨끗해용
+          maxLength: 2000
+          minLength: 0
+        categoryId:
+          type: integer
+          format: int64
+          description: 카테고리 ID
+          example: 19
+        startPrice:
+          type: number
+          description: 경매 시작가
+          example: 400000
+        auctionDurationDays:
+          type: integer
+          format: int32
+          description: 경매 진행 기간(일 단위)
+          example: 1
+        location:
+          type: string
+          description: 거래 위치
+          example: 경기도 부천시 소사구 소사동로72번길 32
+          maxLength: 100
+          minLength: 0
+        images:
+          type: array
+          items:
+            $ref: "#/components/schemas/ProductImagePayload"
+            minItems: 1
+          minItems: 1
+      required:
+      - auctionDurationDays
+      - categoryId
+      - description
+      - images
+      - location
+      - name
+      - startPrice
+    AuctionEditDetailResponse:
+      type: object
+      description: 경매 수정용 상세 응답
+      properties:
+        productId:
+          type: integer
+          format: int64
+          description: 상품 ID
+          example: 10
+        auctionId:
+          type: integer
+          format: int64
+          description: 경매 ID. 별도 경매 테이블 도입 전까지 상품 ID와 동일
+          example: 10
+        name:
+          type: string
+          description: 상품명
+          example: 아이폰 14 Pro
+        description:
+          type: string
+          description: 상품 설명
+          example: 거의 새것입니다.
+        categoryId:
+          type: integer
+          format: int64
+          description: 카테고리 ID
+          example: 19
+        categoryName:
+          type: string
+          description: 카테고리명
+          example: 전자기기
+        location:
+          type: string
+          description: 거래 위치
+          example: 서울 강남구
+        images:
+          type: array
+          description: 상품 이미지 목록
+          items:
+            $ref: "#/components/schemas/AuctionEditImageResponse"
+        startPrice:
+          type: number
+          description: 경매 시작가
+          example: 700000
+        auctionDurationDays:
+          type: integer
+          format: int64
+          description: 경매 진행 기간(일)
+          example: 3
+        auctionStatus:
+          type: string
+          description: 경매 상태
+          enum:
+          - DRAFT
+          - ON_SALE
+          - AUCTION_LIVE
+          - ENDED
+          example: AUCTION_LIVE
+        bidCount:
+          type: integer
+          format: int32
+          description: 입찰 수
+          example: 0
+        bidderCount:
+          type: integer
+          format: int32
+          description: 입찰자 수
+          example: 0
+        canEdit:
+          type: boolean
+          description: 수정 가능 여부
+          example: true
+    AuctionEditImageResponse:
+      type: object
+      description: 경매 수정용 이미지
+      properties:
+        imageId:
+          type: integer
+          format: int64
+          description: 이미지 ID
+          example: 1
+        imageUrl:
+          type: string
+          description: 이미지 URL
+          example: https://example.com/auction/images/10.jpg
+        sortOrder:
+          type: integer
+          format: int32
+          description: 정렬 순서
+          example: 1
     MyLocationResponse:
       type: object
       properties:
@@ -1977,12 +3101,124 @@ components:
           type: string
         detailAddress:
           type: string
+        latitude:
+          type: number
+        longitude:
+          type: number
         locationSource:
           type: string
           enum:
           - MANUAL
           - POSTCODE
           - GPS
+    CategoryResponse:
+      type: object
+      properties:
+        categoryId:
+          type: integer
+          format: int64
+          description: 카테고리 ID
+          example: 19
+        nameKo:
+          type: string
+          description: 카테고리 한글명
+          example: 전자기기
+        nameEn:
+          type: string
+          description: 카테고리 영문명
+          example: Digital/Electronics
+    ProductDetailResponse:
+      type: object
+      description: 상품 상세 조회 응답
+      properties:
+        productId:
+          type: integer
+          format: int64
+          description: 상품 ID
+          example: 1001
+        name:
+          type: string
+          description: 상품명
+          example: 아이폰 14 Pro
+        description:
+          type: string
+          description: 상품 설명
+          example: 거의 새 상품입니다.
+        saleType:
+          type: string
+          description: 판매 유형
+          enum:
+          - REGULAR
+          - AUCTION
+          example: REGULAR
+        category:
+          $ref: "#/components/schemas/CategoryResponse"
+          description: 카테고리 정보
+        imageUrls:
+          type: array
+          description: 상품 이미지 URL 목록
+          items:
+            type: string
+        status:
+          type: string
+          description: 상품 공통 상태
+          enum:
+          - DRAFT
+          - ON_SALE
+          - SOLD
+          - ENDED
+          example: ON_SALE
+        seller:
+          $ref: "#/components/schemas/SellerResponse"
+          description: 판매자 정보
+        createdAt:
+          type: string
+          format: date-time
+          description: 생성 시각
+          example: 2026-05-02T10:30:00+09:00
+        updatedAt:
+          type: string
+          format: date-time
+          description: 수정 시각
+          example: 2026-05-02T11:00:00+09:00
+        generalSale:
+          $ref: "#/components/schemas/GeneralSaleResponse"
+          description: 일반 판매 상세 정보. 경매 상품이면 null
+        auction:
+          $ref: "#/components/schemas/AuctionResponse"
+          description: 경매 상세 정보. 일반 상품이면 null
+        canChat:
+          type: boolean
+          description: 채팅 가능 여부
+          example: true
+        canBid:
+          type: boolean
+          description: 입찰 가능 여부
+          example: false
+        canPurchase:
+          type: boolean
+          description: 구매 가능 여부
+          example: true
+        canFavorite:
+          type: boolean
+          description: 찜 가능 여부
+          example: true
+    SellerResponse:
+      type: object
+      properties:
+        memberId:
+          type: integer
+          format: int64
+          description: 판매자 회원 ID
+          example: 3
+        nickname:
+          type: string
+          description: 판매자 닉네임
+          example: dealit-user-3
+        location:
+          type: string
+          description: 거래 위치
+          example: 서울 강남구
     CategoryOptionResponse:
       type: object
       description: 카테고리 선택 옵션
@@ -2009,12 +3245,129 @@ components:
           type: integer
           format: int64
           description: 부모 카테고리 ID
-          example: 'null'
+          example: "null"
         children:
           type: array
           description: 하위 카테고리 목록
           items:
-            "$ref": "#/components/schemas/CategoryOptionResponse"
+            $ref: "#/components/schemas/CategoryOptionResponse"
+    MySellingAuctionItemResponse:
+      type: object
+      description: 내 판매중 경매 항목
+      properties:
+        productId:
+          type: integer
+          format: int64
+          description: 상품 ID
+          example: 10
+        auctionId:
+          type: integer
+          format: int64
+          description: 경매 ID. 별도 경매 테이블 도입 전까지 상품 ID와 동일
+          example: 10
+        name:
+          type: string
+          description: 상품명
+          example: 아이폰 14 Pro
+        description:
+          type: string
+          description: 상품 설명
+          example: 거의 새것입니다.
+        categoryName:
+          type: string
+          description: 카테고리명
+          example: 전자기기
+        thumbnailUrl:
+          type: string
+          description: 썸네일 이미지 URL
+          example: https://example.com/auction/images/10.jpg
+        auctionStatus:
+          type: string
+          description: 경매 상태
+          enum:
+          - DRAFT
+          - ON_SALE
+          - AUCTION_LIVE
+          - ENDED
+          example: AUCTION_LIVE
+        startPrice:
+          type: number
+          description: 경매 시작가
+          example: 700000
+        currentPrice:
+          type: number
+          description: 현재가
+          example: 700000
+        minimumNextBidPrice:
+          type: number
+          description: 최소 다음 입찰가
+          example: 700000
+        bidCount:
+          type: integer
+          format: int32
+          description: 입찰 수
+          example: 0
+        bidderCount:
+          type: integer
+          format: int32
+          description: 입찰자 수
+          example: 0
+        startAt:
+          type: string
+          format: date-time
+          description: 경매 시작 시각
+          example: 2026-04-30T09:00:00+09:00
+        endAt:
+          type: string
+          format: date-time
+          description: 경매 종료 시각
+          example: 2026-05-03T09:00:00+09:00
+        canEdit:
+          type: boolean
+          description: 수정 가능 여부
+          example: true
+        canDelete:
+          type: boolean
+          description: 삭제 가능 여부
+          example: true
+        createdAt:
+          type: string
+          format: date-time
+          description: 생성 시각
+          example: 2026-04-30T08:40:00+09:00
+        updatedAt:
+          type: string
+          format: date-time
+          description: 수정 시각
+          example: 2026-04-30T10:12:00+09:00
+    MySellingAuctionListResponse:
+      type: object
+      description: 내 판매중 경매 목록 응답
+      properties:
+        content:
+          type: array
+          description: 판매중 경매 목록
+          items:
+            $ref: "#/components/schemas/MySellingAuctionItemResponse"
+        page:
+          type: integer
+          format: int32
+          description: 현재 페이지 번호(0부터 시작)
+          example: 0
+        size:
+          type: integer
+          format: int32
+          description: 페이지 크기
+          example: 20
+        totalElements:
+          type: integer
+          format: int64
+          description: 전체 상품 수
+          example: 1
+        hasNext:
+          type: boolean
+          description: 다음 페이지 존재 여부
+          example: false
     NicknameCheckResponse:
       type: object
       properties:
@@ -2029,6 +3382,146 @@ components:
           type: string
         available:
           type: boolean
+    SseEmitter:
+      type: object
+      properties:
+        timeout:
+          type: integer
+          format: int64
+    UnreadCountResponse:
+      type: object
+      properties:
+        totalUnreadCount:
+          type: integer
+          format: int32
+        updatedAt:
+          type: string
+          format: date-time
+    ChatRoomListItemResponse:
+      type: object
+      properties:
+        roomId:
+          type: integer
+          format: int64
+        opponent:
+          $ref: "#/components/schemas/OpponentInfo"
+        product:
+          $ref: "#/components/schemas/ProductInfo"
+        chatType:
+          type: string
+          enum:
+          - GENERAL
+          - AUCTION
+        lastMessage:
+          $ref: "#/components/schemas/LastMessageInfo"
+        unreadCount:
+          type: integer
+          format: int32
+        updatedAt:
+          type: string
+          format: date-time
+    ChatRoomListResponse:
+      type: object
+      properties:
+        content:
+          type: array
+          items:
+            $ref: "#/components/schemas/ChatRoomListItemResponse"
+        page:
+          type: integer
+          format: int32
+        size:
+          type: integer
+          format: int32
+        totalElements:
+          type: integer
+          format: int64
+        totalPages:
+          type: integer
+          format: int32
+        hasNext:
+          type: boolean
+    LastMessageInfo:
+      type: object
+      properties:
+        messageId:
+          type: integer
+          format: int64
+        type:
+          type: string
+        content:
+          type: string
+        sentAt:
+          type: string
+          format: date-time
+    OpponentInfo:
+      type: object
+      properties:
+        userId:
+          type: integer
+          format: int64
+        nickname:
+          type: string
+        profileImageUrl:
+          type: string
+    RoomUnreadCountResponse:
+      type: object
+      properties:
+        roomId:
+          type: integer
+          format: int64
+        unreadCount:
+          type: integer
+          format: int32
+        updatedAt:
+          type: string
+          format: date-time
+    ChatMessageListResponse:
+      type: object
+      properties:
+        content:
+          type: array
+          items:
+            $ref: "#/components/schemas/ChatMessageResponse"
+        page:
+          type: integer
+          format: int32
+        size:
+          type: integer
+          format: int32
+        totalElements:
+          type: integer
+          format: int64
+        totalPages:
+          type: integer
+          format: int32
+        hasNext:
+          type: boolean
+    ChatMessageResponse:
+      type: object
+      properties:
+        messageId:
+          type: integer
+          format: int64
+        senderId:
+          type: integer
+          format: int64
+        senderNickname:
+          type: string
+        messageType:
+          type: string
+          enum:
+          - TEXT
+          - IMAGE
+          - SYSTEM
+          - TALK
+        content:
+          type: string
+        isRead:
+          type: boolean
+        sentAt:
+          type: string
+          format: date-time
     CurrentMemberResponse:
       type: object
       description: 현재 인증된 회원 정보

--- a/src/main/java/com/dealit/dealit/domain/product/controller/ProductDetailController.java
+++ b/src/main/java/com/dealit/dealit/domain/product/controller/ProductDetailController.java
@@ -1,0 +1,44 @@
+package com.dealit.dealit.domain.product.controller;
+
+import com.dealit.dealit.domain.product.dto.ProductDetailResponse;
+import com.dealit.dealit.domain.product.service.ProductDetailService;
+import com.dealit.dealit.global.security.AuthenticatedMember;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Product Detail", description = "상품 상세 조회 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/products")
+public class ProductDetailController {
+
+    private final ProductDetailService productDetailService;
+
+    @Operation(
+            summary = "상품 상세 조회",
+            description = "productId로 일반 상품 또는 경매 상품의 상세 정보를 조회합니다. 로그인 사용자는 이메일 인증 여부와 관계없이 조회할 수 있습니다."
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = "상품 상세 조회 성공",
+            content = @Content(schema = @Schema(implementation = ProductDetailResponse.class))
+    )
+    @ApiResponse(responseCode = "401", description = "인증 실패")
+    @ApiResponse(responseCode = "404", description = "상품 없음")
+    @GetMapping("/{productId}")
+    public ProductDetailResponse getProductDetail(
+            @AuthenticationPrincipal AuthenticatedMember member,
+            @PathVariable Long productId
+    ) {
+        return productDetailService.getProductDetail(member.memberId(), productId);
+    }
+}

--- a/src/main/java/com/dealit/dealit/domain/product/dto/ProductDetailResponse.java
+++ b/src/main/java/com/dealit/dealit/domain/product/dto/ProductDetailResponse.java
@@ -1,0 +1,128 @@
+package com.dealit.dealit.domain.product.dto;
+
+import com.dealit.dealit.domain.auction.AuctionStatus;
+import com.dealit.dealit.domain.product.ProductSaleType;
+import com.dealit.dealit.domain.product.ProductStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+import java.util.List;
+
+@Schema(description = "상품 상세 조회 응답")
+public record ProductDetailResponse(
+        @Schema(description = "상품 ID", example = "1001")
+        Long productId,
+
+        @Schema(description = "상품명", example = "아이폰 14 Pro")
+        String name,
+
+        @Schema(description = "상품 설명", example = "거의 새 상품입니다.")
+        String description,
+
+        @Schema(description = "판매 유형", example = "REGULAR", allowableValues = {"REGULAR", "AUCTION"})
+        ProductSaleType saleType,
+
+        @Schema(description = "카테고리 정보")
+        CategoryResponse category,
+
+        @Schema(description = "상품 이미지 URL 목록")
+        List<String> imageUrls,
+
+        @Schema(description = "상품 공통 상태", example = "ON_SALE")
+        ProductStatus status,
+
+        @Schema(description = "판매자 정보")
+        SellerResponse seller,
+
+        @Schema(description = "생성 시각", example = "2026-05-02T10:30:00+09:00")
+        OffsetDateTime createdAt,
+
+        @Schema(description = "수정 시각", example = "2026-05-02T11:00:00+09:00")
+        OffsetDateTime updatedAt,
+
+        @Schema(description = "일반 판매 상세 정보. 경매 상품이면 null")
+        GeneralSaleResponse generalSale,
+
+        @Schema(description = "경매 상세 정보. 일반 상품이면 null")
+        AuctionResponse auction,
+
+        @Schema(description = "채팅 가능 여부", example = "true")
+        boolean canChat,
+
+        @Schema(description = "입찰 가능 여부", example = "false")
+        boolean canBid,
+
+        @Schema(description = "구매 가능 여부", example = "true")
+        boolean canPurchase,
+
+        @Schema(description = "찜 가능 여부", example = "true")
+        boolean canFavorite
+) {
+
+    public record CategoryResponse(
+            @Schema(description = "카테고리 ID", example = "19")
+            Long categoryId,
+
+            @Schema(description = "카테고리 한글명", example = "전자기기")
+            String nameKo,
+
+            @Schema(description = "카테고리 영문명", example = "Digital/Electronics")
+            String nameEn
+    ) {
+    }
+
+    public record SellerResponse(
+            @Schema(description = "판매자 회원 ID", example = "3")
+            Long memberId,
+
+            @Schema(description = "판매자 닉네임", example = "dealit-user-3")
+            String nickname,
+
+            @Schema(description = "거래 위치", example = "서울 강남구")
+            String location
+    ) {
+    }
+
+    public record GeneralSaleResponse(
+            @Schema(description = "일반 판매 가격", example = "12000")
+            BigDecimal price,
+
+            @Schema(description = "조회수", example = "10")
+            long viewCount,
+
+            @Schema(description = "찜 수", example = "2")
+            long favoriteCount,
+
+            @Schema(description = "채팅 수", example = "1")
+            long chatCount,
+
+            @Schema(description = "일반 판매 상태", example = "ON_SALE")
+            ProductStatus status
+    ) {
+    }
+
+    public record AuctionResponse(
+            @Schema(description = "경매 ID", example = "5")
+            Long auctionId,
+
+            @Schema(description = "경매 시작가", example = "70000")
+            BigDecimal startPrice,
+
+            @Schema(description = "현재가. 입찰 내역이 없으면 시작가와 동일", example = "70000")
+            BigDecimal currentPrice,
+
+            @Schema(description = "최소 다음 입찰가", example = "70700")
+            BigDecimal minimumNextBidPrice,
+
+            @Schema(description = "입찰 수", example = "0")
+            long bidCount,
+
+            @Schema(description = "경매 종료 시각", example = "2026-05-05T10:30:00+09:00")
+            OffsetDateTime endAt,
+
+            @Schema(description = "경매 상태", example = "AUCTION_LIVE")
+            AuctionStatus status
+    ) {
+    }
+}

--- a/src/main/java/com/dealit/dealit/domain/product/entity/Product.java
+++ b/src/main/java/com/dealit/dealit/domain/product/entity/Product.java
@@ -71,6 +71,15 @@ public class Product extends BaseEntity {
 	@Column(name = "status", nullable = false, length = 30)
 	private ProductStatus status;
 
+	@Column(name = "view_count", nullable = false)
+	private long viewCount = 0L;
+
+	@Column(name = "favorite_count", nullable = false)
+	private long favoriteCount = 0L;
+
+	@Column(name = "chat_count", nullable = false)
+	private long chatCount = 0L;
+
 	@OneToMany(mappedBy = "product", cascade = CascadeType.ALL)
 	private final List<ProductImage> images = new ArrayList<>();
 
@@ -118,6 +127,10 @@ public class Product extends BaseEntity {
 			images.add(image);
 		}
 		image.assignToProduct(this, sortOrder);
+	}
+
+	public void increaseViewCount() {
+		this.viewCount++;
 	}
 
 	public void updateEditableDetails(

--- a/src/main/java/com/dealit/dealit/domain/product/exception/ProductNotFoundException.java
+++ b/src/main/java/com/dealit/dealit/domain/product/exception/ProductNotFoundException.java
@@ -1,0 +1,10 @@
+package com.dealit.dealit.domain.product.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class ProductNotFoundException extends ProductException {
+
+    public ProductNotFoundException(String message) {
+        super(HttpStatus.NOT_FOUND, "PRODUCT_NOT_FOUND", message);
+    }
+}

--- a/src/main/java/com/dealit/dealit/domain/product/repository/ProductRepository.java
+++ b/src/main/java/com/dealit/dealit/domain/product/repository/ProductRepository.java
@@ -1,7 +1,13 @@
 package com.dealit.dealit.domain.product.repository;
 
 import com.dealit.dealit.domain.product.entity.Product;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface ProductRepository extends JpaRepository<Product, Long> {
+
+    @EntityGraph(attributePaths = "images")
+    Optional<Product> findByProductIdAndDeletedAtIsNull(Long productId);
 }

--- a/src/main/java/com/dealit/dealit/domain/product/service/ProductDetailService.java
+++ b/src/main/java/com/dealit/dealit/domain/product/service/ProductDetailService.java
@@ -1,0 +1,210 @@
+package com.dealit.dealit.domain.product.service;
+
+import com.dealit.dealit.domain.auction.AuctionStatus;
+import com.dealit.dealit.domain.auction.entity.Auction;
+import com.dealit.dealit.domain.auction.entity.Category;
+import com.dealit.dealit.domain.auction.repository.AuctionRepository;
+import com.dealit.dealit.domain.auction.repository.CategoryRepository;
+import com.dealit.dealit.domain.auth.exception.InvalidCredentialsException;
+import com.dealit.dealit.domain.member.entity.Member;
+import com.dealit.dealit.domain.member.repository.MemberRepository;
+import com.dealit.dealit.domain.product.ProductSaleType;
+import com.dealit.dealit.domain.product.ProductStatus;
+import com.dealit.dealit.domain.product.dto.ProductDetailResponse;
+import com.dealit.dealit.domain.product.entity.Product;
+import com.dealit.dealit.domain.product.entity.ProductImage;
+import com.dealit.dealit.domain.product.exception.ProductNotFoundException;
+import com.dealit.dealit.domain.product.repository.ProductRepository;
+import com.dealit.dealit.global.service.ImageUrlService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.util.Comparator;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ProductDetailService {
+
+    private static final ZoneId SEOUL_ZONE = ZoneId.of("Asia/Seoul");
+
+    private final ProductRepository productRepository;
+    private final AuctionRepository auctionRepository;
+    private final CategoryRepository categoryRepository;
+    private final MemberRepository memberRepository;
+    private final ImageUrlService imageUrlService;
+
+    @Transactional
+    public ProductDetailResponse getProductDetail(Long memberId, Long productId) {
+        Member viewer = loadActiveMember(memberId);
+        Product product = productRepository.findByProductIdAndDeletedAtIsNull(productId)
+                .orElseThrow(() -> new ProductNotFoundException("존재하지 않는 상품입니다."));
+
+        product.increaseViewCount();
+
+        Category category = categoryRepository.findById(product.getCategoryId()).orElse(null);
+        Member seller = memberRepository.findByMemberIdAndDeletedAtIsNull(product.getMemberId())
+                .orElseThrow(() -> new ProductNotFoundException("상품 판매자 정보를 찾을 수 없습니다."));
+
+        boolean owner = seller.getMemberId().equals(viewer.getMemberId());
+
+        return new ProductDetailResponse(
+                product.getProductId(),
+                product.getName(),
+                product.getDescription(),
+                product.getSaleType(),
+                toCategoryResponse(category, product.getCategoryId()),
+                toImageUrls(product),
+                product.getStatus(),
+                toSellerResponse(seller, product),
+                toSeoulOffsetDateTime(product.getCreatedAt()),
+                toSeoulOffsetDateTime(product.getUpdatedAt() == null ? product.getCreatedAt() : product.getUpdatedAt()),
+                toGeneralSaleResponse(product),
+                toAuctionResponse(product),
+                canChat(product, owner),
+                canBid(product, owner),
+                canPurchase(product, owner),
+                canFavorite(product, owner)
+        );
+    }
+
+    private Member loadActiveMember(Long memberId) {
+        return memberRepository.findByMemberIdAndDeletedAtIsNull(memberId)
+                .orElseThrow(() -> new InvalidCredentialsException("존재하지 않는 회원입니다."));
+    }
+
+    private ProductDetailResponse.CategoryResponse toCategoryResponse(Category category, Long categoryId) {
+        if (category == null) {
+            return new ProductDetailResponse.CategoryResponse(categoryId, "", "");
+        }
+
+        return new ProductDetailResponse.CategoryResponse(
+                category.getId(),
+                category.getNameKo(),
+                category.getNameEn()
+        );
+    }
+
+    private ProductDetailResponse.SellerResponse toSellerResponse(Member seller, Product product) {
+        return new ProductDetailResponse.SellerResponse(
+                seller.getMemberId(),
+                seller.getNickname(),
+                product.getLocation()
+        );
+    }
+
+    private List<String> toImageUrls(Product product) {
+        return product.getImages().stream()
+                .filter(image -> image.getDeletedAt() == null)
+                .filter(image -> image.getImageUrl() != null && !image.getImageUrl().isBlank())
+                .sorted(Comparator.comparing(
+                        ProductImage::getSortOrder,
+                        Comparator.nullsLast(Integer::compareTo)
+                ))
+                .map(image -> imageUrlService.toPublicUrl(image.getImageUrl()))
+                .toList();
+    }
+
+    private ProductDetailResponse.GeneralSaleResponse toGeneralSaleResponse(Product product) {
+        if (product.getSaleType() != ProductSaleType.REGULAR) {
+            return null;
+        }
+
+        return new ProductDetailResponse.GeneralSaleResponse(
+                product.getPrice(),
+                product.getViewCount(),
+                product.getFavoriteCount(),
+                product.getChatCount(),
+                product.getStatus()
+        );
+    }
+
+    private ProductDetailResponse.AuctionResponse toAuctionResponse(Product product) {
+        if (product.getSaleType() != ProductSaleType.AUCTION) {
+            return null;
+        }
+
+        Auction auction = auctionRepository.findByProductProductIdAndDeletedAtIsNullAndProductDeletedAtIsNull(product.getProductId())
+                .orElseThrow(() -> new ProductNotFoundException("경매 상품 정보를 찾을 수 없습니다."));
+
+        BigDecimal currentPrice = resolveCurrentPrice(auction);
+
+        return new ProductDetailResponse.AuctionResponse(
+                auction.getAuctionId(),
+                auction.getStartPrice(),
+                currentPrice,
+                resolveMinimumNextBidPrice(currentPrice),
+                getBidCount(auction),
+                toSeoulOffsetDateTime(auction.getAuctionEndAt()),
+                auction.getStatus()
+        );
+    }
+
+    private BigDecimal resolveCurrentPrice(Auction auction) {
+        if (auction.getCurrentPrice() == null) {
+            return auction.getStartPrice();
+        }
+
+        return auction.getCurrentPrice();
+    }
+
+    private BigDecimal resolveMinimumNextBidPrice(BigDecimal currentPrice) {
+        BigDecimal increaseAmount = currentPrice
+                .multiply(BigDecimal.valueOf(0.01))
+                .setScale(0, RoundingMode.CEILING);
+
+        return currentPrice.add(increaseAmount);
+    }
+
+    private long getBidCount(Auction auction) {
+        return 0;
+    }
+
+    private boolean canChat(Product product, boolean owner) {
+        return !owner && product.getStatus() == ProductStatus.ON_SALE;
+    }
+
+    private boolean canBid(Product product, boolean owner) {
+        if (owner || product.getSaleType() != ProductSaleType.AUCTION) {
+            return false;
+        }
+
+        Auction auction = auctionRepository.findByProductProductIdAndDeletedAtIsNullAndProductDeletedAtIsNull(product.getProductId())
+                .orElse(null);
+
+        return auction != null && auction.getStatus() == AuctionStatus.AUCTION_LIVE;
+    }
+
+    private boolean canPurchase(Product product, boolean owner) {
+        return !owner
+                && product.getSaleType() == ProductSaleType.REGULAR
+                && product.getStatus() == ProductStatus.ON_SALE;
+    }
+
+    private boolean canFavorite(Product product, boolean owner) {
+        return !owner && product.getStatus() == ProductStatus.ON_SALE;
+    }
+
+    private OffsetDateTime toSeoulOffsetDateTime(LocalDateTime dateTime) {
+        if (dateTime == null) {
+            return null;
+        }
+
+        return dateTime.atZone(SEOUL_ZONE).toOffsetDateTime();
+    }
+
+    private OffsetDateTime toSeoulOffsetDateTime(OffsetDateTime dateTime) {
+        if (dateTime == null) {
+            return null;
+        }
+
+        return dateTime.atZoneSameInstant(SEOUL_ZONE).toOffsetDateTime();
+    }
+}

--- a/src/test/java/com/dealit/dealit/domain/product/ProductDetailIntegrationTest.java
+++ b/src/test/java/com/dealit/dealit/domain/product/ProductDetailIntegrationTest.java
@@ -1,0 +1,230 @@
+package com.dealit.dealit.domain.product;
+
+import com.dealit.dealit.domain.auction.AuctionStatus;
+import com.dealit.dealit.domain.auction.entity.Auction;
+import com.dealit.dealit.domain.auction.repository.AuctionRepository;
+import com.dealit.dealit.domain.member.entity.Member;
+import com.dealit.dealit.domain.member.repository.MemberRepository;
+import com.dealit.dealit.domain.product.entity.Product;
+import com.dealit.dealit.domain.product.entity.ProductImage;
+import com.dealit.dealit.domain.product.repository.ProductImageRepository;
+import com.dealit.dealit.domain.product.repository.ProductRepository;
+import com.dealit.dealit.global.security.AuthenticatedMember;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.startsWith;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class ProductDetailIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ProductRepository productRepository;
+
+    @Autowired
+    private ProductImageRepository productImageRepository;
+
+    @Autowired
+    private AuctionRepository auctionRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    private Member seller;
+    private Member viewer;
+
+    @BeforeEach
+    void setUp() {
+        auctionRepository.deleteAll();
+        productImageRepository.deleteAll();
+        productRepository.deleteAll();
+        memberRepository.deleteAll();
+
+        seller = memberRepository.save(Member.create(
+                "detail-seller",
+                "password",
+                "seller@example.com",
+                null,
+                "Detail Seller"
+        ));
+        seller.assignDefaultNickname();
+        seller.updateLocation("Seoul Gangnam");
+        seller = memberRepository.save(seller);
+
+        viewer = memberRepository.save(Member.create(
+                "detail-viewer",
+                "password",
+                "viewer@example.com",
+                null,
+                "Detail Viewer"
+        ));
+        viewer.assignDefaultNickname();
+        viewer.updateLocation("Seoul Mapo");
+        viewer = memberRepository.save(viewer);
+    }
+
+    @Test
+    @DisplayName("일반 상품 상세 조회에 성공하면 generalSale을 반환하고 auction은 null이다")
+    void getRegularProductDetailSuccess() throws Exception {
+        Product product = saveRegularProduct();
+        attachImage(product, "/uploads/product/images/regular-1.jpg", 1);
+
+        mockMvc.perform(get("/api/v1/products/{productId}", product.getProductId())
+                        .with(authentication(authenticatedMember(viewer))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.productId").value(product.getProductId()))
+                .andExpect(jsonPath("$.name").value("Regular Product"))
+                .andExpect(jsonPath("$.description").value("Regular product description"))
+                .andExpect(jsonPath("$.saleType").value("REGULAR"))
+                .andExpect(jsonPath("$.category.categoryId").value(19))
+                .andExpect(jsonPath("$.imageUrls[0]").value(startsWith("http://localhost:8080/uploads/product/images/regular-1.jpg")))
+                .andExpect(jsonPath("$.status").value("ON_SALE"))
+                .andExpect(jsonPath("$.seller.memberId").value(seller.getMemberId()))
+                .andExpect(jsonPath("$.seller.nickname").value(seller.getNickname()))
+                .andExpect(jsonPath("$.seller.location").value("Seoul Gangnam"))
+                .andExpect(jsonPath("$.generalSale.price").value(12000))
+                .andExpect(jsonPath("$.generalSale.viewCount").value(1))
+                .andExpect(jsonPath("$.generalSale.favoriteCount").value(0))
+                .andExpect(jsonPath("$.generalSale.chatCount").value(0))
+                .andExpect(jsonPath("$.generalSale.status").value("ON_SALE"))
+                .andExpect(jsonPath("$.auction").value(nullValue()))
+                .andExpect(jsonPath("$.canChat").value(true))
+                .andExpect(jsonPath("$.canBid").value(false))
+                .andExpect(jsonPath("$.canPurchase").value(true))
+                .andExpect(jsonPath("$.canFavorite").value(true));
+    }
+
+    @Test
+    @DisplayName("경매 상품 상세 조회에 성공하면 auction을 반환하고 generalSale은 null이다")
+    void getAuctionProductDetailSuccess() throws Exception {
+        Product product = saveAuctionProduct();
+        Auction auction = auctionRepository.save(Auction.create(
+                product,
+                BigDecimal.valueOf(70000),
+                OffsetDateTime.now(ZoneOffset.UTC),
+                OffsetDateTime.now(ZoneOffset.UTC).plusDays(3),
+                AuctionStatus.AUCTION_LIVE
+        ));
+        attachImage(product, "/uploads/auction/images/auction-1.jpg", 1);
+
+        mockMvc.perform(get("/api/v1/products/{productId}", product.getProductId())
+                        .with(authentication(authenticatedMember(viewer))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.productId").value(product.getProductId()))
+                .andExpect(jsonPath("$.saleType").value("AUCTION"))
+                .andExpect(jsonPath("$.generalSale").value(nullValue()))
+                .andExpect(jsonPath("$.auction.auctionId").value(auction.getAuctionId()))
+                .andExpect(jsonPath("$.auction.startPrice").value(70000))
+                .andExpect(jsonPath("$.auction.currentPrice").value(70000))
+                .andExpect(jsonPath("$.auction.minimumNextBidPrice").value(70700))
+                .andExpect(jsonPath("$.auction.bidCount").value(0))
+                .andExpect(jsonPath("$.auction.endAt").exists())
+                .andExpect(jsonPath("$.auction.status").value("AUCTION_LIVE"))
+                .andExpect(jsonPath("$.canChat").value(true))
+                .andExpect(jsonPath("$.canBid").value(true))
+                .andExpect(jsonPath("$.canPurchase").value(false))
+                .andExpect(jsonPath("$.canFavorite").value(true));
+    }
+
+    @Test
+    @DisplayName("상품 상세 조회에 성공하면 조회수가 증가한다")
+    void getProductDetailIncreasesViewCount() throws Exception {
+        Product product = saveRegularProduct();
+
+        mockMvc.perform(get("/api/v1/products/{productId}", product.getProductId())
+                        .with(authentication(authenticatedMember(viewer))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.generalSale.viewCount").value(1));
+
+        mockMvc.perform(get("/api/v1/products/{productId}", product.getProductId())
+                        .with(authentication(authenticatedMember(viewer))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.generalSale.viewCount").value(2));
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 상품을 조회하면 404 PRODUCT_NOT_FOUND를 반환한다")
+    void getProductDetailFailsWhenProductNotFound() throws Exception {
+        mockMvc.perform(get("/api/v1/products/{productId}", 999999L)
+                        .with(authentication(authenticatedMember(viewer))))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("PRODUCT_NOT_FOUND"));
+    }
+
+    @Test
+    @DisplayName("비로그인 사용자는 상품 상세를 조회할 수 없다")
+    void getProductDetailRequiresAuthentication() throws Exception {
+        Product product = saveRegularProduct();
+
+        mockMvc.perform(get("/api/v1/products/{productId}", product.getProductId()))
+                .andExpect(status().isUnauthorized());
+    }
+
+    private Product saveRegularProduct() {
+        return productRepository.save(Product.create(
+                "Regular Product",
+                "Regular product description",
+                ProductSaleType.REGULAR,
+                19L,
+                seller.getMemberId(),
+                BigDecimal.valueOf(12000),
+                false,
+                "Seoul Gangnam",
+                null,
+                ProductStatus.ON_SALE
+        ));
+    }
+
+    private Product saveAuctionProduct() {
+        return productRepository.save(Product.create(
+                "Auction Product",
+                "Auction product description",
+                ProductSaleType.AUCTION,
+                19L,
+                seller.getMemberId(),
+                BigDecimal.valueOf(70000),
+                false,
+                "Seoul Gangnam",
+                null,
+                ProductStatus.ON_SALE
+        ));
+    }
+
+    private void attachImage(Product product, String imageUrl, int sortOrder) {
+        ProductImage image = productImageRepository.save(
+                ProductImage.createTemporary(imageUrl, "test-image.jpg", seller.getMemberId())
+        );
+        product.attachImage(image, sortOrder);
+        productImageRepository.save(image);
+    }
+
+    private UsernamePasswordAuthenticationToken authenticatedMember(Member member) {
+        AuthenticatedMember principal = new AuthenticatedMember(member.getMemberId(), member.getLoginId(), "ROLE_USER");
+        return new UsernamePasswordAuthenticationToken(
+                principal,
+                null,
+                List.of(new SimpleGrantedAuthority("ROLE_USER"))
+        );
+    }
+}


### PR DESCRIPTION

상품 상세페이지에서 사용할 상품 상세 조회 API를 구현했습니다.

---

### ✨ Description

- `GET /api/v1/products/{productId}` 상품 상세 조회 API를 추가했습니다.
- 로그인 사용자가 `productId` 기준으로 일반 상품과 경매 상품 상세 정보를 조회할 수 있습니다.
- 상세 조회 성공 시 상품 조회수 `viewCount`가 1 증가합니다.
- 응답의 `saleType`은 `REGULAR`, `AUCTION`으로 반환됩니다.
- 일반 상품인 경우 `generalSale` 객체를 반환하고 `auction`은 `null`로 반환합니다.
- 경매 상품인 경우 `auction` 객체를 반환하고 `generalSale`은 `null`로 반환합니다.
- 상품 이미지 목록은 `sortOrder` 기준으로 정렬해 반환합니다.
- 카테고리 정보, 판매자 정보, 생성/수정 시간, 버튼 제어용 필드를 함께 반환합니다.
- 상품이 존재하지 않는 경우 `404 PRODUCT_NOT_FOUND`를 반환합니다.
- `docs/openapi.yaml`을 최신 API 스펙 기준으로 갱신했습니다.

1) 일반 상품 등록
<img width="1474" height="1210" alt="일반상품_등록" src="https://github.com/user-attachments/assets/8f76159b-c1ae-4f2b-9b8f-26589be98f0c" />

2) 일반 상품 조회
<img width="1507" height="1149" alt="일반상품 상세 조회" src="https://github.com/user-attachments/assets/5f63e8d1-8066-4543-845c-7a826703297c" />

3) viewCount 증가
<img width="1302" height="440" alt="일반상품_다시조회시viewcount증가" src="https://github.com/user-attachments/assets/e0362eae-ff68-4bd4-b797-02e0d24693c3" />

검증한 내용:

- 일반 상품 상세 조회 성공
- 경매 상품 상세 조회 성공
- 상세 조회 시 `viewCount + 1`
- 일반 상품 응답에서 `auction = null`
- 경매 상품 응답에서 `generalSale = null`
- 존재하지 않는 상품 조회 시 `404 PRODUCT_NOT_FOUND`
- 비로그인 사용자 조회 시 `401`


<!-- Please enter {Issue Number} below to automatically close the connected issue. -->

close #{36}
