### PR TITLE
[feat] 딜릿머니 도입 및 관련 API구현

### DIFF
--- a/src/main/java/com/dealit/dealit/domain/wallet/controller/WalletController.java
+++ b/src/main/java/com/dealit/dealit/domain/wallet/controller/WalletController.java
@@ -1,0 +1,76 @@
+package com.dealit.dealit.domain.wallet.controller;
+
+import com.dealit.dealit.domain.wallet.dto.WalletAmountRequest;
+import com.dealit.dealit.domain.wallet.dto.WalletLedgerListResponse;
+import com.dealit.dealit.domain.wallet.dto.WalletResponse;
+import com.dealit.dealit.domain.wallet.service.WalletService;
+import com.dealit.dealit.global.security.AuthenticatedMember;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Wallet", description = "딜릿머니 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/wallet")
+public class WalletController {
+
+	private final WalletService walletService;
+
+	@Operation(summary = "내 딜릿머니 지갑 조회")
+	@ApiResponse(responseCode = "200", description = "내 딜릿머니 지갑 조회 성공")
+	@GetMapping
+	public WalletResponse getMyWallet(@AuthenticationPrincipal AuthenticatedMember member) {
+		return walletService.getMyWallet(member.memberId());
+	}
+
+	@Operation(summary = "딜릿머니 내역 조회")
+	@ApiResponse(responseCode = "200", description = "딜릿머니 내역 조회 성공")
+	@GetMapping("/ledgers")
+	public WalletLedgerListResponse getMyLedgers(
+		@AuthenticationPrincipal AuthenticatedMember member,
+		@RequestParam(defaultValue = "0") int page,
+		@RequestParam(defaultValue = "20") int size
+	) {
+		return walletService.getMyLedgers(member.memberId(), page, size);
+	}
+
+	@Operation(summary = "딜릿머니 임시 충전")
+	@ApiResponse(responseCode = "200", description = "딜릿머니 임시 충전 성공")
+	@PostMapping("/charge")
+	public WalletResponse charge(
+		@AuthenticationPrincipal AuthenticatedMember member,
+		@Valid @RequestBody WalletAmountRequest request
+	) {
+		return walletService.charge(member.memberId(), request.amount());
+	}
+
+	@Operation(summary = "딜릿머니 환불")
+	@ApiResponse(responseCode = "200", description = "딜릿머니 환불 성공")
+	@PostMapping("/refund")
+	public WalletResponse refund(
+		@AuthenticationPrincipal AuthenticatedMember member,
+		@Valid @RequestBody WalletAmountRequest request
+	) {
+		return walletService.refund(member.memberId(), request.amount());
+	}
+
+	@Operation(summary = "딜릿머니 출금 신청")
+	@ApiResponse(responseCode = "200", description = "딜릿머니 출금 신청 성공")
+	@PostMapping("/withdraw")
+	public WalletResponse withdraw(
+		@AuthenticationPrincipal AuthenticatedMember member,
+		@Valid @RequestBody WalletAmountRequest request
+	) {
+		return walletService.withdraw(member.memberId(), request.amount());
+	}
+}

--- a/src/main/java/com/dealit/dealit/domain/wallet/dto/WalletAmountRequest.java
+++ b/src/main/java/com/dealit/dealit/domain/wallet/dto/WalletAmountRequest.java
@@ -1,0 +1,13 @@
+package com.dealit.dealit.domain.wallet.dto;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+
+public record WalletAmountRequest(
+	@NotNull(message = "금액은 필수입니다.")
+	@Min(value = 1, message = "금액은 1원 이상이어야 합니다.")
+	@Max(value = 10000000, message = "금액은 10,000,000원 이하이어야 합니다.")
+	Long amount
+) {
+}

