### PR TITLE
[feat] 경매 인기/마감임박 목록 api 추가

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1131,6 +1131,50 @@ paths:
             '*/*':
               schema:
                 $ref: "#/components/schemas/LoginResponse"
+  /api/v1/auctions/popular:
+    get:
+      tags:
+      - Auction
+      summary: 실시간 인기 경매 목록 조회
+      description: 입찰 수를 등록 후 경과 시간으로 나눈 점수 기준으로 진행 중인 경매를 조회한다.
+      operationId: getPopularAuctions
+      parameters:
+      - name: limit
+        in: query
+        required: false
+        schema:
+          type: integer
+          format: int32
+          default: 4
+      responses:
+        "200":
+          description: 실시간 인기 경매 목록 조회 성공
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/AuctionListResponse"
+  /api/v1/auctions/closing-soon:
+    get:
+      tags:
+      - Auction
+      summary: 마감임박 경매 목록 조회
+      description: 현재 서버 시간 기준 종료 시각이 가까운 진행 중 경매를 조회한다.
+      operationId: getClosingSoonAuctions
+      parameters:
+      - name: limit
+        in: query
+        required: false
+        schema:
+          type: integer
+          format: int32
+          default: 3
+      responses:
+        "200":
+          description: 마감임박 경매 목록 조회 성공
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/AuctionListResponse"
   /api/v1/auctions/{auctionId}/bids:
     post:
       tags:
@@ -4895,6 +4939,93 @@ components:
           type: boolean
           description: 이메일 인증 여부
           example: false
+    AuctionListResponse:
+      type: object
+      description: 경매 상품 목록 응답
+      properties:
+        content:
+          type: array
+          description: 경매 상품 목록
+          items:
+            $ref: "#/components/schemas/AuctionListItemResponse"
+    AuctionListItemResponse:
+      type: object
+      description: 경매 상품 목록 항목
+      properties:
+        auctionId:
+          type: integer
+          format: int64
+          description: 경매 ID
+          example: 1
+        productId:
+          type: integer
+          format: int64
+          description: 상품 ID
+          example: 1
+        title:
+          type: string
+          description: 상품명
+          example: 맥북 에어 경매
+        thumbnailUrl:
+          type: string
+          description: 대표 이미지 URL
+          example: http://localhost:8080/uploads/auction/images/1.jpg
+        startPrice:
+          type: number
+          description: 시작가
+          example: 10000
+        currentPrice:
+          type: number
+          description: 현재 입찰가
+          example: 35000
+        bidCount:
+          type: integer
+          format: int64
+          description: 입찰 수
+          example: 12
+        endAt:
+          type: string
+          format: date-time
+          description: 경매 종료 시각
+          example: 2026-05-06T18:00:00+09:00
+        auctionStatus:
+          type: string
+          description: 경매 상태
+          enum:
+          - DRAFT
+          - ONGOING
+          - ENDED
+          - NO_BID
+          - SUCCESSFUL_BID
+          example: ONGOING
+        location:
+          type: string
+          description: 거래 위치
+          example: 서울 강남구
+        categoryName:
+          type: string
+          description: 카테고리명
+          example: 디지털기기
+        sellerId:
+          type: integer
+          format: int64
+          description: 판매자 회원 ID
+          example: 10
+        popularScore:
+          type: number
+          format: double
+          description: 경매 인기 점수
+          example: 4.5
+        rank:
+          type: integer
+          format: int32
+          description: 순위
+          example: 1
+        createdAt:
+          type: string
+          format: date-time
+          description: 등록 시각
+          example: 2026-05-03T12:00:00+09:00
     AuctionDetailResponse:
       type: object
       properties:

--- a/src/main/java/com/dealit/dealit/domain/auction/controller/AuctionManagementController.java
+++ b/src/main/java/com/dealit/dealit/domain/auction/controller/AuctionManagementController.java
@@ -2,6 +2,7 @@ package com.dealit.dealit.domain.auction.controller;
 
 import com.dealit.dealit.domain.auction.dto.AuctionDetailResponse;
 import com.dealit.dealit.domain.auction.dto.AuctionBidHistoryResponse;
+import com.dealit.dealit.domain.auction.dto.AuctionListResponse;
 import com.dealit.dealit.domain.auction.dto.BidRequest;
 import com.dealit.dealit.domain.auction.dto.BidResponse;
 import com.dealit.dealit.domain.auction.dto.AuctionEditDetailResponse;
