### PR TITLE
[feat] 경매로직

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -484,6 +484,26 @@ paths:
               schema:
                 $ref: "#/components/schemas/MySellingAuctionListResponse"
   /api/v1/auctions/{auctionId}:
+    get:
+      tags:
+      - Auction
+      summary: 경매 상세 조회
+      description: 경매 상세페이지에 필요한 상품, 판매자, 이미지, 현재 입찰 정보를 조회한다.
+      operationId: getAuction
+      parameters:
+      - name: auctionId
+        in: path
+        required: true
+        schema:
+          type: integer
+          format: int64
+      responses:
+        "200":
+          description: 경매 상세 조회 성공
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/AuctionDetailResponse"
     patch:
       tags:
       - Auction
@@ -1448,11 +1468,24 @@ components:
           type: number
           description: 경매 시작가
           example: 80000
+        minimumBidAmount:
+          type: number
+          description: 최소 입찰 금액/입찰 단위
+          example: 800
         auctionDurationDays:
+          type: number
+          description: 경매 진행 기간(일 단위, 테스트용 소수 허용)
+          example: 0.00011574074074074075
+        auctionDurationSeconds:
           type: integer
           format: int32
-          description: 경매 진행 기간(일 단위)
-          example: 3
+          description: 경매 진행 기간(초 단위, 테스트용)
+          example: 10
+        endsAt:
+          type: string
+          format: date-time
+          description: 경매 종료 시각
+          example: "2026-05-02T12:00:00Z"
         images:
           type: array
           items:
@@ -1505,6 +1538,131 @@ components:
           type: boolean
           description: 다음 페이지 존재 여부
           example: false
+    AuctionDetailResponse:
+      type: object
+      description: 경매 상세페이지 응답
+      properties:
+        auctionId:
+          type: integer
+          format: int64
+          description: 경매 ID
+          example: 10
+        productId:
+          type: integer
+          format: int64
+          description: 상품 ID
+          example: 10
+        name:
+          type: string
+          description: 상품명
+          example: 아이폰 14 Pro
+        description:
+          type: string
+          description: 상품 설명
+          example: 거의 새것입니다.
+        categoryId:
+          type: integer
+          format: int64
+          description: 카테고리 ID
+          example: 19
+        categoryName:
+          type: string
+          description: 카테고리명
+          example: 전자기기
+        location:
+          type: string
+          description: 거래 위치
+          example: 서울 강남구
+        images:
+          type: array
+          description: 상품 이미지 목록
+          items:
+            $ref: "#/components/schemas/AuctionDetailImageResponse"
+        seller:
+          $ref: "#/components/schemas/AuctionDetailSellerResponse"
+        startPrice:
+          type: number
+          description: 경매 시작가
+          example: 700000
+        currentPrice:
+          type: number
+          description: 현재가
+          example: 700000
+        minimumBidAmount:
+          type: number
+          description: 최소 입찰 금액/입찰 단위
+          example: 7000
+        minimumNextBidPrice:
+          type: number
+          description: 최소 다음 입찰가
+          example: 707000
+        bidCount:
+          type: integer
+          format: int32
+          description: 입찰 수
+          example: 0
+        bidderCount:
+          type: integer
+          format: int32
+          description: 입찰자 수
+          example: 0
+        startAt:
+          type: string
+          format: date-time
+          description: 경매 시작 시각
+          example: 2026-04-30T09:00:00+09:00
+        endsAt:
+          type: string
+          format: date-time
+          description: 경매 종료 시각
+          example: 2026-05-03T09:00:00+09:00
+        serverTime:
+          type: string
+          format: date-time
+          description: 서버 현재 시각
+          example: 2026-04-30T09:10:00Z
+        status:
+          type: string
+          description: 경매 상태
+          enum:
+          - AUCTION_LIVE
+          example: AUCTION_LIVE
+    AuctionDetailImageResponse:
+      type: object
+      description: 경매 상세 이미지
+      properties:
+        imageId:
+          type: integer
+          format: int64
+          description: 이미지 ID
+          example: 1
+        imageUrl:
+          type: string
+          description: 이미지 URL
+          example: http://localhost:8080/uploads/auction/images/1-sample.jpg
+        sortOrder:
+          type: integer
+          format: int32
+          description: 정렬 순서
+          example: 1
+    AuctionDetailSellerResponse:
+      type: object
+      description: 경매 판매자 정보
+      properties:
+        memberId:
+          type: integer
+          format: int64
+          description: 판매자 회원 ID
+          example: 1
+        nickname:
+          type: string
+          description: 판매자 닉네임
+          example: Dealit#1
+        profileImageUrl:
+          type: string
+          nullable: true
+          description: 판매자 프로필 이미지 URL
+          example: http://localhost:8080/uploads/profile/images/1-profile.png
     MySellingAuctionItemResponse:
       type: object
       description: 내 판매중 경매 항목
@@ -1546,6 +1704,10 @@ components:
           type: number
           description: 경매 시작가
           example: 700000
+        minimumBidAmount:
+          type: number
+          description: 최소 입찰 금액/입찰 단위
+          example: 7000
         currentPrice:
           type: number
           description: 현재가
@@ -1553,7 +1715,7 @@ components:
         minimumNextBidPrice:
           type: number
           description: 최소 다음 입찰가
-          example: 700000
+          example: 707000
         bidCount:
           type: integer
           format: int32
@@ -1636,6 +1798,10 @@ components:
           type: number
           description: 경매 시작가
           example: 700000
+        minimumBidAmount:
+          type: number
+          description: 최소 입찰 금액/입찰 단위
+          example: 7000
         auctionDurationDays:
           type: integer
           format: int64
@@ -1704,6 +1870,11 @@ components:
           type: number
           description: 경매 시작가
           example: 400000
+        minimumBidAmount:
+          type: number
+          description: 최소 입찰 금액/입찰 단위. 생략 시 시작가의 1%로 계산
+          nullable: true
+          example: 4000
         auctionDurationDays:
           type: integer
           format: int32
@@ -1825,6 +1996,10 @@ components:
           type: number
           description: 경매 시작가
           example: 80000
+        minimumBidAmount:
+          type: number
+          description: 최소 입찰 금액/입찰 단위
+          example: 800
         auctionDurationDays:
           type: integer
           format: int32

--- a/src/main/java/com/dealit/dealit/domain/auction/AuctionStatus.java
+++ b/src/main/java/com/dealit/dealit/domain/auction/AuctionStatus.java
@@ -2,7 +2,8 @@ package com.dealit.dealit.domain.auction;
 
 public enum AuctionStatus {
 	DRAFT,
-	ON_SALE,
-	AUCTION_LIVE,
-	ENDED
+	ONGOING,
+	ENDED,
+	NO_BID,
+	SUCCESSFUL_BID
 }

--- a/src/main/java/com/dealit/dealit/domain/auction/controller/AuctionManagementController.java
+++ b/src/main/java/com/dealit/dealit/domain/auction/controller/AuctionManagementController.java
@@ -1,8 +1,12 @@
 package com.dealit.dealit.domain.auction.controller;
 
+import com.dealit.dealit.domain.auction.dto.AuctionDetailResponse;
+import com.dealit.dealit.domain.auction.dto.BidRequest;
+import com.dealit.dealit.domain.auction.dto.BidResponse;
 import com.dealit.dealit.domain.auction.dto.AuctionEditDetailResponse;
 import com.dealit.dealit.domain.auction.dto.MySellingAuctionListResponse;
 import com.dealit.dealit.domain.auction.dto.UpdateAuctionRequest;
+import com.dealit.dealit.domain.auction.service.AuctionBidService;
 import com.dealit.dealit.domain.auction.service.AuctionService;
 import com.dealit.dealit.global.security.AuthenticatedMember;
 import io.swagger.v3.oas.annotations.Operation;
@@ -22,6 +26,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.PostMapping;
 
 import jakarta.validation.Valid;
 