--- a/src/main/java/com/dealit/dealit/domain/wallet/dto/WalletLedgerListResponse.java
+++ b/src/main/java/com/dealit/dealit/domain/wallet/dto/WalletLedgerListResponse.java
@@ -1,0 +1,12 @@
+package com.dealit.dealit.domain.wallet.dto;
+
+import java.util.List;
+
+public record WalletLedgerListResponse(
+	List<WalletLedgerResponse> content,
+	int page,
+	int size,
+	long totalElements,
+	boolean hasNext
+) {
+}

--- a/src/main/java/com/dealit/dealit/domain/wallet/dto/WalletLedgerResponse.java
+++ b/src/main/java/com/dealit/dealit/domain/wallet/dto/WalletLedgerResponse.java
@@ -1,0 +1,14 @@
+package com.dealit.dealit.domain.wallet.dto;
+
+import com.dealit.dealit.domain.wallet.entity.WalletLedgerType;
+import java.time.OffsetDateTime;
+
+public record WalletLedgerResponse(
+	Long ledgerId,
+	WalletLedgerType type,
+	Long amount,
+	Long balanceAfter,
+	String description,
+	OffsetDateTime createdAt
+) {
+}

--- a/src/main/java/com/dealit/dealit/domain/wallet/dto/WalletResponse.java
+++ b/src/main/java/com/dealit/dealit/domain/wallet/dto/WalletResponse.java
@@ -1,0 +1,8 @@
+package com.dealit.dealit.domain.wallet.dto;
+
+public record WalletResponse(
+	Long walletId,
+	Long memberId,
+	Long balance
+) {
+}

--- a/src/main/java/com/dealit/dealit/domain/wallet/entity/Wallet.java
+++ b/src/main/java/com/dealit/dealit/domain/wallet/entity/Wallet.java
@@ -1,0 +1,58 @@
+package com.dealit.dealit.domain.wallet.entity;
+
+import com.dealit.dealit.global.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.SequenceGenerator;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(
+	name = "wallet",
+	uniqueConstraints = @UniqueConstraint(name = "uk_wallet_member_id", columnNames = "member_id")
+)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SequenceGenerator(
+	name = "wallet_seq_generator",
+	sequenceName = "wallet_seq",
+	allocationSize = 1
+)
+public class Wallet extends BaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "wallet_seq_generator")
+	@Column(name = "wallet_id")
+	private Long walletId;
+
+	@Column(name = "member_id", nullable = false)
+	private Long memberId;
+
+	@Column(name = "balance", nullable = false)
+	private Long balance;
+
+	private Wallet(Long memberId) {
+		this.memberId = memberId;
+		this.balance = 0L;
+	}
+
+	public static Wallet create(Long memberId) {
+		return new Wallet(memberId);
+	}
+
+	public long apply(long amount) {
+		long nextBalance = balance + amount;
+		if (nextBalance < 0) {
+			throw new IllegalArgumentException("잔액이 부족합니다.");
+		}
+		this.balance = nextBalance;
+		return nextBalance;
+	}
+}

--- a/src/main/java/com/dealit/dealit/domain/wallet/entity/WalletLedger.java
+++ b/src/main/java/com/dealit/dealit/domain/wallet/entity/WalletLedger.java
@@ -1,0 +1,80 @@
+package com.dealit.dealit.domain.wallet.entity;
+
+import com.dealit.dealit.global.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.SequenceGenerator;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "wallet_ledger")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SequenceGenerator(
+	name = "wallet_ledger_seq_generator",
+	sequenceName = "wallet_ledger_seq",
+	allocationSize = 1
+)
+public class WalletLedger extends BaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "wallet_ledger_seq_generator")
+	@Column(name = "wallet_ledger_id")
+	private Long walletLedgerId;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "wallet_id", nullable = false)
+	private Wallet wallet;
+
+	@Column(name = "member_id", nullable = false)
+	private Long memberId;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "type", nullable = false, length = 30)
+	private WalletLedgerType type;
+
+	@Column(name = "amount", nullable = false)
+	private Long amount;
+
+	@Column(name = "balance_after", nullable = false)
+	private Long balanceAfter;
+
+	@Column(name = "description", nullable = false, length = 100)
+	private String description;
+
+	private WalletLedger(
+		Wallet wallet,
+		WalletLedgerType type,
+		long amount,
+		long balanceAfter,
+		String description
+	) {
+		this.wallet = wallet;
+		this.memberId = wallet.getMemberId();
+		this.type = type;
+		this.amount = amount;
+		this.balanceAfter = balanceAfter;
+		this.description = description;
+	}
+
+	public static WalletLedger create(
+		Wallet wallet,
+		WalletLedgerType type,
+		long amount,
+		long balanceAfter,
+		String description
+	) {
+		return new WalletLedger(wallet, type, amount, balanceAfter, description);
+	}
+}

