### PR TITLE
[feat]   경매 SSE 이벤트 확장 및 입찰 현황 조회 API 구현

### DIFF
--- a/src/main/java/com/dealit/dealit/domain/auction/controller/AuctionManagementController.java
+++ b/src/main/java/com/dealit/dealit/domain/auction/controller/AuctionManagementController.java
@@ -1,6 +1,7 @@
 package com.dealit.dealit.domain.auction.controller;
 
 import com.dealit.dealit.domain.auction.dto.AuctionDetailResponse;
+import com.dealit.dealit.domain.auction.dto.AuctionBidHistoryResponse;
 import com.dealit.dealit.domain.auction.dto.BidRequest;
 import com.dealit.dealit.domain.auction.dto.BidResponse;
 import com.dealit.dealit.domain.auction.dto.AuctionEditDetailResponse;
@@ -53,6 +54,12 @@ public class AuctionManagementController {
 		@Valid @RequestBody BidRequest request
 	) {
 		return auctionBidService.bid(auctionId, member.memberId(), request.bidPrice());
+	}
+
+	@Operation(summary = "경매 입찰 현황 조회", description = "경매 현재가와 입찰 내역을 최신순으로 조회한다.")
+	@GetMapping("/auctions/{auctionId}/bids")
+	public AuctionBidHistoryResponse getBidHistory(@PathVariable Long auctionId) {
+		return auctionBidService.getBidHistory(auctionId);
 	}
 
 	@Operation(summary = "내 판매중 경매 목록", description = "마이페이지 판매중 화면에서 현재 사용자의 진행중 경매 목록을 페이징 조회한다.")

--- a/src/main/java/com/dealit/dealit/domain/auction/dto/AuctionBidHistoryResponse.java
+++ b/src/main/java/com/dealit/dealit/domain/auction/dto/AuctionBidHistoryResponse.java
@@ -1,0 +1,23 @@
+package com.dealit.dealit.domain.auction.dto;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record AuctionBidHistoryResponse(
+	Long auctionId,
+	BigDecimal currentPrice,
+	long bidCount,
+	List<BidHistoryItem> bids
+) {
+
+	public record BidHistoryItem(
+		Long bidId,
+		Long bidderId,
+		String bidderNickname,
+		BigDecimal bidPrice,
+		LocalDateTime bidAt,
+		boolean highest
+	) {
+	}
+}

--- a/src/main/java/com/dealit/dealit/domain/auction/dto/AuctionEventPayload.java
+++ b/src/main/java/com/dealit/dealit/domain/auction/dto/AuctionEventPayload.java
@@ -10,28 +10,94 @@ public final class AuctionEventPayload {
 	}
 
 	public record BidUpdated(
+		String type,
 		Long auctionId,
 		BigDecimal currentPrice,
 		Long bidderId,
 		OffsetDateTime serverTime
 	) {
+		public BidUpdated(Long auctionId, BigDecimal currentPrice, Long bidderId, OffsetDateTime serverTime) {
+			this("BID_UPDATED", auctionId, currentPrice, bidderId, serverTime);
+		}
 	}
 
 	public record Outbid(
+		String type,
 		Long auctionId,
 		Long previousBidderId,
 		Long newBidderId,
 		BigDecimal currentPrice,
 		OffsetDateTime serverTime
 	) {
+		public Outbid(
+			Long auctionId,
+			Long previousBidderId,
+			Long newBidderId,
+			BigDecimal currentPrice,
+			OffsetDateTime serverTime
+		) {
+			this("OUTBID", auctionId, previousBidderId, newBidderId, currentPrice, serverTime);
+		}
 	}
 
 	public record AuctionEnded(
+		String type,
 		Long auctionId,
 		Long winnerId,
 		BigDecimal finalPrice,
 		AuctionStatus status,
 		OffsetDateTime serverTime
 	) {
+		public AuctionEnded(
+			Long auctionId,
+			Long winnerId,
+			BigDecimal finalPrice,
+			AuctionStatus status,
+			OffsetDateTime serverTime
+		) {
+			this("AUCTION_ENDED", auctionId, winnerId, finalPrice, status, serverTime);
+		}
+	}
+
+	public record BidReceived(
+		String type,
+		Long auctionId,
+		Long bidderId,
+		BigDecimal currentPrice,
+		long bidCount,
+		boolean firstBid,
+		OffsetDateTime serverTime
+	) {
+		public BidReceived(
+			Long auctionId,
+			Long bidderId,
+			BigDecimal currentPrice,
+			long bidCount,
+			boolean firstBid,
+			OffsetDateTime serverTime
+		) {
+			this("BID_RECEIVED", auctionId, bidderId, currentPrice, bidCount, firstBid, serverTime);
+		}
+	}
+
+	public record AuctionBidUpdated(
+		String type,
+		Long auctionId,
+		BigDecimal currentPrice,
+		BigDecimal minimumNextBidPrice,
+		long bidCount,
+		long bidderCount,
+		OffsetDateTime serverTime
+	) {
+		public AuctionBidUpdated(
+			Long auctionId,
+			BigDecimal currentPrice,
+			BigDecimal minimumNextBidPrice,
+			long bidCount,
+			long bidderCount,
+			OffsetDateTime serverTime
+		) {
+			this("AUCTION_BID_UPDATED", auctionId, currentPrice, minimumNextBidPrice, bidCount, bidderCount, serverTime);
+		}
 	}
 }