@@ -32,6 +37,23 @@ import jakarta.validation.Valid;
 public class AuctionManagementController {
 
 	private final AuctionService auctionService;
+	private final AuctionBidService auctionBidService;
+
+	@Operation(summary = "경매 상세 조회", description = "경매 현재가와 서버 시간을 조회한다.")
+	@GetMapping("/auctions/{auctionId}")
+	public AuctionDetailResponse getAuction(@PathVariable Long auctionId) {
+		return auctionBidService.getAuction(auctionId);
+	}
+
+	@Operation(summary = "경매 입찰", description = "서버 도착 시간 기준으로 입찰을 처리한다.")
+	@PostMapping("/auctions/{auctionId}/bids")
+	public BidResponse bid(
+		@AuthenticationPrincipal AuthenticatedMember member,
+		@PathVariable Long auctionId,
+		@Valid @RequestBody BidRequest request
+	) {
+		return auctionBidService.bid(auctionId, member.memberId(), request.bidPrice());
+	}
 
 	@Operation(summary = "내 판매중 경매 목록", description = "마이페이지 판매중 화면에서 현재 사용자의 진행중 경매 목록을 페이징 조회한다.")
 	@ApiResponse(responseCode = "200", description = "내 판매중 경매 목록 조회 성공",

--- a/src/main/java/com/dealit/dealit/domain/auction/dto/AuctionDetailResponse.java
+++ b/src/main/java/com/dealit/dealit/domain/auction/dto/AuctionDetailResponse.java
@@ -1,0 +1,42 @@
+package com.dealit.dealit.domain.auction.dto;
+
+import com.dealit.dealit.domain.auction.AuctionStatus;
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+import java.util.List;
+
+public record AuctionDetailResponse(
+	Long auctionId,
+	Long productId,
+	String name,
+	String description,
+	Long categoryId,
+	String categoryName,
+	String location,
+	List<ImageResponse> images,
+	SellerResponse seller,
+	BigDecimal startPrice,
+	BigDecimal currentPrice,
+	BigDecimal minimumBidAmount,
+	BigDecimal minimumNextBidPrice,
+	int bidCount,
+	int bidderCount,
+	OffsetDateTime startAt,
+	OffsetDateTime endsAt,
+	OffsetDateTime serverTime,
+	AuctionStatus status
+) {
+	public record ImageResponse(
+		Long imageId,
+		String imageUrl,
+		Integer sortOrder
+	) {
+	}
+
+	public record SellerResponse(
+		Long memberId,
+		String nickname,
+		String profileImageUrl
+	) {
+	}
+}

--- a/src/main/java/com/dealit/dealit/domain/auction/dto/AuctionEditDetailResponse.java
+++ b/src/main/java/com/dealit/dealit/domain/auction/dto/AuctionEditDetailResponse.java
@@ -35,10 +35,13 @@ public record AuctionEditDetailResponse(
 	@Schema(description = "경매 시작가", example = "700000")
 	BigDecimal startPrice,
 
+	@Schema(description = "최소 입찰 금액/입찰 단위", example = "7000")
+	BigDecimal minimumBidAmount,
+
 	@Schema(description = "경매 진행 기간(일)", example = "3")
 	long auctionDurationDays,
 
-	@Schema(description = "경매 상태", example = "AUCTION_LIVE")
+	@Schema(description = "경매 상태", example = "ONGOING")
 	AuctionStatus auctionStatus,
 
 	@Schema(description = "입찰 수", example = "0")

--- a/src/main/java/com/dealit/dealit/domain/auction/dto/AuctionEventPayload.java
+++ b/src/main/java/com/dealit/dealit/domain/auction/dto/AuctionEventPayload.java
@@ -1,0 +1,37 @@
+package com.dealit.dealit.domain.auction.dto;
+
+import com.dealit.dealit.domain.auction.AuctionStatus;
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+
+public final class AuctionEventPayload {
+
+	private AuctionEventPayload() {
+	}
+
+	public record BidUpdated(
+		Long auctionId,
+		BigDecimal currentPrice,
+		Long bidderId,
+		OffsetDateTime serverTime
+	) {
+	}
+
+	public record Outbid(
+		Long auctionId,
+		Long previousBidderId,
+		Long newBidderId,
+		BigDecimal currentPrice,
+		OffsetDateTime serverTime
+	) {
+	}
+
+	public record AuctionEnded(
+		Long auctionId,
+		Long winnerId,
+		BigDecimal finalPrice,
+		AuctionStatus status,
+		OffsetDateTime serverTime
+	) {
+	}
+}

--- a/src/main/java/com/dealit/dealit/domain/auction/dto/BidRequest.java
+++ b/src/main/java/com/dealit/dealit/domain/auction/dto/BidRequest.java
@@ -1,0 +1,15 @@
+package com.dealit.dealit.domain.auction.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import java.math.BigDecimal;
+
+@Schema(description = "경매 입찰 요청")
+public record BidRequest(
+	@Schema(description = "입찰가", example = "12000")
+	@NotNull(message = "입찰가는 필수입니다.")
+	@Positive(message = "입찰가는 0보다 커야 합니다.")
+	BigDecimal bidPrice
+) {
+}

--- a/src/main/java/com/dealit/dealit/domain/auction/dto/BidResponse.java
+++ b/src/main/java/com/dealit/dealit/domain/auction/dto/BidResponse.java
@@ -1,0 +1,12 @@
+package com.dealit.dealit.domain.auction.dto;
+
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+
+public record BidResponse(
+	Long auctionId,
+	BigDecimal currentPrice,
+	Long bidderId,
+	OffsetDateTime serverTime
+) {
+}

--- a/src/main/java/com/dealit/dealit/domain/auction/dto/CreateAuctionRequest.java
+++ b/src/main/java/com/dealit/dealit/domain/auction/dto/CreateAuctionRequest.java
@@ -44,9 +44,13 @@ public record CreateAuctionRequest(
 	@Positive(message = "최소 입찰 금액은 0보다 커야 합니다.")
 	BigDecimal minimumBidAmount,
 
-	@Schema(description = "경매 진행 기간(일 단위)", example = "3", nullable = true)
+	@Schema(description = "경매 진행 기간(일 단위, 테스트용 소수 허용)", example = "3", nullable = true)
 	@Positive(message = "경매 진행 기간은 0보다 커야 합니다.")
-	Integer auctionDurationDays,
+	BigDecimal auctionDurationDays,
+
+	@Schema(description = "경매 진행 기간(초 단위, 테스트용)", example = "10", nullable = true)
+	@Positive(message = "경매 진행 기간(초)은 0보다 커야 합니다.")
+	Integer auctionDurationSeconds,
 
 	@Schema(description = "경매 종료 시각", example = "2026-05-02T12:00:00Z", nullable = true)
 	OffsetDateTime endsAt,

--- a/src/main/java/com/dealit/dealit/domain/auction/dto/CreateAuctionRequest.java
+++ b/src/main/java/com/dealit/dealit/domain/auction/dto/CreateAuctionRequest.java
@@ -11,6 +11,7 @@ import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.Size;
 
 import java.math.BigDecimal;
+import java.time.OffsetDateTime;
 import java.util.List;
 
 @Schema(description = "경매 상품 등록 요청")
@@ -39,9 +40,16 @@ public record CreateAuctionRequest(
 	@Schema(description = "경매 시작가", example = "80000", nullable = true)
 	BigDecimal startPrice,
 
+	@Schema(description = "최소 입찰 금액/입찰 단위", example = "800", nullable = true)
+	@Positive(message = "최소 입찰 금액은 0보다 커야 합니다.")
+	BigDecimal minimumBidAmount,
+
 	@Schema(description = "경매 진행 기간(일 단위)", example = "3", nullable = true)
 	@Positive(message = "경매 진행 기간은 0보다 커야 합니다.")
 	Integer auctionDurationDays,
+
+	@Schema(description = "경매 종료 시각", example = "2026-05-02T12:00:00Z", nullable = true)
+	OffsetDateTime endsAt,
 
 	@ArraySchema(schema = @Schema(implementation = ProductImagePayload.class), minItems = 1)
 	@NotEmpty(message = "이미지는 최소 1장 이상 등록해야 합니다.")

--- a/src/main/java/com/dealit/dealit/domain/auction/dto/CreateAuctionResponse.java
+++ b/src/main/java/com/dealit/dealit/domain/auction/dto/CreateAuctionResponse.java
@@ -15,7 +15,7 @@ public record CreateAuctionResponse(
 	@Schema(description = "판매 유형", example = "AUCTION")
 	ProductSaleType saleType,
 
-	@Schema(description = "상품 상태", example = "AUCTION_LIVE")
+	@Schema(description = "상품 상태", example = "ONGOING")
 	AuctionStatus status,
 
 	@Schema(description = "경매 메타 정보")
@@ -24,7 +24,7 @@ public record CreateAuctionResponse(
 
 	@Schema(description = "경매 일정 및 상태 정보")
 	public record AuctionScheduleResponse(
-		@Schema(description = "경매 상태", example = "AUCTION_LIVE")
+		@Schema(description = "경매 상태", example = "ONGOING")
 		AuctionStatus status,
 
 		@Schema(description = "경매 시작 시각", example = "2026-04-15T10:00:00Z")

--- a/src/main/java/com/dealit/dealit/domain/auction/dto/MySellingAuctionItemResponse.java
+++ b/src/main/java/com/dealit/dealit/domain/auction/dto/MySellingAuctionItemResponse.java
@@ -26,11 +26,14 @@ public record MySellingAuctionItemResponse(
 	@Schema(description = "썸네일 이미지 URL", example = "https://example.com/auction/images/10.jpg")
 	String thumbnailUrl,
 
-	@Schema(description = "경매 상태", example = "AUCTION_LIVE")
+	@Schema(description = "경매 상태", example = "ONGOING")
 	AuctionStatus auctionStatus,
 
 	@Schema(description = "경매 시작가", example = "700000")
 	BigDecimal startPrice,
+
+	@Schema(description = "최소 입찰 금액/입찰 단위", example = "7000")
+	BigDecimal minimumBidAmount,
 
 	@Schema(description = "현재가", example = "700000")
 	BigDecimal currentPrice,

--- a/src/main/java/com/dealit/dealit/domain/auction/dto/SaveAuctionDraftRequest.java
+++ b/src/main/java/com/dealit/dealit/domain/auction/dto/SaveAuctionDraftRequest.java
@@ -35,9 +35,9 @@ public record SaveAuctionDraftRequest(
 	@Positive(message = "최소 입찰 금액은 0보다 커야 합니다.")
 	BigDecimal minimumBidAmount,
 
-	@Schema(description = "경매 진행 기간(일 단위)", example = "3", nullable = true)
+	@Schema(description = "경매 진행 기간(일 단위, 테스트용 소수 허용)", example = "3", nullable = true)
 	@Positive(message = "경매 진행 기간은 0보다 커야 합니다.")
-	Integer auctionDurationDays,
+	BigDecimal auctionDurationDays,
 
 	@Schema(description = "상품 이미지 목록", nullable = true)
 	List<@Valid ProductImagePayload> images,

--- a/src/main/java/com/dealit/dealit/domain/auction/dto/SaveAuctionDraftRequest.java
+++ b/src/main/java/com/dealit/dealit/domain/auction/dto/SaveAuctionDraftRequest.java
@@ -31,6 +31,10 @@ public record SaveAuctionDraftRequest(
 	@Schema(description = "경매 시작가", example = "80000", nullable = true)
 	BigDecimal startPrice,
 
+	@Schema(description = "최소 입찰 금액/입찰 단위", example = "800", nullable = true)
+	@Positive(message = "최소 입찰 금액은 0보다 커야 합니다.")
+	BigDecimal minimumBidAmount,
+
 	@Schema(description = "경매 진행 기간(일 단위)", example = "3", nullable = true)
 	@Positive(message = "경매 진행 기간은 0보다 커야 합니다.")
 	Integer auctionDurationDays,
@@ -53,6 +57,7 @@ public record SaveAuctionDraftRequest(
 			request.categoryId(),
 			request.price(),
 			request.startPrice(),
+			request.minimumBidAmount(),
 			request.auctionDurationDays(),
 			request.images(),
 			request.location(),

--- a/src/main/java/com/dealit/dealit/domain/auction/dto/UpdateAuctionRequest.java
+++ b/src/main/java/com/dealit/dealit/domain/auction/dto/UpdateAuctionRequest.java
@@ -32,6 +32,10 @@ public record UpdateAuctionRequest(
 	@NotNull(message = "경매 시작가는 필수입니다.")
 	BigDecimal startPrice,
 
+	@Schema(description = "최소 입찰 금액/입찰 단위. 생략 시 시작가의 1%로 계산", example = "4000", nullable = true)
+	@Positive(message = "최소 입찰 금액은 0보다 커야 합니다.")
+	BigDecimal minimumBidAmount,
+
 	@Schema(description = "경매 진행 기간(일 단위)", example = "1")
 	@NotNull(message = "경매 진행 기간은 필수입니다.")
 	@Positive(message = "경매 진행 기간은 0보다 커야 합니다.")

--- a/src/main/java/com/dealit/dealit/domain/auction/entity/Auction.java
+++ b/src/main/java/com/dealit/dealit/domain/auction/entity/Auction.java
@@ -20,6 +20,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.time.OffsetDateTime;
 
 @Getter
@@ -39,7 +40,7 @@ public class Auction extends BaseEntity {
 	private Long auctionId;
 
 	@OneToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "product_id", nullable = false)
+	@JoinColumn(name = "product_id", nullable = false, unique = true)
 	private Product product;
 
 	@Column(name = "start_price", nullable = false, precision = 15, scale = 2)
@@ -48,11 +49,20 @@ public class Auction extends BaseEntity {
 	@Column(name = "current_price", nullable = false, precision = 15, scale = 2)
 	private BigDecimal currentPrice;
 
-	@Column(name = "auction_start_at", nullable = false)
-	private OffsetDateTime auctionStartAt;
+	@Column(name = "minimum_bid_amount", precision = 15, scale = 2)
+	private BigDecimal minimumBidAmount;
 
-	@Column(name = "auction_end_at", nullable = false)
-	private OffsetDateTime auctionEndAt;
+	@Column(name = "final_price", precision = 15, scale = 2)
+	private BigDecimal finalPrice;
+
+	@Column(name = "winner_id")
+	private Long winnerId;
+
+	@Column(name = "started_at", nullable = false)
+	private OffsetDateTime startedAt;
+
+	@Column(name = "ends_at", nullable = false)
+	private OffsetDateTime endsAt;
 
 	@Enumerated(EnumType.STRING)
 	@Column(name = "status", nullable = false, length = 30)
@@ -62,31 +72,71 @@ public class Auction extends BaseEntity {
 		Product product,
 		BigDecimal startPrice,
 		BigDecimal currentPrice,
-		OffsetDateTime auctionStartAt,
-		OffsetDateTime auctionEndAt,
+		BigDecimal minimumBidAmount,
+		OffsetDateTime startedAt,
+		OffsetDateTime endsAt,
 		AuctionStatus status
 	) {
 		this.product = product;
 		this.startPrice = startPrice;
 		this.currentPrice = currentPrice;
-		this.auctionStartAt = auctionStartAt;
-		this.auctionEndAt = auctionEndAt;
+		this.minimumBidAmount = minimumBidAmount;
+		this.startedAt = startedAt;
+		this.endsAt = endsAt;
 		this.status = status;
 	}
 
 	public static Auction create(
 		Product product,
 		BigDecimal startPrice,
+		BigDecimal minimumBidAmount,
 		OffsetDateTime auctionStartAt,
 		OffsetDateTime auctionEndAt,
 		AuctionStatus status
 	) {
-		return new Auction(product, startPrice, startPrice, auctionStartAt, auctionEndAt, status);
+		return new Auction(product, startPrice, startPrice, minimumBidAmount, auctionStartAt, auctionEndAt, status);
 	}
 
-	public void updateEditableDetails(BigDecimal startPrice, OffsetDateTime auctionEndAt) {
+	public void updateEditableDetails(BigDecimal startPrice, BigDecimal minimumBidAmount, OffsetDateTime auctionEndAt) {
 		this.startPrice = startPrice;
 		this.currentPrice = startPrice;
-		this.auctionEndAt = auctionEndAt;
+		this.minimumBidAmount = minimumBidAmount;
+		this.endsAt = auctionEndAt;
+	}
+
+	public void updateCurrentPrice(BigDecimal currentPrice) {
+		this.currentPrice = currentPrice;
+	}
+
+	public BigDecimal getMinimumBidAmount() {
+		if (minimumBidAmount != null) {
+			return minimumBidAmount;
+		}
+		return startPrice.multiply(BigDecimal.valueOf(0.01)).setScale(0, RoundingMode.CEILING);
+	}
+
+	public void completeWithWinner(Long winnerId, BigDecimal finalPrice) {
+		this.winnerId = winnerId;
+		this.finalPrice = finalPrice;
+		this.currentPrice = finalPrice;
+		this.status = AuctionStatus.SUCCESSFUL_BID;
+	}
+
+	public void completeWithoutBid() {
+		this.finalPrice = null;
+		this.winnerId = null;
+		this.status = AuctionStatus.NO_BID;
+	}
+
+	public boolean isOngoing() {
+		return this.status == AuctionStatus.ONGOING;
+	}
+
+	public OffsetDateTime getAuctionStartAt() {
+		return startedAt;
+	}
+
+	public OffsetDateTime getAuctionEndAt() {
+		return endsAt;
 	}
 }

--- a/src/main/java/com/dealit/dealit/domain/auction/entity/AuctionDraft.java
+++ b/src/main/java/com/dealit/dealit/domain/auction/entity/AuctionDraft.java
@@ -57,6 +57,9 @@ public class AuctionDraft extends BaseEntity {
 	@Column(name = "start_price", precision = 15, scale = 2)
 	private BigDecimal startPrice;
 
+	@Column(name = "minimum_bid_amount", precision = 15, scale = 2)
+	private BigDecimal minimumBidAmount;
+
 	@Column(name = "auction_start_at")
 	private OffsetDateTime auctionStartAt;
 
@@ -84,6 +87,7 @@ public class AuctionDraft extends BaseEntity {
 		Long memberId,
 		BigDecimal price,
 		BigDecimal startPrice,
+		BigDecimal minimumBidAmount,
 		OffsetDateTime auctionStartAt,
 		OffsetDateTime auctionEndAt,
 		Integer auctionDurationDays,
@@ -98,6 +102,7 @@ public class AuctionDraft extends BaseEntity {
 		this.memberId = memberId;
 		this.price = price;
 		this.startPrice = startPrice;
+		this.minimumBidAmount = minimumBidAmount;
 		this.auctionStartAt = auctionStartAt;
 		this.auctionEndAt = auctionEndAt;
 		this.auctionDurationDays = auctionDurationDays;
@@ -114,6 +119,7 @@ public class AuctionDraft extends BaseEntity {
 		Long memberId,
 		BigDecimal price,
 		BigDecimal startPrice,
+		BigDecimal minimumBidAmount,
 		OffsetDateTime auctionStartAt,
 		OffsetDateTime auctionEndAt,
 		Integer auctionDurationDays,
@@ -129,6 +135,7 @@ public class AuctionDraft extends BaseEntity {
 			memberId,
 			price,
 			startPrice,
+			minimumBidAmount,
 			auctionStartAt,
 			auctionEndAt,
 			auctionDurationDays,
@@ -146,6 +153,7 @@ public class AuctionDraft extends BaseEntity {
 		Long memberId,
 		BigDecimal price,
 		BigDecimal startPrice,
+		BigDecimal minimumBidAmount,
 		OffsetDateTime auctionStartAt,
 		OffsetDateTime auctionEndAt,
 		Integer auctionDurationDays,
@@ -160,6 +168,7 @@ public class AuctionDraft extends BaseEntity {
 		this.memberId = memberId;
 		this.price = price;
 		this.startPrice = startPrice;
+		this.minimumBidAmount = minimumBidAmount;
 		this.auctionStartAt = auctionStartAt;
 		this.auctionEndAt = auctionEndAt;
 		this.auctionDurationDays = auctionDurationDays;

--- a/src/main/java/com/dealit/dealit/domain/auction/entity/AuctionDraft.java
+++ b/src/main/java/com/dealit/dealit/domain/auction/entity/AuctionDraft.java
@@ -66,8 +66,8 @@ public class AuctionDraft extends BaseEntity {
 	@Column(name = "auction_end_at")
 	private OffsetDateTime auctionEndAt;
 
-	@Column(name = "auction_duration_days")
-	private Integer auctionDurationDays;
+	@Column(name = "auction_duration_days", precision = 20, scale = 16)
+	private BigDecimal auctionDurationDays;
 
 	@Column(name = "location", length = 100)
 	private String location;
@@ -90,7 +90,7 @@ public class AuctionDraft extends BaseEntity {
 		BigDecimal minimumBidAmount,
 		OffsetDateTime auctionStartAt,
 		OffsetDateTime auctionEndAt,
-		Integer auctionDurationDays,
+		BigDecimal auctionDurationDays,
 		String location,
 		String payloadJson,
 		OffsetDateTime savedAt
@@ -122,7 +122,7 @@ public class AuctionDraft extends BaseEntity {
 		BigDecimal minimumBidAmount,
 		OffsetDateTime auctionStartAt,
 		OffsetDateTime auctionEndAt,
-		Integer auctionDurationDays,
+		BigDecimal auctionDurationDays,
 		String location,
 		String payloadJson,
 		OffsetDateTime savedAt
@@ -156,7 +156,7 @@ public class AuctionDraft extends BaseEntity {
 		BigDecimal minimumBidAmount,
 		OffsetDateTime auctionStartAt,
 		OffsetDateTime auctionEndAt,
-		Integer auctionDurationDays,
+		BigDecimal auctionDurationDays,
 		String location,
 		String payloadJson,
 		OffsetDateTime savedAt

--- a/src/main/java/com/dealit/dealit/domain/auction/entity/Bid.java
+++ b/src/main/java/com/dealit/dealit/domain/auction/entity/Bid.java
@@ -1,0 +1,54 @@
+package com.dealit.dealit.domain.auction.entity;
+
+import com.dealit.dealit.global.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.SequenceGenerator;
+import jakarta.persistence.Table;
+import java.math.BigDecimal;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "bid")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SequenceGenerator(
+	name = "bid_seq_generator",
+	sequenceName = "bid_seq",
+	allocationSize = 1
+)
+public class Bid extends BaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "bid_seq_generator")
+	@Column(name = "bid_id")
+	private Long bidId;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "auction_id", nullable = false)
+	private Auction auction;
+
+	@Column(name = "bidder_id", nullable = false)
+	private Long bidderId;
+
+	@Column(name = "bid_price", nullable = false, precision = 15, scale = 2)
+	private BigDecimal bidPrice;
+
+	private Bid(Auction auction, Long bidderId, BigDecimal bidPrice) {
+		this.auction = auction;
+		this.bidderId = bidderId;
+		this.bidPrice = bidPrice;
+	}
+
+	public static Bid create(Auction auction, Long bidderId, BigDecimal bidPrice) {
+		return new Bid(auction, bidderId, bidPrice);
+	}
+}

--- a/src/main/java/com/dealit/dealit/domain/auction/event/AuctionEventPublisher.java
+++ b/src/main/java/com/dealit/dealit/domain/auction/event/AuctionEventPublisher.java
@@ -1,0 +1,59 @@
+package com.dealit.dealit.domain.auction.event;
+
+import com.dealit.dealit.domain.auction.AuctionStatus;
+import com.dealit.dealit.domain.auction.dto.AuctionEventPayload;
+import com.dealit.dealit.global.event.service.EventStreamService;
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class AuctionEventPublisher {
+
+	private final EventStreamService eventStreamService;
+
+	public void publishBidUpdated(Long auctionId, BigDecimal currentPrice, Long bidderId, OffsetDateTime serverTime) {
+		eventStreamService.publishRemote(
+			bidderId,
+			"BID_UPDATED",
+			new AuctionEventPayload.BidUpdated(auctionId, currentPrice, bidderId, serverTime)
+		);
+	}
+
+	public void publishOutbid(
+		Long auctionId,
+		Long previousBidderId,
+		Long newBidderId,
+		BigDecimal currentPrice,
+		OffsetDateTime serverTime
+	) {
+		if (previousBidderId == null) {
+			return;
+		}
+		eventStreamService.publishRemote(
+			previousBidderId,
+			"OUTBID",
+			new AuctionEventPayload.Outbid(auctionId, previousBidderId, newBidderId, currentPrice, serverTime)
+		);
+	}
+
+	public void publishAuctionEnded(
+		Long receiverId,
+		Long auctionId,
+		Long winnerId,
+		BigDecimal finalPrice,
+		AuctionStatus status,
+		OffsetDateTime serverTime
+	) {
+		if (receiverId == null) {
+			return;
+		}
+		eventStreamService.publishRemote(
+			receiverId,
+			"AUCTION_ENDED",
+			new AuctionEventPayload.AuctionEnded(auctionId, winnerId, finalPrice, status, serverTime)
+		);
+	}
+}

--- a/src/main/java/com/dealit/dealit/domain/auction/exception/AuctionAlreadyBiddedException.java
+++ b/src/main/java/com/dealit/dealit/domain/auction/exception/AuctionAlreadyBiddedException.java
@@ -1,0 +1,14 @@
+package com.dealit.dealit.domain.auction.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class AuctionAlreadyBiddedException extends AuctionException {
+
+	public AuctionAlreadyBiddedException() {
+		super(
+			"AUCTION_ALREADY_BIDDED",
+			"이미 입찰이 발생한 경매 상품은 수정하거나 삭제할 수 없습니다.",
+			HttpStatus.CONFLICT
+		);
+	}
+}

--- a/src/main/java/com/dealit/dealit/domain/auction/exception/AuctionNotFoundException.java
+++ b/src/main/java/com/dealit/dealit/domain/auction/exception/AuctionNotFoundException.java
@@ -1,0 +1,10 @@
+package com.dealit.dealit.domain.auction.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class AuctionNotFoundException extends AuctionException {
+
+	public AuctionNotFoundException(String message) {
+		super("AUCTION_NOT_FOUND", message, HttpStatus.NOT_FOUND);
+	}
+}

--- a/src/main/java/com/dealit/dealit/domain/auction/redis/AuctionRedisService.java
+++ b/src/main/java/com/dealit/dealit/domain/auction/redis/AuctionRedisService.java
@@ -1,0 +1,155 @@
+package com.dealit.dealit.domain.auction.redis;
+
+import com.dealit.dealit.domain.auction.entity.Auction;
+import java.math.BigDecimal;
+import java.time.Clock;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataAccessException;
+import org.springframework.data.redis.RedisConnectionFailureException;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.script.DefaultRedisScript;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class AuctionRedisService {
+
+	public static final String ENDING_KEY = "auction:ending";
+
+	private static final DefaultRedisScript<String> BID_SCRIPT = new DefaultRedisScript<>("""
+		local currentPrice = tonumber(redis.call('HGET', KEYS[1], 'currentPrice'))
+		local minimumBidAmount = tonumber(redis.call('HGET', KEYS[1], 'minimumBidAmount'))
+		local endsAt = tonumber(redis.call('HGET', KEYS[1], 'endsAt'))
+		local bidPrice = tonumber(ARGV[1])
+		local bidderId = ARGV[2]
+		local now = tonumber(ARGV[3])
+
+		if currentPrice == nil or endsAt == nil then
+		    return 'AUCTION_ENDED'
+		end
+
+		if now >= endsAt then
+		    return 'AUCTION_ENDED'
+		end
+
+		if minimumBidAmount == nil then
+		    minimumBidAmount = 0
+		end
+
+		if minimumBidAmount <= 0 and bidPrice <= currentPrice then
+		    return 'BID_TOO_LOW'
+		end
+
+		if minimumBidAmount > 0 and bidPrice < currentPrice + minimumBidAmount then
+		    return 'BID_TOO_LOW'
+		end
+
+		local previousBidderId = redis.call('HGET', KEYS[1], 'highestBidderId')
+
+		redis.call('HSET', KEYS[1],
+		    'currentPrice', bidPrice,
+		    'highestBidderId', bidderId
+		)
+
+		if previousBidderId == false then
+		    previousBidderId = ''
+		end
+
+		return 'SUCCESS:' .. previousBidderId
+		""", String.class);
+
+	private final StringRedisTemplate stringRedisTemplate;
+	private final Clock clock;
+
+	public void initialize(Auction auction) {
+		String stateKey = stateKey(auction.getAuctionId());
+		long endsAtEpochMillis = auction.getEndsAt().toInstant().toEpochMilli();
+
+		try {
+			stringRedisTemplate.opsForHash().putAll(
+				stateKey,
+				Map.of(
+					"currentPrice", auction.getCurrentPrice().toPlainString(),
+					"minimumBidAmount", auction.getMinimumBidAmount().toPlainString(),
+					"highestBidderId", "",
+					"endsAt", Long.toString(endsAtEpochMillis)
+				)
+			);
+			stringRedisTemplate.opsForZSet().add(ENDING_KEY, auction.getAuctionId().toString(), endsAtEpochMillis);
+		} catch (RedisConnectionFailureException exception) {
+			// Local/test profiles may run without Redis; bid processing still requires Redis availability.
+		}
+	}
+
+	public BidScriptResult bid(Long auctionId, BigDecimal bidPrice, Long bidderId) {
+		String result = stringRedisTemplate.execute(
+			BID_SCRIPT,
+			List.of(stateKey(auctionId)),
+			bidPrice.toPlainString(),
+			bidderId.toString(),
+			Long.toString(clock.millis())
+		);
+		if (result == null) {
+			return new BidScriptResult(BidScriptStatus.AUCTION_ENDED, null);
+		}
+		if (result.startsWith("SUCCESS:")) {
+			String previousBidderId = result.substring("SUCCESS:".length());
+			return new BidScriptResult(
+				BidScriptStatus.SUCCESS,
+				previousBidderId.isBlank() ? null : Long.valueOf(previousBidderId)
+			);
+		}
+		return new BidScriptResult(BidScriptStatus.valueOf(result), null);
+	}
+
+	public Set<String> findEndingAuctionIds(long nowEpochMillis) {
+		return stringRedisTemplate.opsForZSet().rangeByScore(ENDING_KEY, 0, nowEpochMillis);
+	}
+
+	public AuctionState getState(Long auctionId) {
+		Map<Object, Object> state = stringRedisTemplate.opsForHash().entries(stateKey(auctionId));
+		Object currentPrice = state.get("currentPrice");
+		Object minimumBidAmount = state.get("minimumBidAmount");
+		Object highestBidderId = state.get("highestBidderId");
+		return new AuctionState(
+			currentPrice == null ? null : new BigDecimal(currentPrice.toString()),
+			minimumBidAmount == null ? null : new BigDecimal(minimumBidAmount.toString()),
+			highestBidderId == null || highestBidderId.toString().isBlank() ? null : Long.valueOf(highestBidderId.toString())
+		);
+	}
+
+	public void removeEnding(Long auctionId) {
+		stringRedisTemplate.opsForZSet().remove(ENDING_KEY, auctionId.toString());
+	}
+
+	public void deleteState(Long auctionId) {
+		stringRedisTemplate.delete(stateKey(auctionId));
+	}
+
+	public void refreshEnding(Auction auction) {
+		try {
+			initialize(auction);
+		} catch (DataAccessException exception) {
+			// Redis state is opportunistic for create/update paths; bid and end paths surface Redis failures.
+		}
+	}
+
+	private String stateKey(Long auctionId) {
+		return "auction:%d:state".formatted(auctionId);
+	}
+
+	public record BidScriptResult(BidScriptStatus status, Long previousBidderId) {
+	}
+
+	public record AuctionState(BigDecimal currentPrice, BigDecimal minimumBidAmount, Long highestBidderId) {
+	}
+
+	public enum BidScriptStatus {
+		SUCCESS,
+		AUCTION_ENDED,
+		BID_TOO_LOW
+	}
+}

--- a/src/main/java/com/dealit/dealit/domain/auction/redis/AuctionRedisService.java
+++ b/src/main/java/com/dealit/dealit/domain/auction/redis/AuctionRedisService.java
@@ -125,6 +125,10 @@ public class AuctionRedisService {
 		stringRedisTemplate.opsForZSet().remove(ENDING_KEY, auctionId.toString());
 	}
 
+	public void removeEndingValue(String auctionId) {
+		stringRedisTemplate.opsForZSet().remove(ENDING_KEY, auctionId);
+	}
+
 	public void deleteState(Long auctionId) {
 		stringRedisTemplate.delete(stateKey(auctionId));
 	}

--- a/src/main/java/com/dealit/dealit/domain/auction/repository/AuctionRepository.java
+++ b/src/main/java/com/dealit/dealit/domain/auction/repository/AuctionRepository.java
@@ -26,4 +26,10 @@ public interface AuctionRepository extends JpaRepository<Auction, Long> {
 
 	@EntityGraph(attributePaths = {"product", "product.images"})
 	Optional<Auction> findByProductProductIdAndDeletedAtIsNullAndProductDeletedAtIsNull(Long productId);
+
+	@EntityGraph(attributePaths = {"product"})
+	Optional<Auction> findByAuctionIdAndDeletedAtIsNullAndProductDeletedAtIsNull(Long auctionId);
+
+	@EntityGraph(attributePaths = {"product", "product.images"})
+	Optional<Auction> findDetailByAuctionIdAndDeletedAtIsNullAndProductDeletedAtIsNull(Long auctionId);
 }

--- a/src/main/java/com/dealit/dealit/domain/auction/repository/BidRepository.java
+++ b/src/main/java/com/dealit/dealit/domain/auction/repository/BidRepository.java
@@ -1,0 +1,15 @@
+package com.dealit.dealit.domain.auction.repository;
+
+import com.dealit.dealit.domain.auction.entity.Bid;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+public interface BidRepository extends JpaRepository<Bid, Long> {
+
+	boolean existsByAuctionAuctionId(Long auctionId);
+
+	long countByAuctionAuctionId(Long auctionId);
+
+	@Query("select count(distinct b.bidderId) from Bid b where b.auction.auctionId = :auctionId")
+	long countDistinctBidderIdByAuctionId(Long auctionId);
+}

--- a/src/main/java/com/dealit/dealit/domain/auction/scheduler/AuctionEndingScheduler.java
+++ b/src/main/java/com/dealit/dealit/domain/auction/scheduler/AuctionEndingScheduler.java
@@ -1,0 +1,38 @@
+package com.dealit.dealit.domain.auction.scheduler;
+
+import com.dealit.dealit.domain.auction.redis.AuctionRedisService;
+import com.dealit.dealit.domain.auction.service.AuctionBidService;
+import java.time.Clock;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.RedisConnectionFailureException;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class AuctionEndingScheduler {
+
+	private final AuctionRedisService auctionRedisService;
+	private final AuctionBidService auctionBidService;
+	private final Clock clock;
+
+	@Scheduled(fixedDelayString = "${app.auction.ending-scheduler-delay-ms:3000}")
+	public void endExpiredAuctions() {
+		Set<String> auctionIds;
+		try {
+			auctionIds = auctionRedisService.findEndingAuctionIds(clock.millis());
+		} catch (RedisConnectionFailureException exception) {
+			return;
+		}
+		if (auctionIds == null || auctionIds.isEmpty()) {
+			return;
+		}
+
+		for (String auctionId : auctionIds) {
+			Long parsedAuctionId = Long.valueOf(auctionId);
+			auctionBidService.endAuction(parsedAuctionId);
+			auctionRedisService.removeEnding(parsedAuctionId);
+		}
+	}
+}

--- a/src/main/java/com/dealit/dealit/domain/auction/scheduler/AuctionEndingScheduler.java
+++ b/src/main/java/com/dealit/dealit/domain/auction/scheduler/AuctionEndingScheduler.java
@@ -1,5 +1,6 @@
 package com.dealit.dealit.domain.auction.scheduler;
 
+import com.dealit.dealit.domain.auction.exception.AuctionNotFoundException;
 import com.dealit.dealit.domain.auction.redis.AuctionRedisService;
 import com.dealit.dealit.domain.auction.service.AuctionBidService;
 import java.time.Clock;
@@ -30,9 +31,21 @@ public class AuctionEndingScheduler {
 		}
 
 		for (String auctionId : auctionIds) {
-			Long parsedAuctionId = Long.valueOf(auctionId);
-			auctionBidService.endAuction(parsedAuctionId);
-			auctionRedisService.removeEnding(parsedAuctionId);
+			Long parsedAuctionId;
+			try {
+				parsedAuctionId = Long.valueOf(auctionId);
+			} catch (NumberFormatException exception) {
+				auctionRedisService.removeEndingValue(auctionId);
+				continue;
+			}
+
+			try {
+				auctionBidService.endAuction(parsedAuctionId);
+			} catch (AuctionNotFoundException exception) {
+				// DB reset or deleted auctions can leave stale members in Redis.
+			} finally {
+				auctionRedisService.removeEnding(parsedAuctionId);
+			}
 		}
 	}
 }

--- a/src/main/java/com/dealit/dealit/domain/auction/service/AuctionBidService.java
+++ b/src/main/java/com/dealit/dealit/domain/auction/service/AuctionBidService.java
@@ -93,6 +93,9 @@ public class AuctionBidService {
 		if (!auction.isOngoing()) {
 			throw new InvalidAuctionRequestException("이미 종료된 경매입니다.");
 		}
+		if (!auction.getEndsAt().isAfter(serverTime())) {
+			throw new InvalidAuctionRequestException("이미 종료된 경매입니다.");
+		}
 		if (bidPrice.compareTo(auction.getCurrentPrice().add(auction.getMinimumBidAmount())) < 0) {
 			throw new InvalidAuctionRequestException("최소 입찰 금액을 충족해야 합니다.");
 		}
@@ -123,6 +126,8 @@ public class AuctionBidService {
 		AuctionState state = auctionRedisService.getState(auctionId);
 		if (state.highestBidderId() == null) {
 			auction.completeWithoutBid();
+			auction.getProduct().markEnded();
+			auction.softDelete();
 			auctionRedisService.removeEnding(auctionId);
 			auctionRedisService.deleteState(auctionId);
 			auctionEventPublisher.publishAuctionEnded(
@@ -137,6 +142,7 @@ public class AuctionBidService {
 		}
 
 		auction.completeWithWinner(state.highestBidderId(), state.currentPrice());
+		auction.getProduct().markSold();
 		auctionRedisService.removeEnding(auctionId);
 		auctionRedisService.deleteState(auctionId);
 		auctionEventPublisher.publishAuctionEnded(

--- a/src/main/java/com/dealit/dealit/domain/auction/service/AuctionBidService.java
+++ b/src/main/java/com/dealit/dealit/domain/auction/service/AuctionBidService.java
@@ -1,0 +1,208 @@
+package com.dealit.dealit.domain.auction.service;
+
+import com.dealit.dealit.domain.auction.AuctionStatus;
+import com.dealit.dealit.domain.auction.dto.AuctionDetailResponse;
+import com.dealit.dealit.domain.auction.dto.AuctionDetailResponse.ImageResponse;
+import com.dealit.dealit.domain.auction.dto.AuctionDetailResponse.SellerResponse;
+import com.dealit.dealit.domain.auction.dto.BidResponse;
+import com.dealit.dealit.domain.auction.entity.Auction;
+import com.dealit.dealit.domain.auction.entity.Category;
+import com.dealit.dealit.domain.auction.entity.Bid;
+import com.dealit.dealit.domain.auction.event.AuctionEventPublisher;
+import com.dealit.dealit.domain.auction.exception.AuctionNotFoundException;
+import com.dealit.dealit.domain.auction.exception.InvalidAuctionRequestException;
+import com.dealit.dealit.domain.auction.redis.AuctionRedisService;
+import com.dealit.dealit.domain.auction.redis.AuctionRedisService.AuctionState;
+import com.dealit.dealit.domain.auction.redis.AuctionRedisService.BidScriptResult;
+import com.dealit.dealit.domain.auction.repository.AuctionRepository;
+import com.dealit.dealit.domain.auction.repository.BidRepository;
+import com.dealit.dealit.domain.auction.repository.CategoryRepository;
+import com.dealit.dealit.domain.member.entity.Member;
+import com.dealit.dealit.domain.member.repository.MemberRepository;
+import com.dealit.dealit.domain.product.entity.Product;
+import com.dealit.dealit.domain.product.entity.ProductImage;
+import com.dealit.dealit.global.service.ImageUrlService;
+import java.math.BigDecimal;
+import java.time.Clock;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.Comparator;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.RedisConnectionFailureException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AuctionBidService {
+
+	private final AuctionRepository auctionRepository;
+	private final BidRepository bidRepository;
+	private final CategoryRepository categoryRepository;
+	private final MemberRepository memberRepository;
+	private final AuctionRedisService auctionRedisService;
+	private final AuctionEventPublisher auctionEventPublisher;
+	private final ImageUrlService imageUrlService;
+	private final Clock clock;
+
+	public AuctionDetailResponse getAuction(Long auctionId) {
+		Auction auction = loadAuctionDetail(auctionId);
+		Product product = auction.getProduct();
+		BigDecimal currentPrice = auction.getCurrentPrice();
+		if (auction.isOngoing()) {
+			try {
+				AuctionState state = auctionRedisService.getState(auctionId);
+				if (state.currentPrice() != null) {
+					currentPrice = state.currentPrice();
+				}
+			} catch (RedisConnectionFailureException exception) {
+				currentPrice = auction.getCurrentPrice();
+			}
+		}
+		currentPrice = resolveDisplayCurrentPrice(auction, currentPrice);
+		Category category = categoryRepository.findById(product.getCategoryId()).orElse(null);
+		Member seller = memberRepository.findByMemberIdAndDeletedAtIsNull(product.getMemberId()).orElse(null);
+		return new AuctionDetailResponse(
+			auction.getAuctionId(),
+			product.getProductId(),
+			product.getName(),
+			product.getDescription(),
+			product.getCategoryId(),
+			category == null ? "" : category.getNameKo(),
+			product.getLocation(),
+			toImageResponses(product),
+			toSellerResponse(seller),
+			auction.getStartPrice(),
+			currentPrice,
+			auction.getMinimumBidAmount(),
+			currentPrice.add(auction.getMinimumBidAmount()),
+			(int) bidRepository.countByAuctionAuctionId(auction.getAuctionId()),
+			(int) bidRepository.countDistinctBidderIdByAuctionId(auction.getAuctionId()),
+			auction.getAuctionStartAt(),
+			auction.getEndsAt(),
+			serverTime(),
+			auction.getStatus()
+		);
+	}
+
+	@Transactional
+	public BidResponse bid(Long auctionId, Long bidderId, BigDecimal bidPrice) {
+		Auction auction = loadAuction(auctionId);
+		if (!auction.isOngoing()) {
+			throw new InvalidAuctionRequestException("이미 종료된 경매입니다.");
+		}
+		if (bidPrice.compareTo(auction.getCurrentPrice().add(auction.getMinimumBidAmount())) < 0) {
+			throw new InvalidAuctionRequestException("최소 입찰 금액을 충족해야 합니다.");
+		}
+
+		BidScriptResult result = auctionRedisService.bid(auctionId, bidPrice, bidderId);
+		switch (result.status()) {
+			case AUCTION_ENDED -> throw new InvalidAuctionRequestException("이미 종료된 경매입니다.");
+			case BID_TOO_LOW -> throw new InvalidAuctionRequestException("현재가보다 높은 금액만 입찰할 수 있습니다.");
+			case SUCCESS -> {
+				bidRepository.save(Bid.create(auction, bidderId, bidPrice));
+				auction.updateCurrentPrice(bidPrice);
+				OffsetDateTime serverTime = serverTime();
+				auctionEventPublisher.publishBidUpdated(auctionId, bidPrice, bidderId, serverTime);
+				auctionEventPublisher.publishOutbid(auctionId, result.previousBidderId(), bidderId, bidPrice, serverTime);
+				return new BidResponse(auctionId, bidPrice, bidderId, serverTime);
+			}
+		}
+		throw new InvalidAuctionRequestException("입찰을 처리할 수 없습니다.");
+	}
+
+	@Transactional
+	public void endAuction(Long auctionId) {
+		Auction auction = loadAuction(auctionId);
+		if (!auction.isOngoing()) {
+			return;
+		}
+
+		AuctionState state = auctionRedisService.getState(auctionId);
+		if (state.highestBidderId() == null) {
+			auction.completeWithoutBid();
+			auctionRedisService.removeEnding(auctionId);
+			auctionRedisService.deleteState(auctionId);
+			auctionEventPublisher.publishAuctionEnded(
+				auction.getProduct().getMemberId(),
+				auctionId,
+				null,
+				null,
+				AuctionStatus.NO_BID,
+				serverTime()
+			);
+			return;
+		}
+
+		auction.completeWithWinner(state.highestBidderId(), state.currentPrice());
+		auctionRedisService.removeEnding(auctionId);
+		auctionRedisService.deleteState(auctionId);
+		auctionEventPublisher.publishAuctionEnded(
+			auction.getProduct().getMemberId(),
+			auctionId,
+			state.highestBidderId(),
+			state.currentPrice(),
+			AuctionStatus.SUCCESSFUL_BID,
+			serverTime()
+		);
+		if (!auction.getProduct().getMemberId().equals(state.highestBidderId())) {
+			auctionEventPublisher.publishAuctionEnded(
+				state.highestBidderId(),
+				auctionId,
+				state.highestBidderId(),
+				state.currentPrice(),
+				AuctionStatus.SUCCESSFUL_BID,
+				serverTime()
+			);
+		}
+	}
+
+	private Auction loadAuction(Long auctionId) {
+		return auctionRepository.findByAuctionIdAndDeletedAtIsNullAndProductDeletedAtIsNull(auctionId)
+			.orElseThrow(() -> new AuctionNotFoundException("존재하지 않는 경매입니다."));
+	}
+
+	private Auction loadAuctionDetail(Long auctionId) {
+		return auctionRepository.findDetailByAuctionIdAndDeletedAtIsNullAndProductDeletedAtIsNull(auctionId)
+			.orElseThrow(() -> new AuctionNotFoundException("존재하지 않는 경매입니다."));
+	}
+
+	private List<ImageResponse> toImageResponses(Product product) {
+		return product.getImages().stream()
+			.filter(image -> image.getDeletedAt() == null)
+			.filter(image -> image.getImageUrl() != null && !image.getImageUrl().isBlank())
+			.sorted(Comparator.comparing(
+				ProductImage::getSortOrder,
+				Comparator.nullsLast(Integer::compareTo)
+			))
+			.map(image -> new ImageResponse(
+				image.getImageId(),
+				imageUrlService.toPublicUrl(image.getImageUrl()),
+				image.getSortOrder()
+			))
+			.toList();
+	}
+
+	private SellerResponse toSellerResponse(Member seller) {
+		if (seller == null) {
+			return null;
+		}
+		String profileImageUrl = seller.getProfileImage() == null || seller.getProfileImage().isBlank()
+			? null
+			: imageUrlService.toPublicUrl(seller.getProfileImage());
+		return new SellerResponse(seller.getMemberId(), seller.getNickname(), profileImageUrl);
+	}
+
+	private BigDecimal resolveDisplayCurrentPrice(Auction auction, BigDecimal currentPrice) {
+		if (currentPrice == null || currentPrice.signum() <= 0) {
+			return auction.getStartPrice();
+		}
+		return currentPrice;
+	}
+
+	private OffsetDateTime serverTime() {
+		return OffsetDateTime.now(clock).withOffsetSameInstant(ZoneOffset.UTC);
+	}
+}

--- a/src/main/java/com/dealit/dealit/domain/auction/service/AuctionService.java
+++ b/src/main/java/com/dealit/dealit/domain/auction/service/AuctionService.java
@@ -24,12 +24,14 @@ import com.dealit.dealit.domain.auction.entity.AuctionDraft;
 import com.dealit.dealit.domain.auction.entity.Category;
 import com.dealit.dealit.domain.auth.exception.InvalidCredentialsException;
 import com.dealit.dealit.domain.auction.exception.AuctionAccessDeniedException;
-import com.dealit.dealit.domain.auction.exception.AuctionConflictException;
+import com.dealit.dealit.domain.auction.exception.AuctionAlreadyBiddedException;
 import com.dealit.dealit.domain.auction.exception.AuctionImageNotFoundException;
 import com.dealit.dealit.domain.auction.exception.AuctionProductNotFoundException;
 import com.dealit.dealit.domain.auction.exception.InvalidAuctionRequestException;
+import com.dealit.dealit.domain.auction.redis.AuctionRedisService;
 import com.dealit.dealit.domain.auction.repository.AuctionRepository;
 import com.dealit.dealit.domain.auction.repository.AuctionDraftRepository;
+import com.dealit.dealit.domain.auction.repository.BidRepository;
 import com.dealit.dealit.domain.auction.repository.CategoryRepository;
 import com.dealit.dealit.domain.member.entity.Member;
 import com.dealit.dealit.domain.member.repository.MemberRepository;
@@ -51,6 +53,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
+import java.time.Clock;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
@@ -71,6 +74,7 @@ public class AuctionService {
 
 	private final AuctionRepository auctionRepository;
 	private final AuctionDraftRepository auctionDraftRepository;
+	private final BidRepository bidRepository;
 	private final CategoryRepository categoryRepository;
 	private final MemberRepository memberRepository;
 	private final ProductRepository productRepository;
@@ -78,6 +82,8 @@ public class AuctionService {
 	private final AuctionImageStorage auctionImageStorage;
 	private final ImageUrlService imageUrlService;
 	private final ObjectMapper objectMapper;
+	private final AuctionRedisService auctionRedisService;
+	private final Clock clock;
 
 	public MySellingAuctionListResponse getMySellingAuctionProducts(Long memberId, int page, int size) {
 		loadActiveMember(memberId);
@@ -85,7 +91,7 @@ public class AuctionService {
 		int normalizedSize = Math.min(Math.max(size, 1), 100);
 		Page<Auction> auctionPage = auctionRepository.findAllByProductMemberIdAndStatusAndDeletedAtIsNullAndProductDeletedAtIsNull(
 			memberId,
-			AuctionStatus.AUCTION_LIVE,
+			AuctionStatus.ONGOING,
 			PageRequest.of(normalizedPage, normalizedSize, Sort.by(Sort.Direction.DESC, "createdAt"))
 		);
 
@@ -142,6 +148,7 @@ public class AuctionService {
 			resolveThumbnailUrl(product),
 			auction.getStatus(),
 			auction.getStartPrice(),
+			auction.getMinimumBidAmount(),
 			resolveCurrentPrice(auction),
 			resolveMinimumNextBidPrice(auction),
 			bidCount,
@@ -182,6 +189,7 @@ public class AuctionService {
 			product.getLocation(),
 			images,
 			auction.getStartPrice(),
+			auction.getMinimumBidAmount(),
 			resolveAuctionDurationDays(auction),
 			auction.getStatus(),
 			bidCount,
@@ -195,7 +203,7 @@ public class AuctionService {
 		loadActiveMember(memberId);
 		Auction auction = loadOwnedAuction(memberId, auctionId);
 		if (getBidCount(auction) > 0) {
-			throw new AuctionConflictException("입찰자가 있는 경매는 삭제할 수 없습니다.");
+			throw new AuctionAlreadyBiddedException();
 		}
 		for (ProductImage image : auction.getProduct().getImages()) {
 			auctionImageStorage.delete(image.getImageUrl());
@@ -211,28 +219,30 @@ public class AuctionService {
 		Auction auction = loadOwnedAuction(memberId, auctionId);
 		Product product = auction.getProduct();
 		if (getBidCount(auction) > 0) {
-			throw new AuctionConflictException("입찰자가 있는 경매는 수정할 수 없습니다.");
+			throw new AuctionAlreadyBiddedException();
 		}
 
 		validateUpdateAuctionRequest(request);
 		validateCategorySelection(request.categoryId());
 
 		OffsetDateTime startAt = auction.getAuctionStartAt() == null
-			? OffsetDateTime.now(ZoneOffset.UTC)
+			? OffsetDateTime.now(clock)
 			: auction.getAuctionStartAt();
 		OffsetDateTime endAt = startAt.plusDays(request.auctionDurationDays());
-		if (!endAt.isAfter(OffsetDateTime.now(ZoneOffset.UTC))) {
+		if (!endAt.isAfter(OffsetDateTime.now(clock))) {
 			throw new InvalidAuctionRequestException("경매 종료 시각은 현재 시각 이후여야 합니다.");
 		}
+		BigDecimal minimumBidAmount = resolveMinimumBidAmount(request.startPrice(), request.minimumBidAmount());
 
 		product.updateEditableDetails(
 			request.name().trim(),
 			request.description().trim(),
 			request.categoryId(),
 			request.startPrice(),
-			request.location().trim()
+				request.location().trim()
 		);
-		auction.updateEditableDetails(request.startPrice(), endAt);
+		auction.updateEditableDetails(request.startPrice(), minimumBidAmount, endAt);
+		auctionRedisService.refreshEnding(auction);
 
 		replaceAuctionImages(product, request.images());
 
@@ -310,19 +320,23 @@ public class AuctionService {
 	}
 
 	private BigDecimal resolveCurrentPrice(Auction auction) {
-		return auction.getCurrentPrice();
+		BigDecimal currentPrice = auction.getCurrentPrice();
+		if (currentPrice == null || currentPrice.signum() <= 0) {
+			return auction.getStartPrice();
+		}
+		return currentPrice;
 	}
 
 	private BigDecimal resolveMinimumNextBidPrice(Auction auction) {
-		return resolveCurrentPrice(auction);
+		return resolveCurrentPrice(auction).add(auction.getMinimumBidAmount());
 	}
 
 	private int getBidCount(Auction auction) {
-		return 0;
+		return (int) bidRepository.countByAuctionAuctionId(auction.getAuctionId());
 	}
 
 	private int getBidderCount(Auction auction) {
-		return 0;
+		return (int) bidRepository.countDistinctBidderIdByAuctionId(auction.getAuctionId());
 	}
 
 	private long resolveAuctionDurationDays(Auction auction) {
@@ -360,7 +374,7 @@ public class AuctionService {
 				.findByProductProductIdAndDeletedAtIsNullAndProductDeletedAtIsNull(image.getProduct().getProductId())
 				.orElseThrow(() -> new InvalidAuctionRequestException("경매 상품 이미지가 아닙니다."));
 			if (getBidCount(auction) > 0) {
-				throw new AuctionConflictException("입찰자가 있는 경매는 수정할 수 없습니다.");
+				throw new AuctionAlreadyBiddedException();
 			}
 			auction.getProduct().removeImage(image);
 		}
@@ -387,6 +401,7 @@ public class AuctionService {
 				member.getMemberId(),
 				request.price(),
 				request.startPrice(),
+				request.minimumBidAmount(),
 				null,
 				null,
 				request.auctionDurationDays(),
@@ -404,6 +419,7 @@ public class AuctionService {
 							member.getMemberId(),
 							request.price(),
 							request.startPrice(),
+							request.minimumBidAmount(),
 							null,
 							null,
 							request.auctionDurationDays(),
@@ -421,6 +437,7 @@ public class AuctionService {
 						member.getMemberId(),
 						request.price(),
 						request.startPrice(),
+						request.minimumBidAmount(),
 						null,
 						null,
 						request.auctionDurationDays(),
@@ -486,8 +503,9 @@ public class AuctionService {
 		validateRequestBySaleType(request);
 		validateCategorySelection(request.categoryId());
 		Member member = loadActiveMember(memberId);
-		OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+		OffsetDateTime now = OffsetDateTime.now(clock);
 		AuctionPeriod auctionPeriod = resolveAuctionPeriod(request, now);
+		BigDecimal minimumBidAmount = resolveMinimumBidAmount(request.startPrice(), request.minimumBidAmount());
 
 		Product product = productRepository.save(
 			Product.create(
@@ -508,6 +526,7 @@ public class AuctionService {
 			Auction.create(
 				product,
 				request.startPrice(),
+				minimumBidAmount,
 				auctionPeriod.startAt(),
 				auctionPeriod.endAt(),
 				determineStatus(
@@ -516,6 +535,7 @@ public class AuctionService {
 				)
 			)
 		);
+		auctionRedisService.initialize(auction);
 
 		Map<Long, ProductImage> imagesById = loadRequestedProductImages(member.getMemberId(), request.images());
 		for (ProductImagePayload imagePayload : request.images()) {
@@ -625,13 +645,14 @@ public class AuctionService {
 		if (request.startPrice() == null) {
 			throw new InvalidAuctionRequestException("경매 판매에서는 시작가가 필수입니다.");
 		}
-		if (request.auctionDurationDays() == null) {
-			throw new InvalidAuctionRequestException("경매 판매에서는 진행 기간이 필수입니다.");
+		if (request.auctionDurationDays() == null && request.endsAt() == null) {
+			throw new InvalidAuctionRequestException("경매 판매에서는 진행 기간 또는 종료 시각이 필수입니다.");
 		}
 		if (request.startPrice().signum() <= 0) {
 			throw new InvalidAuctionRequestException("시작가는 0보다 커야 합니다.");
 		}
-		if (request.auctionDurationDays() <= 0) {
+		resolveMinimumBidAmount(request.startPrice(), request.minimumBidAmount());
+		if (request.auctionDurationDays() != null && request.auctionDurationDays() <= 0) {
 			throw new InvalidAuctionRequestException("경매 진행 기간은 0보다 커야 합니다.");
 		}
 	}
@@ -640,14 +661,25 @@ public class AuctionService {
 		if (request.startPrice().signum() <= 0) {
 			throw new InvalidAuctionRequestException("시작가는 0보다 커야 합니다.");
 		}
+		resolveMinimumBidAmount(request.startPrice(), request.minimumBidAmount());
 		if (request.auctionDurationDays() <= 0) {
 			throw new InvalidAuctionRequestException("경매 진행 기간은 0보다 커야 합니다.");
 		}
 	}
 
+	private BigDecimal resolveMinimumBidAmount(BigDecimal startPrice, BigDecimal requestedMinimumBidAmount) {
+		if (requestedMinimumBidAmount != null) {
+			if (requestedMinimumBidAmount.signum() <= 0) {
+				throw new InvalidAuctionRequestException("최소 입찰 금액은 0보다 커야 합니다.");
+			}
+			return requestedMinimumBidAmount;
+		}
+		return startPrice.multiply(BigDecimal.valueOf(0.01)).setScale(0, RoundingMode.CEILING);
+	}
+
 	private AuctionPeriod resolveAuctionPeriod(CreateAuctionRequest request, OffsetDateTime now) {
 		OffsetDateTime startAt = now;
-		OffsetDateTime endAt = startAt.plusDays(request.auctionDurationDays());
+		OffsetDateTime endAt = request.endsAt() == null ? startAt.plusDays(request.auctionDurationDays()) : request.endsAt();
 		return new AuctionPeriod(startAt, endAt);
 	}
 
@@ -658,7 +690,7 @@ public class AuctionService {
 		if (auctionEndAt != null && auctionEndAt.isBefore(now)) {
 			throw new InvalidAuctionRequestException("경매 종료 시각은 현재 시각 이후여야 합니다.");
 		}
-		return AuctionStatus.AUCTION_LIVE;
+		return AuctionStatus.ONGOING;
 	}
 
 	private String serializeDraft(SaveAuctionDraftRequest request) {
@@ -676,6 +708,7 @@ public class AuctionService {
 		boolean hasCategory = request.categoryId() != null;
 		boolean hasPrice = request.price() != null;
 		boolean hasStartPrice = request.startPrice() != null;
+		boolean hasMinimumBidAmount = request.minimumBidAmount() != null;
 		boolean hasAuctionDurationDays = request.auctionDurationDays() != null;
 		boolean hasImages = request.images() != null && !request.images().isEmpty();
 		boolean hasLocation = normalizeBlank(request.location()) != null;
@@ -687,6 +720,7 @@ public class AuctionService {
 			!hasCategory &&
 			!hasPrice &&
 			!hasStartPrice &&
+			!hasMinimumBidAmount &&
 			!hasAuctionDurationDays &&
 			!hasImages &&
 			!hasLocation

--- a/src/main/java/com/dealit/dealit/domain/auction/service/AuctionService.java
+++ b/src/main/java/com/dealit/dealit/domain/auction/service/AuctionService.java
@@ -645,15 +645,18 @@ public class AuctionService {
 		if (request.startPrice() == null) {
 			throw new InvalidAuctionRequestException("경매 판매에서는 시작가가 필수입니다.");
 		}
-		if (request.auctionDurationDays() == null && request.endsAt() == null) {
+		if (request.auctionDurationDays() == null && request.auctionDurationSeconds() == null && request.endsAt() == null) {
 			throw new InvalidAuctionRequestException("경매 판매에서는 진행 기간 또는 종료 시각이 필수입니다.");
 		}
 		if (request.startPrice().signum() <= 0) {
 			throw new InvalidAuctionRequestException("시작가는 0보다 커야 합니다.");
 		}
 		resolveMinimumBidAmount(request.startPrice(), request.minimumBidAmount());
-		if (request.auctionDurationDays() != null && request.auctionDurationDays() <= 0) {
+		if (request.auctionDurationDays() != null && request.auctionDurationDays().signum() <= 0) {
 			throw new InvalidAuctionRequestException("경매 진행 기간은 0보다 커야 합니다.");
+		}
+		if (request.auctionDurationSeconds() != null && request.auctionDurationSeconds() <= 0) {
+			throw new InvalidAuctionRequestException("경매 진행 기간(초)은 0보다 커야 합니다.");
 		}
 	}
 
@@ -679,8 +682,23 @@ public class AuctionService {
 
 	private AuctionPeriod resolveAuctionPeriod(CreateAuctionRequest request, OffsetDateTime now) {
 		OffsetDateTime startAt = now;
-		OffsetDateTime endAt = request.endsAt() == null ? startAt.plusDays(request.auctionDurationDays()) : request.endsAt();
+		OffsetDateTime endAt;
+		if (request.endsAt() != null) {
+			endAt = request.endsAt();
+		} else if (request.auctionDurationSeconds() != null) {
+			endAt = startAt.plusSeconds(request.auctionDurationSeconds());
+		} else {
+			endAt = startAt.plus(toDurationFromDays(request.auctionDurationDays()));
+		}
 		return new AuctionPeriod(startAt, endAt);
+	}
+
+	private Duration toDurationFromDays(BigDecimal auctionDurationDays) {
+		long millis = auctionDurationDays
+			.multiply(BigDecimal.valueOf(24L * 60L * 60L * 1000L))
+			.setScale(0, RoundingMode.HALF_UP)
+			.longValueExact();
+		return Duration.ofMillis(millis);
 	}
 
 	private AuctionStatus determineStatus(

--- a/src/main/java/com/dealit/dealit/domain/product/entity/Product.java
+++ b/src/main/java/com/dealit/dealit/domain/product/entity/Product.java
@@ -134,6 +134,15 @@ public class Product extends BaseEntity {
 		this.location = location;
 	}
 
+	public void markSold() {
+		this.status = ProductStatus.SOLD;
+	}
+
+	public void markEnded() {
+		this.status = ProductStatus.ENDED;
+		softDelete();
+	}
+
 	public void replaceImages(Collection<ProductImage> nextImages) {
 		List<ProductImage> removedImages = images.stream()
 			.filter(image -> !nextImages.contains(image))

--- a/src/main/java/com/dealit/dealit/global/config/TimeConfig.java
+++ b/src/main/java/com/dealit/dealit/global/config/TimeConfig.java
@@ -1,0 +1,16 @@
+package com.dealit.dealit.global.config;
+
+import java.time.Clock;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+public class TimeConfig {
+
+	@Bean
+	public Clock clock() {
+		return Clock.systemUTC();
+	}
+}

--- a/src/test/java/com/dealit/dealit/domain/auction/AuctionBidServiceTest.java
+++ b/src/test/java/com/dealit/dealit/domain/auction/AuctionBidServiceTest.java
@@ -1,0 +1,248 @@
+package com.dealit.dealit.domain.auction;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.dealit.dealit.domain.auction.dto.BidResponse;
+import com.dealit.dealit.domain.auction.entity.Auction;
+import com.dealit.dealit.domain.auction.entity.Bid;
+import com.dealit.dealit.domain.auction.event.AuctionEventPublisher;
+import com.dealit.dealit.domain.auction.exception.InvalidAuctionRequestException;
+import com.dealit.dealit.domain.auction.redis.AuctionRedisService;
+import com.dealit.dealit.domain.auction.redis.AuctionRedisService.AuctionState;
+import com.dealit.dealit.domain.auction.redis.AuctionRedisService.BidScriptResult;
+import com.dealit.dealit.domain.auction.redis.AuctionRedisService.BidScriptStatus;
+import com.dealit.dealit.domain.auction.repository.AuctionRepository;
+import com.dealit.dealit.domain.auction.repository.BidRepository;
+import com.dealit.dealit.domain.auction.repository.CategoryRepository;
+import com.dealit.dealit.domain.auction.service.AuctionBidService;
+import com.dealit.dealit.domain.member.repository.MemberRepository;
+import com.dealit.dealit.domain.product.ProductSaleType;
+import com.dealit.dealit.domain.product.ProductStatus;
+import com.dealit.dealit.domain.product.entity.Product;
+import com.dealit.dealit.global.service.ImageUrlService;
+import java.math.BigDecimal;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class AuctionBidServiceTest {
+
+	private static final Clock FIXED_CLOCK = Clock.fixed(Instant.parse("2026-05-02T00:00:00Z"), ZoneOffset.UTC);
+
+	private final AuctionRepository auctionRepository = mock(AuctionRepository.class);
+	private final BidRepository bidRepository = mock(BidRepository.class);
+	private final CategoryRepository categoryRepository = mock(CategoryRepository.class);
+	private final MemberRepository memberRepository = mock(MemberRepository.class);
+	private final AuctionRedisService auctionRedisService = mock(AuctionRedisService.class);
+	private final AuctionEventPublisher auctionEventPublisher = mock(AuctionEventPublisher.class);
+	private final ImageUrlService imageUrlService = mock(ImageUrlService.class);
+
+	private final AuctionBidService auctionBidService = new AuctionBidService(
+		auctionRepository,
+		bidRepository,
+		categoryRepository,
+		memberRepository,
+		auctionRedisService,
+		auctionEventPublisher,
+		imageUrlService,
+		FIXED_CLOCK
+	);
+
+	@Test
+	@DisplayName("종료 시 입찰자가 없으면 유찰 상태로 종료한다")
+	void endAuctionCompletesWithoutBidWhenNoHighestBidder() {
+		Long auctionId = 1L;
+		Long sellerId = 10L;
+		Auction auction = auction(sellerId);
+		when(auctionRepository.findByAuctionIdAndDeletedAtIsNullAndProductDeletedAtIsNull(auctionId))
+			.thenReturn(Optional.of(auction));
+		when(auctionRedisService.getState(auctionId))
+			.thenReturn(new AuctionState(new BigDecimal("100000"), new BigDecimal("1000"), null));
+
+		auctionBidService.endAuction(auctionId);
+
+		assertThat(auction.getStatus()).isEqualTo(AuctionStatus.NO_BID);
+		assertThat(auction.getProduct().getStatus()).isEqualTo(ProductStatus.ENDED);
+		assertThat(auction.getDeletedAt()).isNotNull();
+		assertThat(auction.getProduct().getDeletedAt()).isNotNull();
+		assertThat(auction.getWinnerId()).isNull();
+		assertThat(auction.getFinalPrice()).isNull();
+		verify(auctionRedisService).removeEnding(auctionId);
+		verify(auctionRedisService).deleteState(auctionId);
+		verify(auctionEventPublisher).publishAuctionEnded(
+			eq(sellerId),
+			eq(auctionId),
+			eq(null),
+			eq(null),
+			eq(AuctionStatus.NO_BID),
+			any(OffsetDateTime.class)
+		);
+	}
+
+	@Test
+	@DisplayName("종료 시 최고 입찰자가 있으면 낙찰 상태와 최종가를 저장한다")
+	void endAuctionCompletesWithWinnerWhenHighestBidderExists() {
+		Long auctionId = 1L;
+		Long sellerId = 10L;
+		Long winnerId = 20L;
+		BigDecimal finalPrice = new BigDecimal("150000");
+		Auction auction = auction(sellerId);
+		when(auctionRepository.findByAuctionIdAndDeletedAtIsNullAndProductDeletedAtIsNull(auctionId))
+			.thenReturn(Optional.of(auction));
+		when(auctionRedisService.getState(auctionId))
+			.thenReturn(new AuctionState(finalPrice, new BigDecimal("1000"), winnerId));
+
+		auctionBidService.endAuction(auctionId);
+
+		assertThat(auction.getStatus()).isEqualTo(AuctionStatus.SUCCESSFUL_BID);
+		assertThat(auction.getProduct().getStatus()).isEqualTo(ProductStatus.SOLD);
+		assertThat(auction.getWinnerId()).isEqualTo(winnerId);
+		assertThat(auction.getFinalPrice()).isEqualByComparingTo(finalPrice);
+		assertThat(auction.getCurrentPrice()).isEqualByComparingTo(finalPrice);
+		verify(auctionRedisService).removeEnding(auctionId);
+		verify(auctionRedisService).deleteState(auctionId);
+		verify(auctionEventPublisher).publishAuctionEnded(
+			eq(sellerId),
+			eq(auctionId),
+			eq(winnerId),
+			eq(finalPrice),
+			eq(AuctionStatus.SUCCESSFUL_BID),
+			any(OffsetDateTime.class)
+		);
+		verify(auctionEventPublisher).publishAuctionEnded(
+			eq(winnerId),
+			eq(auctionId),
+			eq(winnerId),
+			eq(finalPrice),
+			eq(AuctionStatus.SUCCESSFUL_BID),
+			any(OffsetDateTime.class)
+		);
+	}
+
+	@Test
+	@DisplayName("동시에 최소가를 만족한 두 입찰이 들어와도 Redis 판정 기준으로 하나만 성공한다")
+	void concurrentBidsAllowOnlyOneWinnerWhenSecondBidIsTooLowAfterAtomicUpdate() throws Exception {
+		Long auctionId = 1L;
+		Auction auction = auction(10L);
+		AtomicReference<BigDecimal> currentPrice = new AtomicReference<>(new BigDecimal("100000"));
+		when(auctionRepository.findByAuctionIdAndDeletedAtIsNullAndProductDeletedAtIsNull(auctionId))
+			.thenReturn(Optional.of(auction));
+		when(bidRepository.save(any(Bid.class))).thenAnswer(invocation -> invocation.getArgument(0));
+		when(auctionRedisService.bid(eq(auctionId), any(BigDecimal.class), anyLong()))
+			.thenAnswer(invocation -> {
+				BigDecimal bidPrice = invocation.getArgument(1);
+				synchronized (currentPrice) {
+					BigDecimal minimumNextPrice = currentPrice.get().add(new BigDecimal("1000"));
+					if (bidPrice.compareTo(minimumNextPrice) < 0) {
+						return new BidScriptResult(BidScriptStatus.BID_TOO_LOW, null);
+					}
+					currentPrice.set(bidPrice);
+					return new BidScriptResult(BidScriptStatus.SUCCESS, null);
+				}
+			});
+
+		CountDownLatch start = new CountDownLatch(1);
+		try (var executor = Executors.newFixedThreadPool(2)) {
+			List<Future<Object>> futures = new ArrayList<>();
+			futures.add(executor.submit(() -> bidAfterStart(start, auctionId, 20L, new BigDecimal("101000"))));
+			futures.add(executor.submit(() -> bidAfterStart(start, auctionId, 30L, new BigDecimal("101500"))));
+			start.countDown();
+
+			List<Object> results = List.of(futures.get(0).get(), futures.get(1).get());
+
+			assertThat(results.stream().filter(BidResponse.class::isInstance)).hasSize(1);
+			assertThat(results.stream().filter(InvalidAuctionRequestException.class::isInstance)).hasSize(1);
+			assertThat(auction.getCurrentPrice()).isIn(new BigDecimal("101000"), new BigDecimal("101500"));
+			verify(bidRepository, times(1)).save(any(Bid.class));
+			verify(auctionEventPublisher, times(1)).publishBidUpdated(
+				eq(auctionId),
+				any(BigDecimal.class),
+				anyLong(),
+				any(OffsetDateTime.class)
+			);
+		}
+	}
+
+	@Test
+	@DisplayName("상태가 진행중이어도 종료 시각이 지났으면 입찰을 거절한다")
+	void bidFailsWhenAuctionEndTimeAlreadyPassed() {
+		Long auctionId = 1L;
+		Auction auction = endedByTimeAuction(10L);
+		when(auctionRepository.findByAuctionIdAndDeletedAtIsNullAndProductDeletedAtIsNull(auctionId))
+			.thenReturn(Optional.of(auction));
+
+		Object result;
+		try {
+			result = auctionBidService.bid(auctionId, 20L, new BigDecimal("101000"));
+		} catch (InvalidAuctionRequestException exception) {
+			result = exception;
+		}
+
+		assertThat(result).isInstanceOf(InvalidAuctionRequestException.class);
+		assertThat(((InvalidAuctionRequestException) result).getMessage()).isEqualTo("이미 종료된 경매입니다.");
+		verify(auctionRedisService, never()).bid(anyLong(), any(BigDecimal.class), anyLong());
+		verify(bidRepository, never()).save(any(Bid.class));
+	}
+
+	private Object bidAfterStart(CountDownLatch start, Long auctionId, Long bidderId, BigDecimal bidPrice)
+		throws InterruptedException {
+		start.await();
+		try {
+			return auctionBidService.bid(auctionId, bidderId, bidPrice);
+		} catch (InvalidAuctionRequestException exception) {
+			return exception;
+		}
+	}
+
+	private Auction auction(Long sellerId) {
+		return auction(sellerId, OffsetDateTime.now(FIXED_CLOCK).plusDays(1));
+	}
+
+	private Auction endedByTimeAuction(Long sellerId) {
+		return auction(sellerId, OffsetDateTime.now(FIXED_CLOCK).minusSeconds(1));
+	}
+
+	private Auction auction(Long sellerId, OffsetDateTime endsAt) {
+		Product product = Product.create(
+			"auction product",
+			"description",
+			ProductSaleType.AUCTION,
+			21L,
+			sellerId,
+			BigDecimal.ZERO,
+			false,
+			"서울 마포구",
+			null,
+			ProductStatus.ON_SALE
+		);
+		return Auction.create(
+			product,
+			new BigDecimal("100000"),
+			new BigDecimal("1000"),
+			OffsetDateTime.now(FIXED_CLOCK).minusDays(1),
+			endsAt,
+			AuctionStatus.ONGOING
+		);
+	}
+}

--- a/src/test/java/com/dealit/dealit/domain/auction/AuctionEndingSchedulerTest.java
+++ b/src/test/java/com/dealit/dealit/domain/auction/AuctionEndingSchedulerTest.java
@@ -1,0 +1,53 @@
+package com.dealit.dealit.domain.auction;
+
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.dealit.dealit.domain.auction.exception.AuctionNotFoundException;
+import com.dealit.dealit.domain.auction.redis.AuctionRedisService;
+import com.dealit.dealit.domain.auction.scheduler.AuctionEndingScheduler;
+import com.dealit.dealit.domain.auction.service.AuctionBidService;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.Set;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class AuctionEndingSchedulerTest {
+
+	private final AuctionRedisService auctionRedisService = mock(AuctionRedisService.class);
+	private final AuctionBidService auctionBidService = mock(AuctionBidService.class);
+	private final Clock clock = Clock.fixed(Instant.parse("2026-05-02T00:00:00Z"), ZoneOffset.UTC);
+	private final AuctionEndingScheduler scheduler = new AuctionEndingScheduler(
+		auctionRedisService,
+		auctionBidService,
+		clock
+	);
+
+	@Test
+	@DisplayName("종료 큐에 DB에 없는 경매 ID가 남아 있어도 제거하고 다음 실행을 막지 않는다")
+	void endExpiredAuctionsRemovesStaleAuctionIdWhenAuctionDoesNotExist() {
+		when(auctionRedisService.findEndingAuctionIds(clock.millis())).thenReturn(Set.of("999"));
+		doThrow(new AuctionNotFoundException("존재하지 않는 경매입니다."))
+			.when(auctionBidService)
+			.endAuction(999L);
+
+		scheduler.endExpiredAuctions();
+
+		verify(auctionBidService).endAuction(999L);
+		verify(auctionRedisService).removeEnding(999L);
+	}
+
+	@Test
+	@DisplayName("종료 큐에 숫자가 아닌 값이 있어도 제거한다")
+	void endExpiredAuctionsRemovesInvalidAuctionIdValue() {
+		when(auctionRedisService.findEndingAuctionIds(clock.millis())).thenReturn(Set.of("bad-id"));
+
+		scheduler.endExpiredAuctions();
+
+		verify(auctionRedisService).removeEndingValue("bad-id");
+	}
+}

--- a/src/test/java/com/dealit/dealit/domain/auction/AuctionIntegrationTest.java
+++ b/src/test/java/com/dealit/dealit/domain/auction/AuctionIntegrationTest.java
@@ -142,8 +142,9 @@ class AuctionIntegrationTest {
 			.andExpect(jsonPath("$.content[0].thumbnailUrl").value("http://localhost:8080/uploads/auction/images/test-image.jpg"))
 			.andExpect(jsonPath("$.content[0].auctionStatus").value("AUCTION_LIVE"))
 			.andExpect(jsonPath("$.content[0].startPrice").value(180000))
+			.andExpect(jsonPath("$.content[0].minimumBidAmount").value(1800))
 			.andExpect(jsonPath("$.content[0].currentPrice").value(180000))
-			.andExpect(jsonPath("$.content[0].minimumNextBidPrice").value(180000))
+			.andExpect(jsonPath("$.content[0].minimumNextBidPrice").value(181800))
 			.andExpect(jsonPath("$.content[0].bidCount").value(0))
 			.andExpect(jsonPath("$.content[0].bidderCount").value(0))
 			.andExpect(jsonPath("$.content[0].startAt").value(notNullValue()))
@@ -378,6 +379,119 @@ class AuctionIntegrationTest {
 			.andExpect(jsonPath("$.auction.status").value("AUCTION_LIVE"))
 			.andExpect(jsonPath("$.auction.startAt").value(notNullValue()))
 			.andExpect(jsonPath("$.auction.endAt").value(notNullValue()));
+	}
+
+	@Test
+	@DisplayName("경매 상세 조회는 상품, 판매자, 이미지, 입찰 메타 정보를 함께 반환한다")
+	void getAuctionDetailReturnsProductSellerImagesAndBidMeta() throws Exception {
+		mockMvc.perform(post("/api/v1/auction")
+				.header("Authorization", "Bearer " + accessToken)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{
+					  "name": "Nintendo Switch OLED",
+					  "description": "Includes dock and controller.",
+					  "saleType": "AUCTION",
+					  "categoryId": 21,
+					  "price": null,
+					  "startPrice": 180000,
+					  "minimumBidAmount": 1800,
+					  "auctionDurationDays": 2,
+					  "images": [
+					    {
+					      "imageId": %d,
+					      "imageUrl": "http://localhost:8080/uploads/auction/images/test-image.jpg",
+					      "sortOrder": 1
+					    }
+					  ],
+					  "location": "서울 마포구",
+					  "draftId": null
+					}
+					""".formatted(uploadedImage.getImageId())))
+			.andExpect(status().isCreated());
+
+		Long auctionId = auctionRepository.findAll().getFirst().getAuctionId();
+
+		mockMvc.perform(get("/api/v1/auctions/{auctionId}", auctionId)
+				.header("Authorization", "Bearer " + accessToken))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.auctionId").value(auctionId))
+			.andExpect(jsonPath("$.productId").isNumber())
+			.andExpect(jsonPath("$.name").value("Nintendo Switch OLED"))
+			.andExpect(jsonPath("$.description").value("Includes dock and controller."))
+			.andExpect(jsonPath("$.categoryId").value(21))
+			.andExpect(jsonPath("$.categoryName").value("사무용노트북"))
+			.andExpect(jsonPath("$.location").value("서울 마포구"))
+			.andExpect(jsonPath("$.images", hasSize(1)))
+			.andExpect(jsonPath("$.images[0].imageId").value(uploadedImage.getImageId()))
+			.andExpect(jsonPath("$.images[0].imageUrl").value("http://localhost:8080/uploads/auction/images/test-image.jpg"))
+			.andExpect(jsonPath("$.images[0].sortOrder").value(1))
+			.andExpect(jsonPath("$.seller.memberId").isNumber())
+			.andExpect(jsonPath("$.seller.nickname").value(startsWith("Dealit#")))
+			.andExpect(jsonPath("$.startPrice").value(180000))
+			.andExpect(jsonPath("$.currentPrice").value(180000))
+			.andExpect(jsonPath("$.minimumBidAmount").value(1800))
+			.andExpect(jsonPath("$.minimumNextBidPrice").value(181800))
+			.andExpect(jsonPath("$.bidCount").value(0))
+			.andExpect(jsonPath("$.bidderCount").value(0))
+			.andExpect(jsonPath("$.startAt").value(notNullValue()))
+			.andExpect(jsonPath("$.endsAt").value(notNullValue()))
+			.andExpect(jsonPath("$.serverTime").value(notNullValue()))
+			.andExpect(jsonPath("$.status").value("AUCTION_LIVE"));
+	}
+
+	@Test
+	@DisplayName("입찰가는 현재가에 최소 입찰 금액을 더한 금액 이상이어야 한다")
+	void bidFailsWhenBidPriceIsBelowMinimumNextBidPrice() throws Exception {
+		mockMvc.perform(post("/api/v1/auction")
+				.header("Authorization", "Bearer " + accessToken)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{
+					  "name": "Nintendo Switch OLED",
+					  "description": "Includes dock and controller.",
+					  "saleType": "AUCTION",
+					  "categoryId": 21,
+					  "price": null,
+					  "startPrice": 180000,
+					  "minimumBidAmount": 1800,
+					  "auctionDurationDays": 2,
+					  "images": [
+					    {
+					      "imageId": %d,
+					      "imageUrl": "http://localhost:8080/uploads/auction/images/test-image.jpg",
+					      "sortOrder": 1
+					    }
+					  ],
+					  "location": "서울 마포구",
+					  "draftId": null
+					}
+					""".formatted(uploadedImage.getImageId())))
+			.andExpect(status().isCreated());
+
+		Long auctionId = auctionRepository.findAll().getFirst().getAuctionId();
+		Member bidder = Member.create(
+			"auction-bidder",
+			passwordEncoder.encode("Password123!"),
+			"auction-bidder@dealit.com",
+			null,
+			"입찰자"
+		);
+		Member savedBidder = memberRepository.save(bidder);
+		savedBidder.assignDefaultNickname();
+		String bidderToken = jwtService.generateAccessToken(memberRepository.save(savedBidder));
+
+		mockMvc.perform(post("/api/v1/auctions/{auctionId}/bids", auctionId)
+				.header("Authorization", "Bearer " + bidderToken)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{
+					  "bidPrice": 181000
+					}
+					"""))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.code").value("INVALID_AUCTION_REQUEST"))
+			.andExpect(jsonPath("$.message").value("최소 입찰 금액을 충족해야 합니다."));
 	}
 
 	@Test

--- a/src/test/java/com/dealit/dealit/domain/auction/AuctionIntegrationTest.java
+++ b/src/test/java/com/dealit/dealit/domain/auction/AuctionIntegrationTest.java
@@ -23,8 +23,10 @@ import org.springframework.test.web.servlet.MockMvc;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.Comparator;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
@@ -379,6 +381,42 @@ class AuctionIntegrationTest {
 			.andExpect(jsonPath("$.auction.status").value("AUCTION_LIVE"))
 			.andExpect(jsonPath("$.auction.startAt").value(notNullValue()))
 			.andExpect(jsonPath("$.auction.endAt").value(notNullValue()));
+	}
+
+	@Test
+	@DisplayName("경매 등록은 테스트용 소수 day 기간으로 10초 경매를 생성할 수 있다")
+	void createAuctionSupportsFractionalDurationDaysForTenSecondAuction() throws Exception {
+		mockMvc.perform(post("/api/v1/auction")
+				.header("Authorization", "Bearer " + accessToken)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{
+					  "name": "10 second auction",
+					  "description": "Short auction for completion test.",
+					  "saleType": "AUCTION",
+					  "categoryId": 21,
+					  "price": null,
+					  "startPrice": 500000,
+					  "minimumBidAmount": 5000,
+					  "auctionDurationDays": 0.00011574074074074075,
+					  "images": [
+					    {
+					      "imageId": %d,
+					      "imageUrl": "http://localhost:8080/uploads/auction/images/test-image.jpg",
+					      "sortOrder": 1
+					    }
+					  ],
+					  "location": "서울 마포구",
+					  "draftId": null
+					}
+					""".formatted(uploadedImage.getImageId())))
+			.andExpect(status().isCreated())
+			.andExpect(jsonPath("$.auction.startAt").value(notNullValue()))
+			.andExpect(jsonPath("$.auction.endAt").value(notNullValue()));
+
+		var auction = auctionRepository.findAll().getFirst();
+		assertThat(Duration.between(auction.getAuctionStartAt(), auction.getAuctionEndAt()))
+			.isEqualTo(Duration.ofSeconds(10));
 	}
 
 	@Test


### PR DESCRIPTION
### 🚀 Summary

<!-- 작업 내용에 대한 간략한 설명을 써주세요. -->
- 경매 로직 구현
---

### ✨ Description

<!-- 상세한 설명, 기능의 사용법, 주의 사항 실행 결과(이미지 첨부 가능) 등을 보여주세요. -->
### 낙찰 프로세스
#### 경매시작
<img width="659" height="266" alt="스크린샷 2026-05-02 오후 9 23 56" src="https://github.com/user-attachments/assets/9eff8874-ad22-44f7-99b1-1e99f4995de0" />

#### 입찰
<img width="1408" height="359" alt="스크린샷 2026-05-02 오후 9 24 03" src="https://github.com/user-attachments/assets/a38c4ac4-2428-4f09-bf48-0e37e187bf8f" />

<img width="1409" height="464" alt="스크린샷 2026-05-02 오후 9 24 51" src="https://github.com/user-attachments/assets/5cfdd7de-1ae5-45b8-9e5d-0bf2753de01f" />

<img width="1382" height="578" alt="스크린샷 2026-05-02 오후 9 24 57" src="https://github.com/user-attachments/assets/0f7940c3-8294-4cf5-9707-1c8ea277b821" />

#### auction 테이블에서 SUCCESSFULL_BID 
<img width="738" height="48" alt="스크린샷 2026-05-02 오후 9 46 06" src="https://github.com/user-attachments/assets/7cb5e1a7-ff54-492b-bc76-3edf15ebbd9b" />


#### 낙찰시에 이렇게 product테이블에서는 SOLD로 상태가바뀜 (결제프로세스)
<img width="731" height="82" alt="스크린샷 2026-05-02 오후 9 40 07" src="https://github.com/user-attachments/assets/9b1ba9a6-f47b-4512-ac2f-eba1332804a6" />


### 유찰 프로세스
#### 경매생성
<img width="654" height="197" alt="스크린샷 2026-05-02 오후 9 43 39" src="https://github.com/user-attachments/assets/325158bf-cbc3-4498-adf7-b4d8fc4e8eb3" />

#### 아무도 입찰안함
<img width="1411" height="562" alt="스크린샷 2026-05-02 오후 9 44 00" src="https://github.com/user-attachments/assets/d824b4c0-cb26-44b5-8876-3c0fe2cdff32" />

#### auction테이블에서 NO_BID 유찰(삭제됨)
<img width="818" height="48" alt="스크린샷 2026-05-02 오후 9 44 41" src="https://github.com/user-attachments/assets/a51b320b-8faf-4844-bc0b-edecfa3f2d0a" />

#### product테이블에서는 바로 ENDED로 아예끝 (결제x, 삭제됨)
<img width="724" height="55" alt="스크린샷 2026-05-02 오후 9 44 22" src="https://github.com/user-attachments/assets/d1d6b321-cc49-4227-8fd6-fa2136e1154a" />


낙찰시 -> SUCCESSFULL_BID (일반 상품의 결제 프로세스랑 같음)
유찰시 -> NO_BID (유찰은 바로 삭제 처리함)
진행중 -> ON_GOING
<img width="953" height="312" alt="스크린샷 2026-05-02 오후 9 25 53" src="https://github.com/user-attachments/assets/856bd510-3659-47c3-b4cf-3803f9845b7d" />



PS. 현재는 테스트를 위해 판매자도 경매에 참여할수있음 실시간은 SSE와 연동을 해야하기에 추후 구현할예정
경매로직자체는 정상작동!

---

### 🎲 Issue Number

<!-- Please enter {Issue Number} below to automatically close the connected issue. -->

close #38 