--- a/src/main/java/com/dealit/dealit/domain/wallet/entity/WalletLedgerType.java
+++ b/src/main/java/com/dealit/dealit/domain/wallet/entity/WalletLedgerType.java
@@ -1,0 +1,7 @@
+package com.dealit.dealit.domain.wallet.entity;
+
+public enum WalletLedgerType {
+	TEMP_CHARGE,
+	REFUND,
+	WITHDRAWAL
+}

--- a/src/main/java/com/dealit/dealit/domain/wallet/exception/InvalidWalletRequestException.java
+++ b/src/main/java/com/dealit/dealit/domain/wallet/exception/InvalidWalletRequestException.java
@@ -1,0 +1,10 @@
+package com.dealit.dealit.domain.wallet.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class InvalidWalletRequestException extends WalletException {
+
+	public InvalidWalletRequestException(String message) {
+		super(HttpStatus.BAD_REQUEST, "INVALID_WALLET_REQUEST", message);
+	}
+}

--- a/src/main/java/com/dealit/dealit/domain/wallet/exception/WalletException.java
+++ b/src/main/java/com/dealit/dealit/domain/wallet/exception/WalletException.java
@@ -1,0 +1,17 @@
+package com.dealit.dealit.domain.wallet.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class WalletException extends RuntimeException {
+
+	private final HttpStatus status;
+	private final String code;
+
+	public WalletException(HttpStatus status, String code, String message) {
+		super(message);
+		this.status = status;
+		this.code = code;
+	}
+}

--- a/src/main/java/com/dealit/dealit/domain/wallet/repository/WalletLedgerRepository.java
+++ b/src/main/java/com/dealit/dealit/domain/wallet/repository/WalletLedgerRepository.java
@@ -1,0 +1,11 @@
+package com.dealit.dealit.domain.wallet.repository;
+
+import com.dealit.dealit.domain.wallet.entity.WalletLedger;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface WalletLedgerRepository extends JpaRepository<WalletLedger, Long> {
+
+	Page<WalletLedger> findAllByMemberId(Long memberId, Pageable pageable);
+}

--- a/src/main/java/com/dealit/dealit/domain/wallet/repository/WalletRepository.java
+++ b/src/main/java/com/dealit/dealit/domain/wallet/repository/WalletRepository.java
@@ -1,0 +1,15 @@
+package com.dealit.dealit.domain.wallet.repository;
+
+import com.dealit.dealit.domain.wallet.entity.Wallet;
+import jakarta.persistence.LockModeType;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+
+public interface WalletRepository extends JpaRepository<Wallet, Long> {
+
+	Optional<Wallet> findByMemberId(Long memberId);
+
+	@Lock(LockModeType.PESSIMISTIC_WRITE)
+	Optional<Wallet> findWithLockByMemberId(Long memberId);
+}