@@ -39,6 +40,22 @@ public class AuctionManagementController {
 
 	private final AuctionService auctionService;
 	private final AuctionBidService auctionBidService;
+
+	@Operation(summary = "실시간 인기 경매 목록 조회", description = "입찰 수를 등록 후 경과 시간으로 나눈 점수 기준으로 진행 중인 경매를 조회한다.")
+	@ApiResponse(responseCode = "200", description = "실시간 인기 경매 목록 조회 성공",
+		content = @Content(schema = @Schema(implementation = AuctionListResponse.class)))
+	@GetMapping("/auctions/popular")
+	public AuctionListResponse getPopularAuctions(@RequestParam(defaultValue = "4") int limit) {
+		return auctionService.getPopularAuctions(limit);
+	}
+
+	@Operation(summary = "마감임박 경매 목록 조회", description = "현재 서버 시간 기준 종료 시각이 가까운 진행 중 경매를 조회한다.")
+	@ApiResponse(responseCode = "200", description = "마감임박 경매 목록 조회 성공",
+		content = @Content(schema = @Schema(implementation = AuctionListResponse.class)))
+	@GetMapping("/auctions/closing-soon")
+	public AuctionListResponse getClosingSoonAuctions(@RequestParam(defaultValue = "3") int limit) {
+		return auctionService.getClosingSoonAuctions(limit);
+	}
 
 	@Operation(summary = "경매 상세 조회", description = "경매 현재가와 서버 시간을 조회한다.")
 	@GetMapping("/auctions/{auctionId}")

--- a/src/main/java/com/dealit/dealit/domain/auction/controller/AuctionManagementController.java
+++ b/src/main/java/com/dealit/dealit/domain/auction/controller/AuctionManagementController.java
@@ -58,13 +58,13 @@ public class AuctionManagementController {
 	}
 
 	@Operation(summary = "경매 상세 조회", description = "경매 현재가와 서버 시간을 조회한다.")
-	@GetMapping("/auctions/{auctionId}")
+	@GetMapping("/auctions/{auctionId:\\d+}")
 	public AuctionDetailResponse getAuction(@PathVariable Long auctionId) {
 		return auctionBidService.getAuction(auctionId);
 	}
 
 	@Operation(summary = "경매 입찰", description = "서버 도착 시간 기준으로 입찰을 처리한다.")
-	@PostMapping("/auctions/{auctionId}/bids")
+	@PostMapping("/auctions/{auctionId:\\d+}/bids")
 	public BidResponse bid(
 		@AuthenticationPrincipal AuthenticatedMember member,
 		@PathVariable Long auctionId,
@@ -74,7 +74,7 @@ public class AuctionManagementController {
 	}
 
 	@Operation(summary = "경매 입찰 현황 조회", description = "경매 현재가와 입찰 내역을 최신순으로 조회한다.")
-	@GetMapping("/auctions/{auctionId}/bids")
+	@GetMapping("/auctions/{auctionId:\\d+}/bids")
 	public AuctionBidHistoryResponse getBidHistory(@PathVariable Long auctionId) {
 		return auctionBidService.getBidHistory(auctionId);
 	}
@@ -94,7 +94,7 @@ public class AuctionManagementController {
 	@Operation(summary = "경매 수정용 상세 조회", description = "현재 사용자가 등록한 경매의 수정 화면 데이터를 조회한다.")
 	@ApiResponse(responseCode = "200", description = "경매 수정용 상세 조회 성공",
 		content = @Content(schema = @Schema(implementation = AuctionEditDetailResponse.class)))
-	@GetMapping("/auctions/{auctionId}/edit")
+	@GetMapping("/auctions/{auctionId:\\d+}/edit")
 	public AuctionEditDetailResponse getAuctionEditDetail(
 		@AuthenticationPrincipal AuthenticatedMember member,
 		@PathVariable Long auctionId
@@ -106,7 +106,7 @@ public class AuctionManagementController {
 	@ApiResponse(responseCode = "200", description = "경매 수정 성공",
 		content = @Content(schema = @Schema(implementation = AuctionEditDetailResponse.class)))
 	@ApiResponse(responseCode = "409", description = "입찰자가 있는 경매는 수정 불가")
-	@PatchMapping("/auctions/{auctionId}")
+	@PatchMapping("/auctions/{auctionId:\\d+}")
 	public AuctionEditDetailResponse updateAuction(
 		@AuthenticationPrincipal AuthenticatedMember member,
 		@PathVariable Long auctionId,
@@ -118,7 +118,7 @@ public class AuctionManagementController {
 	@Operation(summary = "경매 삭제", description = "입찰이 없는 현재 사용자의 경매를 삭제한다.")
 	@ApiResponse(responseCode = "204", description = "경매 삭제 성공")
 	@ApiResponse(responseCode = "409", description = "입찰자가 있는 경매는 삭제 불가")
-	@DeleteMapping("/auctions/{auctionId}")
+	@DeleteMapping("/auctions/{auctionId:\\d+}")
 	@ResponseStatus(HttpStatus.NO_CONTENT)
 	public void deleteAuction(
 		@AuthenticationPrincipal AuthenticatedMember member,

--- a/src/main/java/com/dealit/dealit/domain/auction/dto/AuctionListItemResponse.java
+++ b/src/main/java/com/dealit/dealit/domain/auction/dto/AuctionListItemResponse.java
@@ -1,0 +1,56 @@
+package com.dealit.dealit.domain.auction.dto;
+
+import com.dealit.dealit.domain.auction.AuctionStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+
+@Schema(description = "경매 상품 목록 항목")
+public record AuctionListItemResponse(
+	@Schema(description = "경매 ID", example = "1")
+	Long auctionId,
+
+	@Schema(description = "상품 ID", example = "1")
+	Long productId,
+
+	@Schema(description = "상품명", example = "맥북 에어 경매")
+	String title,
+
+	@Schema(description = "대표 이미지 URL", example = "http://localhost:8080/uploads/auction/images/1.jpg")
+	String thumbnailUrl,
+
+	@Schema(description = "시작가", example = "10000")
+	BigDecimal startPrice,
+
+	@Schema(description = "현재 입찰가", example = "35000")
+	BigDecimal currentPrice,
+
+	@Schema(description = "입찰 수", example = "12")
+	long bidCount,
+
+	@Schema(description = "경매 종료 시각", example = "2026-05-06T18:00:00+09:00")
+	OffsetDateTime endAt,
+
+	@Schema(description = "경매 상태", example = "ONGOING")
+	AuctionStatus auctionStatus,
+
+	@Schema(description = "거래 위치", example = "서울 강남구")
+	String location,
+
+	@Schema(description = "카테고리명", example = "디지털기기")
+	String categoryName,
+
+	@Schema(description = "판매자 회원 ID", example = "10")
+	Long sellerId,
+
+	@Schema(description = "경매 인기 점수", example = "4.5")
+	double popularScore,
+
+	@Schema(description = "순위", example = "1")
+	int rank,
+
+	@Schema(description = "등록 시각", example = "2026-05-03T12:00:00+09:00")
+	OffsetDateTime createdAt
+) {
+}

--- a/src/main/java/com/dealit/dealit/domain/auction/dto/AuctionListResponse.java
+++ b/src/main/java/com/dealit/dealit/domain/auction/dto/AuctionListResponse.java
@@ -1,0 +1,12 @@
+package com.dealit.dealit.domain.auction.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+@Schema(description = "경매 상품 목록 응답")
+public record AuctionListResponse(
+	@Schema(description = "경매 상품 목록")
+	List<AuctionListItemResponse> content
+) {
+}

--- a/src/main/java/com/dealit/dealit/domain/auction/repository/AuctionRankProjection.java
+++ b/src/main/java/com/dealit/dealit/domain/auction/repository/AuctionRankProjection.java
@@ -1,14 +1,14 @@
 package com.dealit.dealit.domain.auction.repository;
 
-import com.dealit.dealit.domain.auction.entity.Auction;
-
 import java.time.LocalDateTime;
 
 public interface AuctionRankProjection {
 
-	Auction getAuction();
+	Long getAuctionId();
 
-	long getBidCount();
+	Number getBidCount();
 
 	LocalDateTime getLatestBidAt();
+
+	Number getPopularScore();
 }

--- a/src/main/java/com/dealit/dealit/domain/auction/repository/AuctionRankProjection.java
+++ b/src/main/java/com/dealit/dealit/domain/auction/repository/AuctionRankProjection.java
@@ -1,0 +1,14 @@
+package com.dealit.dealit.domain.auction.repository;
+
+import com.dealit.dealit.domain.auction.entity.Auction;
+
+import java.time.LocalDateTime;
+
+public interface AuctionRankProjection {
+
+	Auction getAuction();
+
+	long getBidCount();
+
+	LocalDateTime getLatestBidAt();
+}

--- a/src/main/java/com/dealit/dealit/domain/auction/repository/AuctionRepository.java
+++ b/src/main/java/com/dealit/dealit/domain/auction/repository/AuctionRepository.java
@@ -6,7 +6,11 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.time.OffsetDateTime;
+import java.util.List;
 import java.util.Optional;
 
 public interface AuctionRepository extends JpaRepository<Auction, Long> {
@@ -32,4 +36,36 @@ public interface AuctionRepository extends JpaRepository<Auction, Long> {
 
 	@EntityGraph(attributePaths = {"product", "product.images"})
 	Optional<Auction> findDetailByAuctionIdAndDeletedAtIsNullAndProductDeletedAtIsNull(Long auctionId);
+
+	@Query("""
+		select a as auction, count(b) as bidCount, max(b.createdAt) as latestBidAt
+		from Auction a
+		left join Bid b on b.auction = a and b.deletedAt is null
+		where a.status = :status
+			and a.endsAt > :now
+			and a.deletedAt is null
+			and a.product.deletedAt is null
+		group by a
+		""")
+	List<AuctionRankProjection> findOngoingAuctionRanks(
+		@Param("status") AuctionStatus status,
+		@Param("now") OffsetDateTime now
+	);
+
+	@Query("""
+		select a as auction, count(b) as bidCount, max(b.createdAt) as latestBidAt
+		from Auction a
+		left join Bid b on b.auction = a and b.deletedAt is null
+		where a.status = :status
+			and a.endsAt > :now
+			and a.deletedAt is null
+			and a.product.deletedAt is null
+		group by a
+		order by a.endsAt asc, count(b) desc, a.createdAt desc, a.auctionId desc
+		""")
+	List<AuctionRankProjection> findClosingSoonAuctionRanks(
+		@Param("status") AuctionStatus status,
+		@Param("now") OffsetDateTime now,
+		Pageable pageable
+	);
 }

--- a/src/main/java/com/dealit/dealit/domain/auction/repository/AuctionRepository.java
+++ b/src/main/java/com/dealit/dealit/domain/auction/repository/AuctionRepository.java
@@ -10,6 +10,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.time.OffsetDateTime;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
@@ -37,34 +38,58 @@ public interface AuctionRepository extends JpaRepository<Auction, Long> {
 	@EntityGraph(attributePaths = {"product", "product.images"})
 	Optional<Auction> findDetailByAuctionIdAndDeletedAtIsNullAndProductDeletedAtIsNull(Long auctionId);
 
-	@Query("""
-		select a as auction, count(b) as bidCount, max(b.createdAt) as latestBidAt
-		from Auction a
-		left join Bid b on b.auction = a and b.deletedAt is null
+	@EntityGraph(attributePaths = {"product", "product.images"})
+	List<Auction> findAllByAuctionIdInAndDeletedAtIsNullAndProductDeletedAtIsNull(Collection<Long> auctionIds);
+
+	@Query(value = """
+		select
+			a.auction_id as auctionId,
+			count(b.bid_id) as bidCount,
+			max(b.created_at) as latestBidAt,
+			cast(count(b.bid_id) as double precision)
+				/ greatest(1.0, extract(epoch from (cast(:now as timestamp) - p.created_at)) / 3600.0) as popularScore
+		from auction a
+		join product p on p.product_id = a.product_id
+		left join bid b on b.auction_id = a.auction_id and b.deleted_at is null
 		where a.status = :status
-			and a.endsAt > :now
-			and a.deletedAt is null
-			and a.product.deletedAt is null
-		group by a
-		""")
+			and a.ends_at > :now
+			and a.deleted_at is null
+			and p.deleted_at is null
+		group by a.auction_id, p.created_at
+		order by popularScore desc,
+			count(b.bid_id) desc,
+			max(b.created_at) desc nulls last,
+			p.created_at desc,
+			a.auction_id desc
+		""", nativeQuery = true)
 	List<AuctionRankProjection> findOngoingAuctionRanks(
-		@Param("status") AuctionStatus status,
-		@Param("now") OffsetDateTime now
+		@Param("status") String status,
+		@Param("now") OffsetDateTime now,
+		Pageable pageable
 	);
 
-	@Query("""
-		select a as auction, count(b) as bidCount, max(b.createdAt) as latestBidAt
-		from Auction a
-		left join Bid b on b.auction = a and b.deletedAt is null
+	@Query(value = """
+		select
+			a.auction_id as auctionId,
+			count(b.bid_id) as bidCount,
+			max(b.created_at) as latestBidAt,
+			cast(count(b.bid_id) as double precision)
+				/ greatest(1.0, extract(epoch from (cast(:now as timestamp) - p.created_at)) / 3600.0) as popularScore
+		from auction a
+		join product p on p.product_id = a.product_id
+		left join bid b on b.auction_id = a.auction_id and b.deleted_at is null
 		where a.status = :status
-			and a.endsAt > :now
-			and a.deletedAt is null
-			and a.product.deletedAt is null
-		group by a
-		order by a.endsAt asc, count(b) desc, a.createdAt desc, a.auctionId desc
-		""")
+			and a.ends_at > :now
+			and a.deleted_at is null
+			and p.deleted_at is null
+		group by a.auction_id, p.created_at
+		order by a.ends_at asc,
+			count(b.bid_id) desc,
+			p.created_at desc,
+			a.auction_id desc
+		""", nativeQuery = true)
 	List<AuctionRankProjection> findClosingSoonAuctionRanks(
-		@Param("status") AuctionStatus status,
+		@Param("status") String status,
 		@Param("now") OffsetDateTime now,
 		Pageable pageable
 	);

--- a/src/main/java/com/dealit/dealit/domain/auction/service/AuctionService.java
+++ b/src/main/java/com/dealit/dealit/domain/auction/service/AuctionService.java
@@ -64,7 +64,6 @@ import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.util.Collection;
-import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -94,40 +93,28 @@ public class AuctionService {
 		int normalizedLimit = normalizeLimit(limit);
 		OffsetDateTime now = OffsetDateTime.now(clock);
 		List<AuctionRankProjection> rankedAuctions = auctionRepository.findOngoingAuctionRanks(
-			AuctionStatus.ONGOING,
-			now
+			AuctionStatus.ONGOING.name(),
+			now,
+			PageRequest.of(0, normalizedLimit)
 		);
 
-		Map<Long, String> categoryNamesById = loadCategoryNamesFromAuctions(
-			rankedAuctions.stream()
-				.map(AuctionRankProjection::getAuction)
-				.toList()
-		);
-
-		List<AuctionRankProjection> content = rankedAuctions.stream()
-			.sorted(this::comparePopularAuctionRanks)
-			.limit(normalizedLimit)
-			.toList();
-
-		return new AuctionListResponse(toAuctionListItems(content, categoryNamesById));
+		List<Auction> auctions = loadRankedAuctions(rankedAuctions);
+		Map<Long, String> categoryNamesById = loadCategoryNamesFromAuctions(auctions);
+		return new AuctionListResponse(toAuctionListItems(rankedAuctions, auctions, categoryNamesById));
 	}
 
 	public AuctionListResponse getClosingSoonAuctions(int limit) {
 		int normalizedLimit = normalizeLimit(limit);
 		OffsetDateTime now = OffsetDateTime.now(clock);
 		List<AuctionRankProjection> rankedAuctions = auctionRepository.findClosingSoonAuctionRanks(
-			AuctionStatus.ONGOING,
+			AuctionStatus.ONGOING.name(),
 			now,
 			PageRequest.of(0, normalizedLimit)
 		);
 
-		Map<Long, String> categoryNamesById = loadCategoryNamesFromAuctions(
-			rankedAuctions.stream()
-				.map(AuctionRankProjection::getAuction)
-				.toList()
-		);
-
-		return new AuctionListResponse(toAuctionListItems(rankedAuctions, categoryNamesById));
+		List<Auction> auctions = loadRankedAuctions(rankedAuctions);
+		Map<Long, String> categoryNamesById = loadCategoryNamesFromAuctions(auctions);
+		return new AuctionListResponse(toAuctionListItems(rankedAuctions, auctions, categoryNamesById));
 	}
 
 	public MySellingAuctionListResponse getMySellingAuctionProducts(Long memberId, int page, int size) {
@@ -351,21 +338,31 @@ public class AuctionService {
 
 	private List<AuctionListItemResponse> toAuctionListItems(
 		List<AuctionRankProjection> rankedAuctions,
+		List<Auction> auctions,
 		Map<Long, String> categoryNamesById
 	) {
+		Map<Long, Auction> auctionsById = new LinkedHashMap<>();
+		for (Auction auction : auctions) {
+			auctionsById.put(auction.getAuctionId(), auction);
+		}
+
 		List<AuctionListItemResponse> content = new ArrayList<>();
 		for (int index = 0; index < rankedAuctions.size(); index++) {
-			content.add(toAuctionListItemResponse(rankedAuctions.get(index), categoryNamesById, index + 1));
+			AuctionRankProjection rank = rankedAuctions.get(index);
+			Auction auction = auctionsById.get(rank.getAuctionId());
+			if (auction != null) {
+				content.add(toAuctionListItemResponse(rank, auction, categoryNamesById, index + 1));
+			}
 		}
 		return content;
 	}
 
 	private AuctionListItemResponse toAuctionListItemResponse(
 		AuctionRankProjection rank,
+		Auction auction,
 		Map<Long, String> categoryNamesById,
 		int displayRank
 	) {
-		Auction auction = rank.getAuction();
 		Product product = auction.getProduct();
 		return new AuctionListItemResponse(
 			auction.getAuctionId(),
@@ -374,43 +371,34 @@ public class AuctionService {
 			resolveThumbnailUrl(product),
 			auction.getStartPrice(),
 			resolveCurrentPrice(auction),
-			rank.getBidCount(),
+			toLong(rank.getBidCount()),
 			toSeoulOffsetDateTime(auction.getAuctionEndAt()),
 			auction.getStatus(),
 			product.getLocation(),
 			categoryNamesById.getOrDefault(product.getCategoryId(), ""),
 			product.getMemberId(),
-			calculateAuctionPopularScore(rank),
+			toDouble(rank.getPopularScore()),
 			displayRank,
 			toSeoulOffsetDateTime(product.getCreatedAt())
 		);
 	}
 
-	private int comparePopularAuctionRanks(AuctionRankProjection left, AuctionRankProjection right) {
-		return Comparator.comparingDouble(this::calculateAuctionPopularScore)
-			.reversed()
-			.thenComparing(AuctionRankProjection::getBidCount, Comparator.reverseOrder())
-			.thenComparing(AuctionRankProjection::getLatestBidAt, Comparator.nullsLast(Comparator.reverseOrder()))
-			.thenComparing(rank -> rank.getAuction().getProduct().getCreatedAt(), Comparator.nullsLast(Comparator.reverseOrder()))
-			.thenComparing(rank -> rank.getAuction().getAuctionId(), Comparator.reverseOrder())
-			.compare(left, right);
+	private List<Auction> loadRankedAuctions(List<AuctionRankProjection> ranks) {
+		List<Long> auctionIds = ranks.stream()
+			.map(AuctionRankProjection::getAuctionId)
+			.toList();
+		if (auctionIds.isEmpty()) {
+			return List.of();
+		}
+		return auctionRepository.findAllByAuctionIdInAndDeletedAtIsNullAndProductDeletedAtIsNull(auctionIds);
 	}
 
-	private double calculateAuctionPopularScore(AuctionRankProjection rank) {
-		if (rank.getBidCount() <= 0) {
-			return 0.0;
-		}
+	private long toLong(Number value) {
+		return value == null ? 0L : value.longValue();
+	}
 
-		LocalDateTime createdAt = rank.getAuction().getProduct().getCreatedAt();
-		if (createdAt == null) {
-			return (double) rank.getBidCount();
-		}
-
-		long elapsedHours = Math.max(
-			1L,
-			Duration.between(createdAt, LocalDateTime.now(clock.withZone(SEOUL_ZONE))).toHours()
-		);
-		return (double) rank.getBidCount() / elapsedHours;
+	private double toDouble(Number value) {
+		return value == null ? 0.0 : value.doubleValue();
 	}
 
 	private int normalizeLimit(int limit) {

--- a/src/main/java/com/dealit/dealit/domain/auction/service/AuctionService.java
+++ b/src/main/java/com/dealit/dealit/domain/auction/service/AuctionService.java
@@ -4,6 +4,8 @@ import com.dealit.dealit.domain.auction.AuctionStatus;
 import com.dealit.dealit.domain.auction.ProductSaleType;
 import com.dealit.dealit.domain.auction.dto.AuctionEditDetailResponse;
 import com.dealit.dealit.domain.auction.dto.AuctionEditDetailResponse.AuctionEditImageResponse;
+import com.dealit.dealit.domain.auction.dto.AuctionListItemResponse;
+import com.dealit.dealit.domain.auction.dto.AuctionListResponse;
 import com.dealit.dealit.domain.auction.dto.CategoryOptionResponse;
 import com.dealit.dealit.domain.auction.dto.CreateAuctionRequest;
 import com.dealit.dealit.domain.auction.dto.CreateAuctionResponse;
@@ -31,6 +33,7 @@ import com.dealit.dealit.domain.auction.exception.InvalidAuctionRequestException
 import com.dealit.dealit.domain.auction.redis.AuctionRedisService;
 import com.dealit.dealit.domain.auction.repository.AuctionRepository;
 import com.dealit.dealit.domain.auction.repository.AuctionDraftRepository;
+import com.dealit.dealit.domain.auction.repository.AuctionRankProjection;
 import com.dealit.dealit.domain.auction.repository.BidRepository;
 import com.dealit.dealit.domain.auction.repository.CategoryRepository;
 import com.dealit.dealit.domain.member.entity.Member;
@@ -61,6 +64,7 @@ import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -85,6 +89,46 @@ public class AuctionService {
 	private final ObjectMapper objectMapper;
 	private final AuctionRedisService auctionRedisService;
 	private final Clock clock;
+
+	public AuctionListResponse getPopularAuctions(int limit) {
+		int normalizedLimit = normalizeLimit(limit);
+		OffsetDateTime now = OffsetDateTime.now(clock);
+		List<AuctionRankProjection> rankedAuctions = auctionRepository.findOngoingAuctionRanks(
+			AuctionStatus.ONGOING,
+			now
+		);
+
+		Map<Long, String> categoryNamesById = loadCategoryNamesFromAuctions(
+			rankedAuctions.stream()
+				.map(AuctionRankProjection::getAuction)
+				.toList()
+		);
+
+		List<AuctionRankProjection> content = rankedAuctions.stream()
+			.sorted(this::comparePopularAuctionRanks)
+			.limit(normalizedLimit)
+			.toList();
+
+		return new AuctionListResponse(toAuctionListItems(content, categoryNamesById));
+	}
+
+	public AuctionListResponse getClosingSoonAuctions(int limit) {
+		int normalizedLimit = normalizeLimit(limit);
+		OffsetDateTime now = OffsetDateTime.now(clock);
+		List<AuctionRankProjection> rankedAuctions = auctionRepository.findClosingSoonAuctionRanks(
+			AuctionStatus.ONGOING,
+			now,
+			PageRequest.of(0, normalizedLimit)
+		);
+
+		Map<Long, String> categoryNamesById = loadCategoryNamesFromAuctions(
+			rankedAuctions.stream()
+				.map(AuctionRankProjection::getAuction)
+				.toList()
+		);
+
+		return new AuctionListResponse(toAuctionListItems(rankedAuctions, categoryNamesById));
+	}
 
 	public MySellingAuctionListResponse getMySellingAuctionProducts(Long memberId, int page, int size) {
 		loadActiveMember(memberId);
@@ -303,6 +347,74 @@ public class AuctionService {
 		categoryRepository.findAllById(categoryIds)
 			.forEach(category -> categoryNamesById.put(category.getId(), category.getNameKo()));
 		return categoryNamesById;
+	}
+
+	private List<AuctionListItemResponse> toAuctionListItems(
+		List<AuctionRankProjection> rankedAuctions,
+		Map<Long, String> categoryNamesById
+	) {
+		List<AuctionListItemResponse> content = new ArrayList<>();
+		for (int index = 0; index < rankedAuctions.size(); index++) {
+			content.add(toAuctionListItemResponse(rankedAuctions.get(index), categoryNamesById, index + 1));
+		}
+		return content;
+	}
+
+	private AuctionListItemResponse toAuctionListItemResponse(
+		AuctionRankProjection rank,
+		Map<Long, String> categoryNamesById,
+		int displayRank
+	) {
+		Auction auction = rank.getAuction();
+		Product product = auction.getProduct();
+		return new AuctionListItemResponse(
+			auction.getAuctionId(),
+			product.getProductId(),
+			product.getName(),
+			resolveThumbnailUrl(product),
+			auction.getStartPrice(),
+			resolveCurrentPrice(auction),
+			rank.getBidCount(),
+			toSeoulOffsetDateTime(auction.getAuctionEndAt()),
+			auction.getStatus(),
+			product.getLocation(),
+			categoryNamesById.getOrDefault(product.getCategoryId(), ""),
+			product.getMemberId(),
+			calculateAuctionPopularScore(rank),
+			displayRank,
+			toSeoulOffsetDateTime(product.getCreatedAt())
+		);
+	}
+
+	private int comparePopularAuctionRanks(AuctionRankProjection left, AuctionRankProjection right) {
+		return Comparator.comparingDouble(this::calculateAuctionPopularScore)
+			.reversed()
+			.thenComparing(AuctionRankProjection::getBidCount, Comparator.reverseOrder())
+			.thenComparing(AuctionRankProjection::getLatestBidAt, Comparator.nullsLast(Comparator.reverseOrder()))
+			.thenComparing(rank -> rank.getAuction().getProduct().getCreatedAt(), Comparator.nullsLast(Comparator.reverseOrder()))
+			.thenComparing(rank -> rank.getAuction().getAuctionId(), Comparator.reverseOrder())
+			.compare(left, right);
+	}
+
+	private double calculateAuctionPopularScore(AuctionRankProjection rank) {
+		if (rank.getBidCount() <= 0) {
+			return 0.0;
+		}
+
+		LocalDateTime createdAt = rank.getAuction().getProduct().getCreatedAt();
+		if (createdAt == null) {
+			return (double) rank.getBidCount();
+		}
+
+		long elapsedHours = Math.max(
+			1L,
+			Duration.between(createdAt, LocalDateTime.now(clock.withZone(SEOUL_ZONE))).toHours()
+		);
+		return (double) rank.getBidCount() / elapsedHours;
+	}
+
+	private int normalizeLimit(int limit) {
+		return Math.min(Math.max(limit, 1), 100);
 	}
 
 	private String resolveThumbnailUrl(Product product) {


### PR DESCRIPTION
### 🚀 Summary

<!-- 작업 내용에 대한 간략한 설명을 써주세요. -->
- 경매 실시간인기/마감임박 api 추가
---

### ✨ Description

<!-- 상세한 설명, 기능의 사용법, 주의 사항 실행 결과(이미지 첨부 가능) 등을 보여주세요. -->
## 작업 내용

- 경매 목록 조회 API 추가
  - GET /api/v1/auctions/popular?limit=4
  - GET /api/v1/auctions/closing-soon?limit=3

- 실시간 인기 경매 정렬 기준 구현
  - 진행 중인 경매만 조회
  - 이미 종료된 경매 제외: endsAt > now
  - 인기 점수: bidCount / 등록 후 경과 시간
  - 동점 처리:
    - bidCount DESC
    - 최신 입찰 시각 DESC
    - 상품 등록 최신순 DESC
    - auctionId DESC

- 마감임박 경매 정렬 기준 구현
  - 진행 중인 경매만 조회
  - 이미 종료된 경매 제외
  - endsAt ASC
  - 동점 시 `bidCount DESC`, 등록 최신순, auctionId 순으로 정렬

- 경매 목록 응답 DTO 추가
  - AuctionListResponse
  - AuctionListItemResponse
  - 포함 필드:
    - `auctionId`
    - `productId`
    - `title`
    - `thumbnailUrl`
    - `startPrice`
    - `currentPrice`
    - `bidCount`
    - `endAt`
    - `auctionStatus`
    - `location`
    - `categoryName`
    - `sellerId`
    - `popularScore`
    - `rank`
    - `createdAt`

- OpenAPI 문서 반영
  - docs/openapi.yaml에 신규 endpoint/schema 추가

- 경매 목록 조회 성능 개선
  - 랭킹 쿼리에서는 `auctionId`, `bidCount`, `latestBidAt`, `popularScore`만 조회
  - 최종 `auctionId` 목록만 다시 조회
  - 최종 조회 시 `@EntityGraph(attributePaths = {"product", "product.images"})` 적용
  - DTO 변환 시 `product/images` 접근으로 인한 N+1 문제 방지
  - 카테고리명 조회도 최종 결과 목록 기준으로만 수행
## 구현 기준

- 일반상품 인기 목록의 시간 보정 방식과 같은 맥락으로 구현
- 일반상품은 조회/찜 기반 기존 로직 유지
- 경매상품은 입찰 수 기반으로 인기 점수 계산
- 서버 시간은 기존 Clock bean 기준 사용
- limit 파라미터는 1~100 범위로 보정

## 테스트

- ./gradlew compileJava
- ./gradlew test --tests com.dealit.dealit.DealitApplicationTests

PS. 구현 사진은 프론트pr에 첨부하였습니다
---

### 🎲 Issue Number

<!-- Please enter {Issue Number} below to automatically close the connected issue. -->

close #56 