--- a/src/main/java/com/dealit/dealit/domain/auction/event/AuctionEventPublisher.java
+++ b/src/main/java/com/dealit/dealit/domain/auction/event/AuctionEventPublisher.java
@@ -5,6 +5,9 @@ import com.dealit.dealit.domain.auction.dto.AuctionEventPayload;
 import com.dealit.dealit.global.event.service.EventStreamService;
 import java.math.BigDecimal;
 import java.time.OffsetDateTime;
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -29,7 +32,7 @@ public class AuctionEventPublisher {
 		BigDecimal currentPrice,
 		OffsetDateTime serverTime
 	) {
-		if (previousBidderId == null) {
+		if (previousBidderId == null || previousBidderId.equals(newBidderId)) {
 			return;
 		}
 		eventStreamService.publishRemote(
@@ -55,5 +58,53 @@ public class AuctionEventPublisher {
 			"AUCTION_ENDED",
 			new AuctionEventPayload.AuctionEnded(auctionId, winnerId, finalPrice, status, serverTime)
 		);
+	}
+
+	public void publishBidReceived(
+		Long sellerId,
+		Long auctionId,
+		Long bidderId,
+		BigDecimal currentPrice,
+		long bidCount,
+		boolean firstBid,
+		OffsetDateTime serverTime
+	) {
+		if (sellerId == null) {
+			return;
+		}
+		eventStreamService.publishRemote(
+			sellerId,
+			"BID_RECEIVED",
+			new AuctionEventPayload.BidReceived(auctionId, bidderId, currentPrice, bidCount, firstBid, serverTime)
+		);
+	}
+
+	public void publishAuctionBidUpdated(
+		Collection<Long> receiverIds,
+		Long auctionId,
+		BigDecimal currentPrice,
+		BigDecimal minimumNextBidPrice,
+		long bidCount,
+		long bidderCount,
+		OffsetDateTime serverTime
+	) {
+		Set<Long> uniqueReceiverIds = new LinkedHashSet<>(receiverIds);
+		for (Long receiverId : uniqueReceiverIds) {
+			if (receiverId == null) {
+				continue;
+			}
+			eventStreamService.publishRemote(
+				receiverId,
+				"AUCTION_BID_UPDATED",
+				new AuctionEventPayload.AuctionBidUpdated(
+					auctionId,
+					currentPrice,
+					minimumNextBidPrice,
+					bidCount,
+					bidderCount,
+					serverTime
+				)
+			);
+		}
 	}
 }

--- a/src/main/java/com/dealit/dealit/domain/auction/repository/BidRepository.java
+++ b/src/main/java/com/dealit/dealit/domain/auction/repository/BidRepository.java
@@ -1,6 +1,7 @@
 package com.dealit.dealit.domain.auction.repository;
 
 import com.dealit.dealit.domain.auction.entity.Bid;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
@@ -9,6 +10,8 @@ public interface BidRepository extends JpaRepository<Bid, Long> {
 	boolean existsByAuctionAuctionId(Long auctionId);
 
 	long countByAuctionAuctionId(Long auctionId);
+
+	List<Bid> findAllByAuctionAuctionIdOrderByCreatedAtDescBidIdDesc(Long auctionId);
 
 	@Query("select count(distinct b.bidderId) from Bid b where b.auction.auctionId = :auctionId")
 	long countDistinctBidderIdByAuctionId(Long auctionId);

--- a/src/main/java/com/dealit/dealit/domain/auction/service/AuctionBidService.java
+++ b/src/main/java/com/dealit/dealit/domain/auction/service/AuctionBidService.java
@@ -126,6 +126,9 @@ public class AuctionBidService {
 	@Transactional
 	public BidResponse bid(Long auctionId, Long bidderId, BigDecimal bidPrice) {
 		Auction auction = loadAuction(auctionId);
+		if (auction.getProduct().getMemberId().equals(bidderId)) {
+			throw new InvalidAuctionRequestException("자신이 등록한 경매에는 입찰할 수 없습니다.");
+		}
 		if (!auction.isOngoing()) {
 			throw new InvalidAuctionRequestException("이미 종료된 경매입니다.");
 		}

--- a/src/main/java/com/dealit/dealit/domain/auction/service/AuctionBidService.java
+++ b/src/main/java/com/dealit/dealit/domain/auction/service/AuctionBidService.java
@@ -4,6 +4,8 @@ import com.dealit.dealit.domain.auction.AuctionStatus;
 import com.dealit.dealit.domain.auction.dto.AuctionDetailResponse;
 import com.dealit.dealit.domain.auction.dto.AuctionDetailResponse.ImageResponse;
 import com.dealit.dealit.domain.auction.dto.AuctionDetailResponse.SellerResponse;
+import com.dealit.dealit.domain.auction.dto.AuctionBidHistoryResponse;
+import com.dealit.dealit.domain.auction.dto.AuctionBidHistoryResponse.BidHistoryItem;
 import com.dealit.dealit.domain.auction.dto.BidResponse;
 import com.dealit.dealit.domain.auction.entity.Auction;
 import com.dealit.dealit.domain.auction.entity.Category;
@@ -26,8 +28,12 @@ import java.math.BigDecimal;
 import java.time.Clock;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
+import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.RedisConnectionFailureException;
 import org.springframework.stereotype.Service;
@@ -87,6 +93,36 @@ public class AuctionBidService {
 		);
 	}
 
+	public AuctionBidHistoryResponse getBidHistory(Long auctionId) {
+		Auction auction = loadAuction(auctionId);
+		List<Bid> bids = bidRepository.findAllByAuctionAuctionIdOrderByCreatedAtDescBidIdDesc(auctionId);
+		Map<Long, Member> membersById = memberRepository.findAllByMemberIdInAndDeletedAtIsNull(
+				bids.stream().map(Bid::getBidderId).collect(Collectors.toSet())
+			)
+			.stream()
+			.collect(Collectors.toMap(Member::getMemberId, Function.identity()));
+
+		List<BidHistoryItem> bidItems = bids.stream()
+			.map(bid -> new BidHistoryItem(
+				bid.getBidId(),
+				bid.getBidderId(),
+				resolveBidderNickname(membersById.get(bid.getBidderId()), bid.getBidderId()),
+				bid.getBidPrice(),
+				bid.getCreatedAt(),
+				auction.getWinnerId() == null
+					? bid.getBidPrice().compareTo(auction.getCurrentPrice()) == 0
+					: bid.getBidderId().equals(auction.getWinnerId())
+			))
+			.toList();
+
+		return new AuctionBidHistoryResponse(
+			auctionId,
+			resolveDisplayCurrentPrice(auction, auction.getCurrentPrice()),
+			bidItems.size(),
+			bidItems
+		);
+	}
+
 	@Transactional
 	public BidResponse bid(Long auctionId, Long bidderId, BigDecimal bidPrice) {
 		Auction auction = loadAuction(auctionId);
@@ -108,8 +144,30 @@ public class AuctionBidService {
 				bidRepository.save(Bid.create(auction, bidderId, bidPrice));
 				auction.updateCurrentPrice(bidPrice);
 				OffsetDateTime serverTime = serverTime();
+				long bidCount = bidRepository.countByAuctionAuctionId(auction.getAuctionId());
+				long bidderCount = bidRepository.countDistinctBidderIdByAuctionId(auction.getAuctionId());
+				BigDecimal minimumNextBidPrice = bidPrice.add(auction.getMinimumBidAmount());
+				Long sellerId = auction.getProduct().getMemberId();
 				auctionEventPublisher.publishBidUpdated(auctionId, bidPrice, bidderId, serverTime);
 				auctionEventPublisher.publishOutbid(auctionId, result.previousBidderId(), bidderId, bidPrice, serverTime);
+				auctionEventPublisher.publishBidReceived(
+					sellerId,
+					auctionId,
+					bidderId,
+					bidPrice,
+					bidCount,
+					result.previousBidderId() == null,
+					serverTime
+				);
+				auctionEventPublisher.publishAuctionBidUpdated(
+					Arrays.asList(sellerId, bidderId, result.previousBidderId()),
+					auctionId,
+					bidPrice,
+					minimumNextBidPrice,
+					bidCount,
+					bidderCount,
+					serverTime
+				);
 				return new BidResponse(auctionId, bidPrice, bidderId, serverTime);
 			}
 		}
@@ -199,6 +257,13 @@ public class AuctionBidService {
 			? null
 			: imageUrlService.toPublicUrl(seller.getProfileImage());
 		return new SellerResponse(seller.getMemberId(), seller.getNickname(), profileImageUrl);
+	}
+
+	private String resolveBidderNickname(Member bidder, Long bidderId) {
+		if (bidder == null) {
+			return "입찰자 #" + bidderId;
+		}
+		return bidder.getNickname();
 	}
 
 	private BigDecimal resolveDisplayCurrentPrice(Auction auction, BigDecimal currentPrice) {

--- a/src/main/java/com/dealit/dealit/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/dealit/dealit/domain/member/repository/MemberRepository.java
@@ -4,6 +4,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.dealit.dealit.domain.member.entity.Member;
 
+import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
@@ -21,4 +23,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 	Optional<Member> findByLoginIdAndDeletedAtIsNull(String loginId);
 
 	Optional<Member> findByMemberIdAndDeletedAtIsNull(Long memberId);
+
+	List<Member> findAllByMemberIdInAndDeletedAtIsNull(Collection<Long> memberIds);
 }

--- a/src/test/java/com/dealit/dealit/domain/auction/AuctionBidServiceTest.java
+++ b/src/test/java/com/dealit/dealit/domain/auction/AuctionBidServiceTest.java
@@ -205,6 +205,28 @@ class AuctionBidServiceTest {
 		verify(bidRepository, never()).save(any(Bid.class));
 	}
 
+	@Test
+	@DisplayName("판매자는 자신이 등록한 경매에 입찰할 수 없다")
+	void bidFailsWhenBidderIsSeller() {
+		Long auctionId = 1L;
+		Long sellerId = 10L;
+		Auction auction = auction(sellerId);
+		when(auctionRepository.findByAuctionIdAndDeletedAtIsNullAndProductDeletedAtIsNull(auctionId))
+			.thenReturn(Optional.of(auction));
+
+		Object result;
+		try {
+			result = auctionBidService.bid(auctionId, sellerId, new BigDecimal("101000"));
+		} catch (InvalidAuctionRequestException exception) {
+			result = exception;
+		}
+
+		assertThat(result).isInstanceOf(InvalidAuctionRequestException.class);
+		assertThat(((InvalidAuctionRequestException) result).getMessage()).isEqualTo("자신이 등록한 경매에는 입찰할 수 없습니다.");
+		verify(auctionRedisService, never()).bid(anyLong(), any(BigDecimal.class), anyLong());
+		verify(bidRepository, never()).save(any(Bid.class));
+	}
+
 	private Object bidAfterStart(CountDownLatch start, Long auctionId, Long bidderId, BigDecimal bidPrice)
 		throws InterruptedException {
 		start.await();


### PR DESCRIPTION
  ### 🚀 Summary

  경매 SSE 이벤트 확장 및 입찰 현황 조회 API를 추가했습니다

  ---

  ### ✨ Description

  - 경매 SSE payload에 `type` 필드를 추가했습니다.
  - 기존 경매 이벤트를 유지했습니다.
    - `BID_UPDATED`
    - `OUTBID`
    - `AUCTION_ENDED`
  - 신규 경매 SSE 이벤트를 추가했습니다.
    - `BID_RECEIVED`: 판매자에게 첫 입찰/새 입찰 알림
    - `AUCTION_BID_UPDATED`: 관련 사용자에게 현재가, 최소 다음 입찰가, 입찰 수 갱신
  - 입찰 성공 시 관련 사용자에게 SSE 이벤트를 발행하도록 연결했습니다.
    - 판매자
    - 입찰자
    - 이전 최고입찰자
  - 입찰 현황 조회 API를 추가했습니다.
    - `GET /api/v1/auctions/{auctionId}/bids`
    - 현재가, 총 입찰 수, 최신순 입찰 기록 반환
  - 판매자가 자신이 등록한 경매에 입찰하지 못하도록 서버 검증을 추가했습니다.
  - 검증
    - `./gradlew compileJava test --tests com.dealit.dealit.domain.auction.AuctionBidServiceTest`

<img width="562" height="122" alt="image" src="https://github.com/user-attachments/assets/0f6701d2-3240-483d-b427-120d601d057e" />


### 🎲 Issue Number

<!-- Please enter {Issue Number} below to automatically close the connected issue. -->

close #51