--- a/src/main/java/com/dealit/dealit/domain/wallet/service/WalletService.java
+++ b/src/main/java/com/dealit/dealit/domain/wallet/service/WalletService.java
@@ -1,0 +1,130 @@
+package com.dealit.dealit.domain.wallet.service;
+
+import com.dealit.dealit.domain.auth.exception.InvalidCredentialsException;
+import com.dealit.dealit.domain.member.repository.MemberRepository;
+import com.dealit.dealit.domain.wallet.dto.WalletLedgerListResponse;
+import com.dealit.dealit.domain.wallet.dto.WalletLedgerResponse;
+import com.dealit.dealit.domain.wallet.dto.WalletResponse;
+import com.dealit.dealit.domain.wallet.entity.Wallet;
+import com.dealit.dealit.domain.wallet.entity.WalletLedger;
+import com.dealit.dealit.domain.wallet.entity.WalletLedgerType;
+import com.dealit.dealit.domain.wallet.exception.InvalidWalletRequestException;
+import com.dealit.dealit.domain.wallet.repository.WalletLedgerRepository;
+import com.dealit.dealit.domain.wallet.repository.WalletRepository;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class WalletService {
+
+	private static final ZoneId SEOUL_ZONE = ZoneId.of("Asia/Seoul");
+
+	private final WalletRepository walletRepository;
+	private final WalletLedgerRepository walletLedgerRepository;
+	private final MemberRepository memberRepository;
+
+	@Transactional
+	public WalletResponse getMyWallet(Long memberId) {
+		validateActiveMember(memberId);
+		return toWalletResponse(findOrCreateWallet(memberId));
+	}
+
+	@Transactional
+	public WalletResponse charge(Long memberId, long amount) {
+		return apply(memberId, amount, WalletLedgerType.TEMP_CHARGE, "딜릿머니 임시 충전");
+	}
+
+	@Transactional
+	public WalletResponse refund(Long memberId, long amount) {
+		return apply(memberId, amount, WalletLedgerType.REFUND, "딜릿머니 환불");
+	}
+
+	@Transactional
+	public WalletResponse withdraw(Long memberId, long amount) {
+		return apply(memberId, -amount, WalletLedgerType.WITHDRAWAL, "내 계좌로 옮기기");
+	}
+
+	public WalletLedgerListResponse getMyLedgers(Long memberId, int page, int size) {
+		validateActiveMember(memberId);
+		int normalizedPage = Math.max(page, 0);
+		int normalizedSize = Math.min(Math.max(size, 1), 100);
+
+		Page<WalletLedger> ledgerPage = walletLedgerRepository.findAllByMemberId(
+			memberId,
+			PageRequest.of(normalizedPage, normalizedSize, Sort.by(Sort.Direction.DESC, "createdAt"))
+		);
+
+		return new WalletLedgerListResponse(
+			ledgerPage.getContent().stream()
+				.map(this::toLedgerResponse)
+				.toList(),
+			ledgerPage.getNumber(),
+			ledgerPage.getSize(),
+			ledgerPage.getTotalElements(),
+			ledgerPage.hasNext()
+		);
+	}
+
+	private WalletResponse apply(Long memberId, long signedAmount, WalletLedgerType type, String description) {
+		validateActiveMember(memberId);
+		if (signedAmount == 0) {
+			throw new InvalidWalletRequestException("금액은 0원일 수 없습니다.");
+		}
+
+		Wallet wallet = findOrCreateWallet(memberId);
+		wallet = walletRepository.findWithLockByMemberId(memberId).orElse(wallet);
+
+		long nextBalance;
+		try {
+			nextBalance = wallet.apply(signedAmount);
+		} catch (IllegalArgumentException exception) {
+			throw new InvalidWalletRequestException(exception.getMessage());
+		}
+
+		walletLedgerRepository.save(
+			WalletLedger.create(wallet, type, signedAmount, nextBalance, description)
+		);
+		return toWalletResponse(wallet);
+	}
+
+	private Wallet findOrCreateWallet(Long memberId) {
+		return walletRepository.findByMemberId(memberId)
+			.orElseGet(() -> walletRepository.save(Wallet.create(memberId)));
+	}
+
+	private void validateActiveMember(Long memberId) {
+		memberRepository.findByMemberIdAndDeletedAtIsNull(memberId)
+			.orElseThrow(() -> new InvalidCredentialsException("존재하지 않는 회원입니다."));
+	}
+
+	private WalletResponse toWalletResponse(Wallet wallet) {
+		return new WalletResponse(wallet.getWalletId(), wallet.getMemberId(), wallet.getBalance());
+	}
+
+	private WalletLedgerResponse toLedgerResponse(WalletLedger ledger) {
+		return new WalletLedgerResponse(
+			ledger.getWalletLedgerId(),
+			ledger.getType(),
+			ledger.getAmount(),
+			ledger.getBalanceAfter(),
+			ledger.getDescription(),
+			toSeoulOffsetDateTime(ledger.getCreatedAt())
+		);
+	}
+
+	private OffsetDateTime toSeoulOffsetDateTime(LocalDateTime dateTime) {
+		if (dateTime == null) {
+			return null;
+		}
+		return dateTime.atZone(SEOUL_ZONE).toOffsetDateTime();
+	}
+}

--- a/src/main/java/com/dealit/dealit/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/dealit/dealit/global/error/GlobalExceptionHandler.java
@@ -14,6 +14,7 @@ import com.dealit.dealit.domain.member.exception.DuplicateNicknameException;
 import com.dealit.dealit.domain.member.exception.MemberException;
 import com.dealit.dealit.domain.notification.exception.NotificationException;
 import com.dealit.dealit.domain.product.exception.ProductException;
+import com.dealit.dealit.domain.wallet.exception.WalletException;
 import jakarta.validation.ConstraintViolationException;
 import java.util.List;
 import org.springframework.http.HttpStatus;
@@ -127,6 +128,12 @@ public class GlobalExceptionHandler {
 
 	@ExceptionHandler(NotificationException.class)
 	public ResponseEntity<ErrorResponse> handleNotificationException(NotificationException exception) {
+		return ResponseEntity.status(exception.getStatus())
+			.body(ErrorResponse.of(exception.getStatus().value(), exception.getCode(), exception.getMessage(), List.of()));
+	}
+
+	@ExceptionHandler(WalletException.class)
+	public ResponseEntity<ErrorResponse> handleWalletException(WalletException exception) {
 		return ResponseEntity.status(exception.getStatus())
 			.body(ErrorResponse.of(exception.getStatus().value(), exception.getCode(), exception.getMessage(), List.of()));
 	}

--- a/src/main/resources/db/migration/V5__create_wallet_tables.sql
+++ b/src/main/resources/db/migration/V5__create_wallet_tables.sql
@@ -1,0 +1,31 @@
+CREATE SEQUENCE IF NOT EXISTS wallet_seq START WITH 1 INCREMENT BY 1;
+CREATE SEQUENCE IF NOT EXISTS wallet_ledger_seq START WITH 1 INCREMENT BY 1;
+
+CREATE TABLE IF NOT EXISTS wallet (
+    wallet_id BIGINT PRIMARY KEY DEFAULT nextval('wallet_seq'),
+    member_id BIGINT NOT NULL,
+    balance BIGINT NOT NULL DEFAULT 0,
+    created_at TIMESTAMP NOT NULL,
+    updated_at TIMESTAMP,
+    deleted_at TIMESTAMP,
+    CONSTRAINT uk_wallet_member_id UNIQUE (member_id),
+    CONSTRAINT chk_wallet_balance_non_negative CHECK (balance >= 0)
+);
+
+CREATE TABLE IF NOT EXISTS wallet_ledger (
+    wallet_ledger_id BIGINT PRIMARY KEY DEFAULT nextval('wallet_ledger_seq'),
+    wallet_id BIGINT NOT NULL,
+    member_id BIGINT NOT NULL,
+    type VARCHAR(30) NOT NULL,
+    amount BIGINT NOT NULL,
+    balance_after BIGINT NOT NULL,
+    description VARCHAR(100) NOT NULL,
+    created_at TIMESTAMP NOT NULL,
+    updated_at TIMESTAMP,
+    deleted_at TIMESTAMP,
+    CONSTRAINT fk_wallet_ledger_wallet FOREIGN KEY (wallet_id) REFERENCES wallet(wallet_id),
+    CONSTRAINT chk_wallet_ledger_amount_non_zero CHECK (amount <> 0),
+    CONSTRAINT chk_wallet_ledger_balance_after_non_negative CHECK (balance_after >= 0)
+);
+
+CREATE INDEX IF NOT EXISTS idx_wallet_ledger_member_created_at ON wallet_ledger(member_id, created_at DESC);

--- a/src/test/java/com/dealit/dealit/domain/wallet/WalletIntegrationTest.java
+++ b/src/test/java/com/dealit/dealit/domain/wallet/WalletIntegrationTest.java
@@ -1,0 +1,156 @@
+package com.dealit.dealit.domain.wallet;
+
+import com.dealit.dealit.domain.member.entity.Member;
+import com.dealit.dealit.domain.member.repository.MemberRepository;
+import com.dealit.dealit.domain.notification.repository.FcmTokenRepository;
+import com.dealit.dealit.domain.wallet.repository.WalletLedgerRepository;
+import com.dealit.dealit.domain.wallet.repository.WalletRepository;
+import com.dealit.dealit.global.security.jwt.JwtService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class WalletIntegrationTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private MemberRepository memberRepository;
+
+	@Autowired
+	private FcmTokenRepository fcmTokenRepository;
+
+	@Autowired
+	private WalletRepository walletRepository;
+
+	@Autowired
+	private WalletLedgerRepository walletLedgerRepository;
+
+	@Autowired
+	private PasswordEncoder passwordEncoder;
+
+	@Autowired
+	private JwtService jwtService;
+
+	private String accessToken;
+
+	@BeforeEach
+	void setUp() {
+		walletLedgerRepository.deleteAll();
+		walletRepository.deleteAll();
+		fcmTokenRepository.deleteAll();
+		memberRepository.deleteAll();
+
+		Member member = memberRepository.save(Member.create(
+			"dealit-user",
+			passwordEncoder.encode("Password123!"),
+			"user@dealit.com",
+			null,
+			"홍길동"
+		));
+		member.assignDefaultNickname();
+		memberRepository.save(member);
+		accessToken = jwtService.generateAccessToken(member);
+	}
+
+	@Test
+	@DisplayName("내 지갑을 조회하면 지갑이 없을 때 0원 지갑을 생성한다")
+	void getMyWalletCreatesWallet() throws Exception {
+		mockMvc.perform(get("/api/v1/wallet")
+				.header("Authorization", "Bearer " + accessToken))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.walletId").isNumber())
+			.andExpect(jsonPath("$.balance").value(0));
+
+		assertThat(walletRepository.findAll()).hasSize(1);
+	}
+
+	@Test
+	@DisplayName("딜릿머니를 충전하면 잔액이 증가하고 원장이 기록된다")
+	void chargeWallet() throws Exception {
+		mockMvc.perform(post("/api/v1/wallet/charge")
+				.header("Authorization", "Bearer " + accessToken)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{
+					  "amount": 30000
+					}
+					"""))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.balance").value(30000));
+
+		mockMvc.perform(get("/api/v1/wallet/ledgers")
+				.header("Authorization", "Bearer " + accessToken))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.content[0].type").value("TEMP_CHARGE"))
+			.andExpect(jsonPath("$.content[0].amount").value(30000))
+			.andExpect(jsonPath("$.content[0].balanceAfter").value(30000));
+	}
+
+	@Test
+	@DisplayName("환불은 잔액을 증가시키고 출금은 잔액을 차감한다")
+	void refundAndWithdrawWallet() throws Exception {
+		postAmount("/api/v1/wallet/charge", 50000)
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.balance").value(50000));
+
+		postAmount("/api/v1/wallet/refund", 10000)
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.balance").value(60000));
+
+		postAmount("/api/v1/wallet/withdraw", 25000)
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.balance").value(35000));
+
+		mockMvc.perform(get("/api/v1/wallet/ledgers")
+				.header("Authorization", "Bearer " + accessToken))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.content[0].type").value("WITHDRAWAL"))
+			.andExpect(jsonPath("$.content[0].amount").value(-25000))
+			.andExpect(jsonPath("$.content[1].type").value("REFUND"))
+			.andExpect(jsonPath("$.content[1].amount").value(10000));
+	}
+
+	@Test
+	@DisplayName("잔액보다 큰 출금 요청은 실패한다")
+	void withdrawFailsWhenBalanceInsufficient() throws Exception {
+		postAmount("/api/v1/wallet/withdraw", 1)
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.code").value("INVALID_WALLET_REQUEST"))
+			.andExpect(jsonPath("$.message").value("잔액이 부족합니다."));
+	}
+
+	@Test
+	@DisplayName("0원 이하 금액은 검증 오류를 반환한다")
+	void amountValidationFails() throws Exception {
+		postAmount("/api/v1/wallet/charge", 0)
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.code").value("VALIDATION_ERROR"));
+	}
+
+	private org.springframework.test.web.servlet.ResultActions postAmount(String url, long amount) throws Exception {
+		return mockMvc.perform(post(url)
+			.header("Authorization", "Bearer " + accessToken)
+			.contentType(MediaType.APPLICATION_JSON)
+			.content("""
+				{
+				  "amount": %d
+				}
+				""".formatted(amount)));
+	}
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -39,3 +39,5 @@ app:
   images:
     public-base-url: http://localhost:8080
     storage-root: ${java.io.tmpdir}/dealit-test-uploads
+  firebase:
+    enabled: false


### PR DESCRIPTION
### 🚀 Summary

  딜릿머니 기능을 위한 지갑/원장 테이블과 충전, 환불, 출금, 내역 조회 API를 추가했습니다.
원래는 money 컬럼만 추가하려 했으나, 이체 기록등을 위해 테이블을 따로 빼 두는 것이 좋다는 피드백을 반영하였습니다.

  ---

  ### ✨ Description

  - `wallet`, `wallet_ledger` 테이블 생성 마이그레이션을 추가했습니다.
    - `wallet`: 회원별 딜릿머니 잔액 관리
    - `wallet_ledger`: 충전/환불/출금 등 모든 금액 변동 내역 기록
  - 딜릿머니 API를 추가했습니다.
    - `GET /api/v1/wallet`: 내 지갑 조회
    - `GET /api/v1/wallet/ledgers`: 내 딜릿머니 내역 조회
    - `POST /api/v1/wallet/charge`: 임시 충전
    - `POST /api/v1/wallet/refund`: 환불
    - `POST /api/v1/wallet/withdraw`: 내 계좌로 옮기기
  - 금액 변경은 트랜잭션 안에서 잔액 업데이트와 원장 기록을 함께 처리하도록 구현했습니다.
  - 출금 시 잔액 부족 검증을 추가했습니다.
  - 테스트 프로필에서 Firebase 설정이 외부 `.env`에 의해 켜지는 문제를 방지하기 위해 `application-test.yml`에서 Firebase를 명시적으로 비활
  성화했습니다.

  검증:
  - `./gradlew compileJava` 성공
  - `./gradlew test --tests com.dealit.dealit.domain.wallet.WalletIntegrationTest` 성공
  - Docker 실행 시 Flyway `V5__create_wallet_tables.sql` 적용 확인
    - `wallet` 테이블 생성
    - `wallet_ledger` 테이블 생성
    - `flyway_schema_history` version `5` success 확인

관련 API 첨부:
<img width="1248" height="340" alt="image" src="https://github.com/user-attachments/assets/cdcf4df1-7f87-40d5-942a-da18a5cec440" />

### 🎲 Issue Number

<!-- Please enter {Issue Number} below to automatically close the connected issue. -->

close #47 
