### PR TITLE
[feat] 경매 보증금 예치 및 추월 환불 프로세스 구현

### DIFF
--- a/docs/auction-payment-status.md
+++ b/docs/auction-payment-status.md
@@ -1,0 +1,13 @@
+# Auction Payment Status
+
+경매 입찰 예치금과 정산 상태는 `AuctionPaymentStatus`로 관리한다.
+
+| Status | Description |
+| --- | --- |
+| `RESERVED` | 입찰 금액이 지갑에서 차감되어 예치 중인 상태 |
+| `REFUND_PENDING` | 더 높은 입찰로 추월되어 환불 처리가 대기 중인 상태 |
+| `REFUNDED` | 추월된 입찰 예치금이 지갑으로 환불 완료된 상태 |
+| `SETTLED` | 낙찰 금액이 판매자에게 정산 완료된 상태 |
+| `DISPUTED` | 문제 신고로 정산이 보류된 상태 |
+
+추월 입찰 발생 시 입찰 트랜잭션 안에서는 이전 최고 입찰자의 결제를 `REFUND_PENDING`으로만 변경한다. 실제 지갑 환불은 입찰 트랜잭션 커밋 이후 이벤트 리스너 또는 환불 스케줄러가 처리한다.

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1180,7 +1180,7 @@ paths:
       tags:
       - Auction
       summary: 경매 입찰
-      description: 서버 도착 시간 기준으로 입찰을 처리한다.
+      description: 서버 도착 시간 기준으로 입찰을 처리한다. 입찰 금액은 Dealit Pay에서 즉시 예치되고, 추월당한 기존 최고 입찰자의 예치금은 자동 환불된다.
       operationId: bid
       parameters:
       - name: auctionId
@@ -3635,6 +3635,17 @@ components:
         serverTime:
           type: string
           format: date-time
+        messages:
+          $ref: "#/components/schemas/BidMessages"
+    BidMessages:
+      type: object
+      properties:
+        reserveNotice:
+          type: string
+          example: 입찰 시 해당 금액은 Dealit Pay에서 즉시 예치됩니다.
+        refundNotice:
+          type: string
+          example: 경매에서 추월당할 경우 예치금은 자동 환불됩니다.
     CreateAuctionRequest:
       type: object
       description: 경매 상품 등록 요청

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1180,7 +1180,7 @@ paths:
       tags:
       - Auction
       summary: 경매 입찰
-      description: 서버 도착 시간 기준으로 입찰을 처리한다. 입찰 금액은 Dealit Pay에서 즉시 예치되고, 추월당한 기존 최고 입찰자의 예치금은 자동 환불된다.
+      description: 서버 도착 시간 기준으로 입찰을 처리한다. 입찰 금액은 Dealit Pay에서 즉시 예치되고, 추월당한 기존 최고 입찰자의 예치금은 커밋 이후 자동 환불 처리된다.
       operationId: bid
       parameters:
       - name: auctionId

--- a/src/main/java/com/dealit/dealit/domain/auction/AuctionPaymentStatus.java
+++ b/src/main/java/com/dealit/dealit/domain/auction/AuctionPaymentStatus.java
@@ -2,5 +2,8 @@ package com.dealit.dealit.domain.auction;
 
 public enum AuctionPaymentStatus {
 	RESERVED,
-	REFUNDED
+	REFUND_PENDING,
+	REFUNDED,
+	SETTLED,
+	DISPUTED
 }

--- a/src/main/java/com/dealit/dealit/domain/auction/AuctionPaymentStatus.java
+++ b/src/main/java/com/dealit/dealit/domain/auction/AuctionPaymentStatus.java
@@ -1,0 +1,6 @@
+package com.dealit.dealit.domain.auction;
+
+public enum AuctionPaymentStatus {
+	RESERVED,
+	REFUNDED
+}

--- a/src/main/java/com/dealit/dealit/domain/auction/dto/BidResponse.java
+++ b/src/main/java/com/dealit/dealit/domain/auction/dto/BidResponse.java
@@ -7,6 +7,18 @@ public record BidResponse(
 	Long auctionId,
 	BigDecimal currentPrice,
 	Long bidderId,
-	OffsetDateTime serverTime
+	OffsetDateTime serverTime,
+	BidMessages messages
 ) {
+	public record BidMessages(
+		String reserveNotice,
+		String refundNotice
+	) {
+		public static BidMessages defaults() {
+			return new BidMessages(
+				"입찰 시 해당 금액은 Dealit Pay에서 즉시 예치됩니다.",
+				"경매에서 추월당할 경우 예치금은 자동 환불됩니다."
+			);
+		}
+	}
 }

--- a/src/main/java/com/dealit/dealit/domain/auction/entity/AuctionPayment.java
+++ b/src/main/java/com/dealit/dealit/domain/auction/entity/AuctionPayment.java
@@ -1,0 +1,85 @@
+package com.dealit.dealit.domain.auction.entity;
+
+import com.dealit.dealit.domain.auction.AuctionPaymentStatus;
+import com.dealit.dealit.global.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.SequenceGenerator;
+import jakarta.persistence.Table;
+import java.time.OffsetDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "auction_payment")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SequenceGenerator(
+	name = "auction_payment_seq_generator",
+	sequenceName = "auction_payment_seq",
+	allocationSize = 1
+)
+public class AuctionPayment extends BaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "auction_payment_seq_generator")
+	@Column(name = "auction_payment_id")
+	private Long auctionPaymentId;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "auction_id", nullable = false)
+	private Auction auction;
+
+	@Column(name = "bidder_id", nullable = false)
+	private Long bidderId;
+
+	@Column(name = "seller_id", nullable = false)
+	private Long sellerId;
+
+	@Column(name = "amount", nullable = false)
+	private Long amount;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "status", nullable = false, length = 30)
+	private AuctionPaymentStatus status;
+
+	@Column(name = "reserved_at", nullable = false)
+	private OffsetDateTime reservedAt;
+
+	@Column(name = "refunded_at")
+	private OffsetDateTime refundedAt;
+
+	private AuctionPayment(Auction auction, Long bidderId, Long sellerId, Long amount, OffsetDateTime reservedAt) {
+		this.auction = auction;
+		this.bidderId = bidderId;
+		this.sellerId = sellerId;
+		this.amount = amount;
+		this.status = AuctionPaymentStatus.RESERVED;
+		this.reservedAt = reservedAt;
+	}
+
+	public static AuctionPayment reserve(Auction auction, Long bidderId, Long sellerId, Long amount, OffsetDateTime reservedAt) {
+		return new AuctionPayment(auction, bidderId, sellerId, amount, reservedAt);
+	}
+
+	public boolean refund(OffsetDateTime refundedAt) {
+		if (status == AuctionPaymentStatus.REFUNDED) {
+			return false;
+		}
+		if (status != AuctionPaymentStatus.RESERVED) {
+			return false;
+		}
+		this.status = AuctionPaymentStatus.REFUNDED;
+		this.refundedAt = refundedAt;
+		return true;
+	}
+}

--- a/src/main/java/com/dealit/dealit/domain/auction/entity/AuctionPayment.java
+++ b/src/main/java/com/dealit/dealit/domain/auction/entity/AuctionPayment.java
@@ -55,8 +55,17 @@ public class AuctionPayment extends BaseEntity {
 	@Column(name = "reserved_at", nullable = false)
 	private OffsetDateTime reservedAt;
 
+	@Column(name = "refund_requested_at")
+	private OffsetDateTime refundRequestedAt;
+
 	@Column(name = "refunded_at")
 	private OffsetDateTime refundedAt;
+
+	@Column(name = "settled_at")
+	private OffsetDateTime settledAt;
+
+	@Column(name = "disputed_at")
+	private OffsetDateTime disputedAt;
 
 	private AuctionPayment(Auction auction, Long bidderId, Long sellerId, Long amount, OffsetDateTime reservedAt) {
 		this.auction = auction;
@@ -71,11 +80,23 @@ public class AuctionPayment extends BaseEntity {
 		return new AuctionPayment(auction, bidderId, sellerId, amount, reservedAt);
 	}
 
-	public boolean refund(OffsetDateTime refundedAt) {
-		if (status == AuctionPaymentStatus.REFUNDED) {
+	public boolean requestRefund(OffsetDateTime refundRequestedAt) {
+		if (status == AuctionPaymentStatus.REFUND_PENDING || status == AuctionPaymentStatus.REFUNDED) {
 			return false;
 		}
 		if (status != AuctionPaymentStatus.RESERVED) {
+			return false;
+		}
+		this.status = AuctionPaymentStatus.REFUND_PENDING;
+		this.refundRequestedAt = refundRequestedAt;
+		return true;
+	}
+
+	public boolean completeRefund(OffsetDateTime refundedAt) {
+		if (status == AuctionPaymentStatus.REFUNDED) {
+			return false;
+		}
+		if (status != AuctionPaymentStatus.REFUND_PENDING) {
 			return false;
 		}
 		this.status = AuctionPaymentStatus.REFUNDED;

--- a/src/main/java/com/dealit/dealit/domain/auction/event/AuctionRefundEventListener.java
+++ b/src/main/java/com/dealit/dealit/domain/auction/event/AuctionRefundEventListener.java
@@ -1,0 +1,31 @@
+package com.dealit.dealit.domain.auction.event;
+
+import com.dealit.dealit.domain.auction.service.AuctionRefundService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AuctionRefundEventListener {
+
+	private final AuctionRefundService auctionRefundService;
+
+	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+	public void refund(AuctionRefundRequestedEvent event) {
+		try {
+			auctionRefundService.refundPendingPayment(event.paymentId());
+		} catch (RuntimeException exception) {
+			log.warn(
+				"Auction refund event handling failed. paymentId={}, auctionId={}, bidderId={}",
+				event.paymentId(),
+				event.auctionId(),
+				event.bidderId(),
+				exception
+			);
+		}
+	}
+}

--- a/src/main/java/com/dealit/dealit/domain/auction/event/AuctionRefundRequestedEvent.java
+++ b/src/main/java/com/dealit/dealit/domain/auction/event/AuctionRefundRequestedEvent.java
@@ -1,0 +1,9 @@
+package com.dealit.dealit.domain.auction.event;
+
+public record AuctionRefundRequestedEvent(
+	Long auctionId,
+	Long bidderId,
+	Long paymentId,
+	Long amount
+) {
+}

--- a/src/main/java/com/dealit/dealit/domain/auction/redis/AuctionRedisService.java
+++ b/src/main/java/com/dealit/dealit/domain/auction/redis/AuctionRedisService.java
@@ -48,6 +48,11 @@ public class AuctionRedisService {
 		end
 
 		local previousBidderId = redis.call('HGET', KEYS[1], 'highestBidderId')
+		local previousPrice = currentPrice
+
+		if previousBidderId == bidderId then
+		    return 'SAME_BIDDER:' .. previousPrice
+		end
 
 		redis.call('HSET', KEYS[1],
 		    'currentPrice', bidPrice,
@@ -58,7 +63,26 @@ public class AuctionRedisService {
 		    previousBidderId = ''
 		end
 
-		return 'SUCCESS:' .. previousBidderId
+		return 'SUCCESS:' .. previousBidderId .. ':' .. previousPrice
+		""", String.class);
+
+	private static final DefaultRedisScript<String> RESTORE_BID_SCRIPT = new DefaultRedisScript<>("""
+		local currentPrice = redis.call('HGET', KEYS[1], 'currentPrice')
+		local highestBidderId = redis.call('HGET', KEYS[1], 'highestBidderId')
+		local failedBidPrice = ARGV[1]
+		local failedBidderId = ARGV[2]
+		local previousPrice = ARGV[3]
+		local previousBidderId = ARGV[4]
+
+		if currentPrice == failedBidPrice and highestBidderId == failedBidderId then
+		    redis.call('HSET', KEYS[1],
+		        'currentPrice', previousPrice,
+		        'highestBidderId', previousBidderId
+		    )
+		    return 'RESTORED'
+		end
+
+		return 'SKIPPED'
 		""", String.class);
 
 	private final StringRedisTemplate stringRedisTemplate;
@@ -93,16 +117,34 @@ public class AuctionRedisService {
 			Long.toString(clock.millis())
 		);
 		if (result == null) {
-			return new BidScriptResult(BidScriptStatus.AUCTION_ENDED, null);
+			return new BidScriptResult(BidScriptStatus.AUCTION_ENDED, null, null);
 		}
 		if (result.startsWith("SUCCESS:")) {
-			String previousBidderId = result.substring("SUCCESS:".length());
+			String[] parts = result.substring("SUCCESS:".length()).split(":", -1);
 			return new BidScriptResult(
 				BidScriptStatus.SUCCESS,
-				previousBidderId.isBlank() ? null : Long.valueOf(previousBidderId)
+				parts[0].isBlank() ? null : Long.valueOf(parts[0]),
+				parts.length < 2 || parts[1].isBlank() ? null : new BigDecimal(parts[1])
 			);
 		}
-		return new BidScriptResult(BidScriptStatus.valueOf(result), null);
+		if (result.startsWith("SAME_BIDDER:")) {
+			return new BidScriptResult(BidScriptStatus.SAME_BIDDER, null, new BigDecimal(result.substring("SAME_BIDDER:".length())));
+		}
+		return new BidScriptResult(BidScriptStatus.valueOf(result), null, null);
+	}
+
+	public void restoreBidState(Long auctionId, BigDecimal failedBidPrice, Long failedBidderId, BigDecimal previousPrice, Long previousBidderId) {
+		if (previousPrice == null) {
+			return;
+		}
+		stringRedisTemplate.execute(
+			RESTORE_BID_SCRIPT,
+			List.of(stateKey(auctionId)),
+			failedBidPrice.toPlainString(),
+			failedBidderId.toString(),
+			previousPrice.toPlainString(),
+			previousBidderId == null ? "" : previousBidderId.toString()
+		);
 	}
 
 	public Set<String> findEndingAuctionIds(long nowEpochMillis) {
@@ -145,7 +187,7 @@ public class AuctionRedisService {
 		return "auction:%d:state".formatted(auctionId);
 	}
 
-	public record BidScriptResult(BidScriptStatus status, Long previousBidderId) {
+	public record BidScriptResult(BidScriptStatus status, Long previousBidderId, BigDecimal previousPrice) {
 	}
 
 	public record AuctionState(BigDecimal currentPrice, BigDecimal minimumBidAmount, Long highestBidderId) {
@@ -154,6 +196,7 @@ public class AuctionRedisService {
 	public enum BidScriptStatus {
 		SUCCESS,
 		AUCTION_ENDED,
-		BID_TOO_LOW
+		BID_TOO_LOW,
+		SAME_BIDDER
 	}
 }

--- a/src/main/java/com/dealit/dealit/domain/auction/repository/AuctionPaymentRepository.java
+++ b/src/main/java/com/dealit/dealit/domain/auction/repository/AuctionPaymentRepository.java
@@ -1,0 +1,18 @@
+package com.dealit.dealit.domain.auction.repository;
+
+import com.dealit.dealit.domain.auction.AuctionPaymentStatus;
+import com.dealit.dealit.domain.auction.entity.AuctionPayment;
+import jakarta.persistence.LockModeType;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+
+public interface AuctionPaymentRepository extends JpaRepository<AuctionPayment, Long> {
+
+	@Lock(LockModeType.PESSIMISTIC_WRITE)
+	Optional<AuctionPayment> findFirstByAuctionAuctionIdAndBidderIdAndStatusAndDeletedAtIsNullOrderByReservedAtDescAuctionPaymentIdDesc(
+		Long auctionId,
+		Long bidderId,
+		AuctionPaymentStatus status
+	);
+}

--- a/src/main/java/com/dealit/dealit/domain/auction/repository/AuctionPaymentRepository.java
+++ b/src/main/java/com/dealit/dealit/domain/auction/repository/AuctionPaymentRepository.java
@@ -3,9 +3,14 @@ package com.dealit.dealit.domain.auction.repository;
 import com.dealit.dealit.domain.auction.AuctionPaymentStatus;
 import com.dealit.dealit.domain.auction.entity.AuctionPayment;
 import jakarta.persistence.LockModeType;
+import java.time.OffsetDateTime;
+import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface AuctionPaymentRepository extends JpaRepository<AuctionPayment, Long> {
 
@@ -14,5 +19,22 @@ public interface AuctionPaymentRepository extends JpaRepository<AuctionPayment, 
 		Long auctionId,
 		Long bidderId,
 		AuctionPaymentStatus status
+	);
+
+	@Lock(LockModeType.PESSIMISTIC_WRITE)
+	Optional<AuctionPayment> findByAuctionPaymentIdAndDeletedAtIsNull(Long auctionPaymentId);
+
+	@Query("""
+		SELECT p
+		FROM AuctionPayment p
+		WHERE p.status = :status
+		  AND p.refundRequestedAt < :threshold
+		  AND p.deletedAt IS NULL
+		ORDER BY p.refundRequestedAt ASC, p.auctionPaymentId ASC
+	""")
+	List<AuctionPayment> findRefundPendingBefore(
+		@Param("status") AuctionPaymentStatus status,
+		@Param("threshold") OffsetDateTime threshold,
+		Pageable pageable
 	);
 }

--- a/src/main/java/com/dealit/dealit/domain/auction/repository/AuctionRepository.java
+++ b/src/main/java/com/dealit/dealit/domain/auction/repository/AuctionRepository.java
@@ -2,10 +2,12 @@ package com.dealit.dealit.domain.auction.repository;
 
 import com.dealit.dealit.domain.auction.AuctionStatus;
 import com.dealit.dealit.domain.auction.entity.Auction;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -34,6 +36,10 @@ public interface AuctionRepository extends JpaRepository<Auction, Long> {
 
 	@EntityGraph(attributePaths = {"product"})
 	Optional<Auction> findByAuctionIdAndDeletedAtIsNullAndProductDeletedAtIsNull(Long auctionId);
+
+	@Lock(LockModeType.PESSIMISTIC_WRITE)
+	@EntityGraph(attributePaths = {"product"})
+	Optional<Auction> findWithLockByAuctionIdAndDeletedAtIsNullAndProductDeletedAtIsNull(Long auctionId);
 
 	@EntityGraph(attributePaths = {"product", "product.images"})
 	Optional<Auction> findDetailByAuctionIdAndDeletedAtIsNullAndProductDeletedAtIsNull(Long auctionId);

--- a/src/main/java/com/dealit/dealit/domain/auction/scheduler/AuctionRefundScheduler.java
+++ b/src/main/java/com/dealit/dealit/domain/auction/scheduler/AuctionRefundScheduler.java
@@ -1,0 +1,27 @@
+package com.dealit.dealit.domain.auction.scheduler;
+
+import com.dealit.dealit.domain.auction.service.AuctionRefundService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AuctionRefundScheduler {
+
+	private final AuctionRefundService auctionRefundService;
+
+	@Scheduled(fixedDelayString = "${app.auction.refund-scheduler-delay-ms:60000}")
+	public void refundStalePendingPayments() {
+		auctionRefundService.findStalePendingPaymentIds()
+			.forEach(paymentId -> {
+				try {
+					auctionRefundService.refundPendingPayment(paymentId);
+				} catch (RuntimeException exception) {
+					log.warn("Auction refund scheduler failed. paymentId={}", paymentId, exception);
+				}
+			});
+	}
+}

--- a/src/main/java/com/dealit/dealit/domain/auction/service/AuctionBidService.java
+++ b/src/main/java/com/dealit/dealit/domain/auction/service/AuctionBidService.java
@@ -1,13 +1,16 @@
 package com.dealit.dealit.domain.auction.service;
 
 import com.dealit.dealit.domain.auction.AuctionStatus;
+import com.dealit.dealit.domain.auction.AuctionPaymentStatus;
 import com.dealit.dealit.domain.auction.dto.AuctionDetailResponse;
 import com.dealit.dealit.domain.auction.dto.AuctionDetailResponse.ImageResponse;
 import com.dealit.dealit.domain.auction.dto.AuctionDetailResponse.SellerResponse;
 import com.dealit.dealit.domain.auction.dto.AuctionBidHistoryResponse;
 import com.dealit.dealit.domain.auction.dto.AuctionBidHistoryResponse.BidHistoryItem;
 import com.dealit.dealit.domain.auction.dto.BidResponse;
+import com.dealit.dealit.domain.auction.dto.BidResponse.BidMessages;
 import com.dealit.dealit.domain.auction.entity.Auction;
+import com.dealit.dealit.domain.auction.entity.AuctionPayment;
 import com.dealit.dealit.domain.auction.entity.Category;
 import com.dealit.dealit.domain.auction.entity.Bid;
 import com.dealit.dealit.domain.auction.event.AuctionEventPublisher;
@@ -17,12 +20,15 @@ import com.dealit.dealit.domain.auction.redis.AuctionRedisService;
 import com.dealit.dealit.domain.auction.redis.AuctionRedisService.AuctionState;
 import com.dealit.dealit.domain.auction.redis.AuctionRedisService.BidScriptResult;
 import com.dealit.dealit.domain.auction.repository.AuctionRepository;
+import com.dealit.dealit.domain.auction.repository.AuctionPaymentRepository;
 import com.dealit.dealit.domain.auction.repository.BidRepository;
 import com.dealit.dealit.domain.auction.repository.CategoryRepository;
 import com.dealit.dealit.domain.member.entity.Member;
+import com.dealit.dealit.domain.member.exception.EmailNotVerifiedException;
 import com.dealit.dealit.domain.member.repository.MemberRepository;
 import com.dealit.dealit.domain.product.entity.Product;
 import com.dealit.dealit.domain.product.entity.ProductImage;
+import com.dealit.dealit.domain.wallet.service.WalletService;
 import com.dealit.dealit.global.service.ImageUrlService;
 import java.math.BigDecimal;
 import java.time.Clock;
@@ -46,8 +52,10 @@ public class AuctionBidService {
 
 	private final AuctionRepository auctionRepository;
 	private final BidRepository bidRepository;
+	private final AuctionPaymentRepository auctionPaymentRepository;
 	private final CategoryRepository categoryRepository;
 	private final MemberRepository memberRepository;
+	private final WalletService walletService;
 	private final AuctionRedisService auctionRedisService;
 	private final AuctionEventPublisher auctionEventPublisher;
 	private final ImageUrlService imageUrlService;
@@ -126,7 +134,8 @@ public class AuctionBidService {
 	@Transactional
 	public BidResponse bid(Long auctionId, Long bidderId, BigDecimal bidPrice) {
 		Auction auction = loadAuction(auctionId);
-		if (auction.getProduct().getMemberId().equals(bidderId)) {
+		Long sellerId = auction.getProduct().getMemberId();
+		if (sellerId.equals(bidderId)) {
 			throw new InvalidAuctionRequestException("자신이 등록한 경매에는 입찰할 수 없습니다.");
 		}
 		if (!auction.isOngoing()) {
@@ -138,40 +147,54 @@ public class AuctionBidService {
 		if (bidPrice.compareTo(auction.getCurrentPrice().add(auction.getMinimumBidAmount())) < 0) {
 			throw new InvalidAuctionRequestException("최소 입찰 금액을 충족해야 합니다.");
 		}
+		Member bidder = loadActiveMember(bidderId);
+		if (!bidder.isVerified()) {
+			throw new EmailNotVerifiedException();
+		}
+
+		long bidAmount = toWalletAmount(bidPrice);
+		walletService.reserveAuctionBid(bidderId, bidAmount, auctionId);
 
 		BidScriptResult result = auctionRedisService.bid(auctionId, bidPrice, bidderId);
 		switch (result.status()) {
 			case AUCTION_ENDED -> throw new InvalidAuctionRequestException("이미 종료된 경매입니다.");
 			case BID_TOO_LOW -> throw new InvalidAuctionRequestException("현재가보다 높은 금액만 입찰할 수 있습니다.");
+			case SAME_BIDDER -> throw new InvalidAuctionRequestException("현재 최고 입찰자는 다시 입찰할 수 없습니다.");
 			case SUCCESS -> {
-				bidRepository.save(Bid.create(auction, bidderId, bidPrice));
-				auction.updateCurrentPrice(bidPrice);
-				OffsetDateTime serverTime = serverTime();
-				long bidCount = bidRepository.countByAuctionAuctionId(auction.getAuctionId());
-				long bidderCount = bidRepository.countDistinctBidderIdByAuctionId(auction.getAuctionId());
-				BigDecimal minimumNextBidPrice = bidPrice.add(auction.getMinimumBidAmount());
-				Long sellerId = auction.getProduct().getMemberId();
-				auctionEventPublisher.publishBidUpdated(auctionId, bidPrice, bidderId, serverTime);
-				auctionEventPublisher.publishOutbid(auctionId, result.previousBidderId(), bidderId, bidPrice, serverTime);
-				auctionEventPublisher.publishBidReceived(
-					sellerId,
-					auctionId,
-					bidderId,
-					bidPrice,
-					bidCount,
-					result.previousBidderId() == null,
-					serverTime
-				);
-				auctionEventPublisher.publishAuctionBidUpdated(
-					Arrays.asList(sellerId, bidderId, result.previousBidderId()),
-					auctionId,
-					bidPrice,
-					minimumNextBidPrice,
-					bidCount,
-					bidderCount,
-					serverTime
-				);
-				return new BidResponse(auctionId, bidPrice, bidderId, serverTime);
+				try {
+					OffsetDateTime serverTime = serverTime();
+					auctionPaymentRepository.save(AuctionPayment.reserve(auction, bidderId, sellerId, bidAmount, serverTime));
+					refundPreviousHighestBidder(auctionId, result.previousBidderId(), serverTime);
+					bidRepository.save(Bid.create(auction, bidderId, bidPrice));
+					auction.updateCurrentPrice(bidPrice);
+					long bidCount = bidRepository.countByAuctionAuctionId(auction.getAuctionId());
+					long bidderCount = bidRepository.countDistinctBidderIdByAuctionId(auction.getAuctionId());
+					BigDecimal minimumNextBidPrice = bidPrice.add(auction.getMinimumBidAmount());
+					auctionEventPublisher.publishBidUpdated(auctionId, bidPrice, bidderId, serverTime);
+					auctionEventPublisher.publishOutbid(auctionId, result.previousBidderId(), bidderId, bidPrice, serverTime);
+					auctionEventPublisher.publishBidReceived(
+						sellerId,
+						auctionId,
+						bidderId,
+						bidPrice,
+						bidCount,
+						result.previousBidderId() == null,
+						serverTime
+					);
+					auctionEventPublisher.publishAuctionBidUpdated(
+						Arrays.asList(sellerId, bidderId, result.previousBidderId()),
+						auctionId,
+						bidPrice,
+						minimumNextBidPrice,
+						bidCount,
+						bidderCount,
+						serverTime
+					);
+					return new BidResponse(auctionId, bidPrice, bidderId, serverTime, BidMessages.defaults());
+				} catch (RuntimeException exception) {
+					auctionRedisService.restoreBidState(auctionId, bidPrice, bidderId, result.previousPrice(), result.previousBidderId());
+					throw exception;
+				}
 			}
 		}
 		throw new InvalidAuctionRequestException("입찰을 처리할 수 없습니다.");
@@ -236,6 +259,27 @@ public class AuctionBidService {
 			.orElseThrow(() -> new AuctionNotFoundException("존재하지 않는 경매입니다."));
 	}
 
+	private Member loadActiveMember(Long memberId) {
+		return memberRepository.findByMemberIdAndDeletedAtIsNull(memberId)
+			.orElseThrow(() -> new InvalidAuctionRequestException("존재하지 않는 회원입니다."));
+	}
+
+	private void refundPreviousHighestBidder(Long auctionId, Long previousBidderId, OffsetDateTime refundedAt) {
+		if (previousBidderId == null) {
+			return;
+		}
+		AuctionPayment previousPayment = auctionPaymentRepository
+			.findFirstByAuctionAuctionIdAndBidderIdAndStatusAndDeletedAtIsNullOrderByReservedAtDescAuctionPaymentIdDesc(
+				auctionId,
+				previousBidderId,
+				AuctionPaymentStatus.RESERVED
+			)
+			.orElseThrow(() -> new InvalidAuctionRequestException("이전 최고 입찰자의 예치금을 찾을 수 없습니다."));
+		if (previousPayment.refund(refundedAt)) {
+			walletService.refundAuctionPayment(previousPayment.getBidderId(), previousPayment.getAmount(), auctionId);
+		}
+	}
+
 	private List<ImageResponse> toImageResponses(Product product) {
 		return product.getImages().stream()
 			.filter(image -> image.getDeletedAt() == null)
@@ -278,5 +322,13 @@ public class AuctionBidService {
 
 	private OffsetDateTime serverTime() {
 		return OffsetDateTime.now(clock).withOffsetSameInstant(ZoneOffset.UTC);
+	}
+
+	private long toWalletAmount(BigDecimal amount) {
+		try {
+			return amount.stripTrailingZeros().longValueExact();
+		} catch (ArithmeticException exception) {
+			throw new InvalidAuctionRequestException("입찰가는 원 단위로 입력해주세요.");
+		}
 	}
 }

--- a/src/main/java/com/dealit/dealit/domain/auction/service/AuctionBidService.java
+++ b/src/main/java/com/dealit/dealit/domain/auction/service/AuctionBidService.java
@@ -14,6 +14,7 @@ import com.dealit.dealit.domain.auction.entity.AuctionPayment;
 import com.dealit.dealit.domain.auction.entity.Category;
 import com.dealit.dealit.domain.auction.entity.Bid;
 import com.dealit.dealit.domain.auction.event.AuctionEventPublisher;
+import com.dealit.dealit.domain.auction.event.AuctionRefundRequestedEvent;
 import com.dealit.dealit.domain.auction.exception.AuctionNotFoundException;
 import com.dealit.dealit.domain.auction.exception.InvalidAuctionRequestException;
 import com.dealit.dealit.domain.auction.redis.AuctionRedisService;
@@ -41,6 +42,7 @@ import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.redis.RedisConnectionFailureException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -58,6 +60,7 @@ public class AuctionBidService {
 	private final WalletService walletService;
 	private final AuctionRedisService auctionRedisService;
 	private final AuctionEventPublisher auctionEventPublisher;
+	private final ApplicationEventPublisher applicationEventPublisher;
 	private final ImageUrlService imageUrlService;
 	private final Clock clock;
 
@@ -164,7 +167,7 @@ public class AuctionBidService {
 				try {
 					OffsetDateTime serverTime = serverTime();
 					auctionPaymentRepository.save(AuctionPayment.reserve(auction, bidderId, sellerId, bidAmount, serverTime));
-					refundPreviousHighestBidder(auctionId, result.previousBidderId(), serverTime);
+					requestPreviousHighestBidderRefund(auctionId, result.previousBidderId(), serverTime);
 					bidRepository.save(Bid.create(auction, bidderId, bidPrice));
 					auction.updateCurrentPrice(bidPrice);
 					long bidCount = bidRepository.countByAuctionAuctionId(auction.getAuctionId());
@@ -269,7 +272,7 @@ public class AuctionBidService {
 			.orElseThrow(() -> new InvalidAuctionRequestException("존재하지 않는 회원입니다."));
 	}
 
-	private void refundPreviousHighestBidder(Long auctionId, Long previousBidderId, OffsetDateTime refundedAt) {
+	private void requestPreviousHighestBidderRefund(Long auctionId, Long previousBidderId, OffsetDateTime refundRequestedAt) {
 		if (previousBidderId == null) {
 			return;
 		}
@@ -280,8 +283,13 @@ public class AuctionBidService {
 				AuctionPaymentStatus.RESERVED
 			)
 			.orElseThrow(() -> new InvalidAuctionRequestException("이전 최고 입찰자의 예치금을 찾을 수 없습니다."));
-		if (previousPayment.refund(refundedAt)) {
-			walletService.refundAuctionPayment(previousPayment.getBidderId(), previousPayment.getAmount(), auctionId);
+		if (previousPayment.requestRefund(refundRequestedAt)) {
+			applicationEventPublisher.publishEvent(new AuctionRefundRequestedEvent(
+				auctionId,
+				previousPayment.getBidderId(),
+				previousPayment.getAuctionPaymentId(),
+				previousPayment.getAmount()
+			));
 		}
 	}
 

--- a/src/main/java/com/dealit/dealit/domain/auction/service/AuctionBidService.java
+++ b/src/main/java/com/dealit/dealit/domain/auction/service/AuctionBidService.java
@@ -133,7 +133,7 @@ public class AuctionBidService {
 
 	@Transactional
 	public BidResponse bid(Long auctionId, Long bidderId, BigDecimal bidPrice) {
-		Auction auction = loadAuction(auctionId);
+		Auction auction = loadAuctionWithLock(auctionId);
 		Long sellerId = auction.getProduct().getMemberId();
 		if (sellerId.equals(bidderId)) {
 			throw new InvalidAuctionRequestException("자신이 등록한 경매에는 입찰할 수 없습니다.");
@@ -251,6 +251,11 @@ public class AuctionBidService {
 
 	private Auction loadAuction(Long auctionId) {
 		return auctionRepository.findByAuctionIdAndDeletedAtIsNullAndProductDeletedAtIsNull(auctionId)
+			.orElseThrow(() -> new AuctionNotFoundException("존재하지 않는 경매입니다."));
+	}
+
+	private Auction loadAuctionWithLock(Long auctionId) {
+		return auctionRepository.findWithLockByAuctionIdAndDeletedAtIsNullAndProductDeletedAtIsNull(auctionId)
 			.orElseThrow(() -> new AuctionNotFoundException("존재하지 않는 경매입니다."));
 	}
 

--- a/src/main/java/com/dealit/dealit/domain/auction/service/AuctionRefundService.java
+++ b/src/main/java/com/dealit/dealit/domain/auction/service/AuctionRefundService.java
@@ -1,0 +1,58 @@
+package com.dealit.dealit.domain.auction.service;
+
+import com.dealit.dealit.domain.auction.AuctionPaymentStatus;
+import com.dealit.dealit.domain.auction.entity.AuctionPayment;
+import com.dealit.dealit.domain.auction.repository.AuctionPaymentRepository;
+import com.dealit.dealit.domain.wallet.service.WalletService;
+import java.time.Clock;
+import java.time.OffsetDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AuctionRefundService {
+
+	private static final int REFUND_BATCH_SIZE = 100;
+
+	private final AuctionPaymentRepository auctionPaymentRepository;
+	private final WalletService walletService;
+	private final Clock clock;
+
+	@Transactional
+	public void refundPendingPayment(Long paymentId) {
+		AuctionPayment payment = auctionPaymentRepository.findByAuctionPaymentIdAndDeletedAtIsNull(paymentId)
+			.orElse(null);
+		if (payment == null || payment.getStatus() == AuctionPaymentStatus.REFUNDED) {
+			return;
+		}
+		if (payment.getStatus() != AuctionPaymentStatus.REFUND_PENDING) {
+			return;
+		}
+
+		OffsetDateTime refundedAt = OffsetDateTime.now(clock);
+		if (payment.completeRefund(refundedAt)) {
+			walletService.refundAuctionPayment(
+				payment.getBidderId(),
+				payment.getAmount(),
+				payment.getAuction().getAuctionId()
+			);
+		}
+	}
+
+	public List<Long> findStalePendingPaymentIds() {
+		OffsetDateTime threshold = OffsetDateTime.now(clock).minusSeconds(10);
+		return auctionPaymentRepository.findRefundPendingBefore(
+				AuctionPaymentStatus.REFUND_PENDING,
+				threshold,
+				PageRequest.of(0, REFUND_BATCH_SIZE)
+			)
+			.stream()
+			.map(AuctionPayment::getAuctionPaymentId)
+			.toList();
+	}
+}

--- a/src/main/java/com/dealit/dealit/domain/wallet/entity/WalletLedgerType.java
+++ b/src/main/java/com/dealit/dealit/domain/wallet/entity/WalletLedgerType.java
@@ -3,5 +3,7 @@ package com.dealit.dealit.domain.wallet.entity;
 public enum WalletLedgerType {
 	TEMP_CHARGE,
 	REFUND,
-	WITHDRAWAL
+	WITHDRAWAL,
+	AUCTION_RESERVE,
+	AUCTION_REFUND
 }

--- a/src/main/java/com/dealit/dealit/domain/wallet/service/WalletService.java
+++ b/src/main/java/com/dealit/dealit/domain/wallet/service/WalletService.java
@@ -53,6 +53,16 @@ public class WalletService {
 		return apply(memberId, -amount, WalletLedgerType.WITHDRAWAL, "내 계좌로 옮기기");
 	}
 
+	@Transactional
+	public long reserveAuctionBid(Long memberId, long amount, Long auctionId) {
+		return applyForAuction(memberId, -amount, WalletLedgerType.AUCTION_RESERVE, "경매 입찰 예치금 차감: auctionId=%d".formatted(auctionId));
+	}
+
+	@Transactional
+	public long refundAuctionPayment(Long memberId, long amount, Long auctionId) {
+		return applyForAuction(memberId, amount, WalletLedgerType.AUCTION_REFUND, "경매 예치금 환불: auctionId=%d".formatted(auctionId));
+	}
+
 	public WalletLedgerListResponse getMyLedgers(Long memberId, int page, int size) {
 		validateActiveMember(memberId);
 		int normalizedPage = Math.max(page, 0);
@@ -75,6 +85,13 @@ public class WalletService {
 	}
 
 	private WalletResponse apply(Long memberId, long signedAmount, WalletLedgerType type, String description) {
+		applyForAuction(memberId, signedAmount, type, description);
+		Wallet wallet = walletRepository.findByMemberId(memberId)
+			.orElseThrow(() -> new InvalidWalletRequestException("지갑을 찾을 수 없습니다."));
+		return toWalletResponse(wallet);
+	}
+
+	private long applyForAuction(Long memberId, long signedAmount, WalletLedgerType type, String description) {
 		validateActiveMember(memberId);
 		if (signedAmount == 0) {
 			throw new InvalidWalletRequestException("금액은 0원일 수 없습니다.");
@@ -93,7 +110,7 @@ public class WalletService {
 		walletLedgerRepository.save(
 			WalletLedger.create(wallet, type, signedAmount, nextBalance, description)
 		);
-		return toWalletResponse(wallet);
+		return nextBalance;
 	}
 
 	private Wallet findOrCreateWallet(Long memberId) {

--- a/src/test/java/com/dealit/dealit/domain/auction/AuctionBidServiceTest.java
+++ b/src/test/java/com/dealit/dealit/domain/auction/AuctionBidServiceTest.java
@@ -155,7 +155,7 @@ class AuctionBidServiceTest {
 		Long auctionId = 1L;
 		Auction auction = auction(10L);
 		AtomicReference<BigDecimal> currentPrice = new AtomicReference<>(new BigDecimal("100000"));
-		when(auctionRepository.findByAuctionIdAndDeletedAtIsNullAndProductDeletedAtIsNull(auctionId))
+		when(auctionRepository.findWithLockByAuctionIdAndDeletedAtIsNullAndProductDeletedAtIsNull(auctionId))
 			.thenReturn(Optional.of(auction));
 		when(memberRepository.findByMemberIdAndDeletedAtIsNull(20L)).thenReturn(Optional.of(verifiedMember("bidder20")));
 		when(memberRepository.findByMemberIdAndDeletedAtIsNull(30L)).thenReturn(Optional.of(verifiedMember("bidder30")));
@@ -203,7 +203,7 @@ class AuctionBidServiceTest {
 	void bidFailsWhenAuctionEndTimeAlreadyPassed() {
 		Long auctionId = 1L;
 		Auction auction = endedByTimeAuction(10L);
-		when(auctionRepository.findByAuctionIdAndDeletedAtIsNullAndProductDeletedAtIsNull(auctionId))
+		when(auctionRepository.findWithLockByAuctionIdAndDeletedAtIsNullAndProductDeletedAtIsNull(auctionId))
 			.thenReturn(Optional.of(auction));
 
 		Object result;
@@ -225,7 +225,7 @@ class AuctionBidServiceTest {
 		Long auctionId = 1L;
 		Long sellerId = 10L;
 		Auction auction = auction(sellerId);
-		when(auctionRepository.findByAuctionIdAndDeletedAtIsNullAndProductDeletedAtIsNull(auctionId))
+		when(auctionRepository.findWithLockByAuctionIdAndDeletedAtIsNullAndProductDeletedAtIsNull(auctionId))
 			.thenReturn(Optional.of(auction));
 
 		Object result;
@@ -247,7 +247,7 @@ class AuctionBidServiceTest {
 		Long auctionId = 1L;
 		Long bidderId = 20L;
 		Auction auction = auction(10L);
-		when(auctionRepository.findByAuctionIdAndDeletedAtIsNullAndProductDeletedAtIsNull(auctionId))
+		when(auctionRepository.findWithLockByAuctionIdAndDeletedAtIsNullAndProductDeletedAtIsNull(auctionId))
 			.thenReturn(Optional.of(auction));
 		when(memberRepository.findByMemberIdAndDeletedAtIsNull(bidderId))
 			.thenReturn(Optional.of(unverifiedMember("unverified-bidder")));

--- a/src/test/java/com/dealit/dealit/domain/auction/AuctionBidServiceTest.java
+++ b/src/test/java/com/dealit/dealit/domain/auction/AuctionBidServiceTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.when;
 
 import com.dealit.dealit.domain.auction.dto.BidResponse;
 import com.dealit.dealit.domain.auction.entity.Auction;
+import com.dealit.dealit.domain.auction.entity.AuctionPayment;
 import com.dealit.dealit.domain.auction.entity.Bid;
 import com.dealit.dealit.domain.auction.event.AuctionEventPublisher;
 import com.dealit.dealit.domain.auction.exception.InvalidAuctionRequestException;
@@ -20,13 +21,17 @@ import com.dealit.dealit.domain.auction.redis.AuctionRedisService.AuctionState;
 import com.dealit.dealit.domain.auction.redis.AuctionRedisService.BidScriptResult;
 import com.dealit.dealit.domain.auction.redis.AuctionRedisService.BidScriptStatus;
 import com.dealit.dealit.domain.auction.repository.AuctionRepository;
+import com.dealit.dealit.domain.auction.repository.AuctionPaymentRepository;
 import com.dealit.dealit.domain.auction.repository.BidRepository;
 import com.dealit.dealit.domain.auction.repository.CategoryRepository;
 import com.dealit.dealit.domain.auction.service.AuctionBidService;
+import com.dealit.dealit.domain.member.entity.Member;
+import com.dealit.dealit.domain.member.exception.EmailNotVerifiedException;
 import com.dealit.dealit.domain.member.repository.MemberRepository;
 import com.dealit.dealit.domain.product.ProductSaleType;
 import com.dealit.dealit.domain.product.ProductStatus;
 import com.dealit.dealit.domain.product.entity.Product;
+import com.dealit.dealit.domain.wallet.service.WalletService;
 import com.dealit.dealit.global.service.ImageUrlService;
 import java.math.BigDecimal;
 import java.time.Clock;
@@ -52,8 +57,10 @@ class AuctionBidServiceTest {
 
 	private final AuctionRepository auctionRepository = mock(AuctionRepository.class);
 	private final BidRepository bidRepository = mock(BidRepository.class);
+	private final AuctionPaymentRepository auctionPaymentRepository = mock(AuctionPaymentRepository.class);
 	private final CategoryRepository categoryRepository = mock(CategoryRepository.class);
 	private final MemberRepository memberRepository = mock(MemberRepository.class);
+	private final WalletService walletService = mock(WalletService.class);
 	private final AuctionRedisService auctionRedisService = mock(AuctionRedisService.class);
 	private final AuctionEventPublisher auctionEventPublisher = mock(AuctionEventPublisher.class);
 	private final ImageUrlService imageUrlService = mock(ImageUrlService.class);
@@ -61,8 +68,10 @@ class AuctionBidServiceTest {
 	private final AuctionBidService auctionBidService = new AuctionBidService(
 		auctionRepository,
 		bidRepository,
+		auctionPaymentRepository,
 		categoryRepository,
 		memberRepository,
+		walletService,
 		auctionRedisService,
 		auctionEventPublisher,
 		imageUrlService,
@@ -148,17 +157,22 @@ class AuctionBidServiceTest {
 		AtomicReference<BigDecimal> currentPrice = new AtomicReference<>(new BigDecimal("100000"));
 		when(auctionRepository.findByAuctionIdAndDeletedAtIsNullAndProductDeletedAtIsNull(auctionId))
 			.thenReturn(Optional.of(auction));
+		when(memberRepository.findByMemberIdAndDeletedAtIsNull(20L)).thenReturn(Optional.of(verifiedMember("bidder20")));
+		when(memberRepository.findByMemberIdAndDeletedAtIsNull(30L)).thenReturn(Optional.of(verifiedMember("bidder30")));
 		when(bidRepository.save(any(Bid.class))).thenAnswer(invocation -> invocation.getArgument(0));
+		when(auctionPaymentRepository.save(any(AuctionPayment.class))).thenAnswer(invocation -> invocation.getArgument(0));
+		when(walletService.reserveAuctionBid(anyLong(), anyLong(), eq(auctionId))).thenReturn(0L);
 		when(auctionRedisService.bid(eq(auctionId), any(BigDecimal.class), anyLong()))
 			.thenAnswer(invocation -> {
 				BigDecimal bidPrice = invocation.getArgument(1);
 				synchronized (currentPrice) {
 					BigDecimal minimumNextPrice = currentPrice.get().add(new BigDecimal("1000"));
 					if (bidPrice.compareTo(minimumNextPrice) < 0) {
-						return new BidScriptResult(BidScriptStatus.BID_TOO_LOW, null);
+						return new BidScriptResult(BidScriptStatus.BID_TOO_LOW, null, null);
 					}
+					BigDecimal previousPrice = currentPrice.get();
 					currentPrice.set(bidPrice);
-					return new BidScriptResult(BidScriptStatus.SUCCESS, null);
+					return new BidScriptResult(BidScriptStatus.SUCCESS, null, previousPrice);
 				}
 			});
 
@@ -227,6 +241,30 @@ class AuctionBidServiceTest {
 		verify(bidRepository, never()).save(any(Bid.class));
 	}
 
+	@Test
+	@DisplayName("이메일 미인증 회원은 경매에 입찰할 수 없다")
+	void bidFailsWhenBidderEmailIsNotVerified() {
+		Long auctionId = 1L;
+		Long bidderId = 20L;
+		Auction auction = auction(10L);
+		when(auctionRepository.findByAuctionIdAndDeletedAtIsNullAndProductDeletedAtIsNull(auctionId))
+			.thenReturn(Optional.of(auction));
+		when(memberRepository.findByMemberIdAndDeletedAtIsNull(bidderId))
+			.thenReturn(Optional.of(unverifiedMember("unverified-bidder")));
+
+		Object result;
+		try {
+			result = auctionBidService.bid(auctionId, bidderId, new BigDecimal("101000"));
+		} catch (EmailNotVerifiedException exception) {
+			result = exception;
+		}
+
+		assertThat(result).isInstanceOf(EmailNotVerifiedException.class);
+		verify(walletService, never()).reserveAuctionBid(anyLong(), anyLong(), anyLong());
+		verify(auctionRedisService, never()).bid(anyLong(), any(BigDecimal.class), anyLong());
+		verify(bidRepository, never()).save(any(Bid.class));
+	}
+
 	private Object bidAfterStart(CountDownLatch start, Long auctionId, Long bidderId, BigDecimal bidPrice)
 		throws InterruptedException {
 		start.await();
@@ -239,6 +277,14 @@ class AuctionBidServiceTest {
 
 	private Auction auction(Long sellerId) {
 		return auction(sellerId, OffsetDateTime.now(FIXED_CLOCK).plusDays(1));
+	}
+
+	private Member verifiedMember(String loginId) {
+		return Member.create(loginId, "password", loginId + "@example.com", "입찰자", true);
+	}
+
+	private Member unverifiedMember(String loginId) {
+		return Member.create(loginId, "password", loginId + "@example.com", "입찰자", false);
 	}
 
 	private Auction endedByTimeAuction(Long sellerId) {

--- a/src/test/java/com/dealit/dealit/domain/auction/AuctionBidServiceTest.java
+++ b/src/test/java/com/dealit/dealit/domain/auction/AuctionBidServiceTest.java
@@ -48,6 +48,8 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
@@ -63,6 +65,7 @@ class AuctionBidServiceTest {
 	private final WalletService walletService = mock(WalletService.class);
 	private final AuctionRedisService auctionRedisService = mock(AuctionRedisService.class);
 	private final AuctionEventPublisher auctionEventPublisher = mock(AuctionEventPublisher.class);
+	private final ApplicationEventPublisher applicationEventPublisher = mock(ApplicationEventPublisher.class);
 	private final ImageUrlService imageUrlService = mock(ImageUrlService.class);
 
 	private final AuctionBidService auctionBidService = new AuctionBidService(
@@ -74,6 +77,7 @@ class AuctionBidServiceTest {
 		walletService,
 		auctionRedisService,
 		auctionEventPublisher,
+		applicationEventPublisher,
 		imageUrlService,
 		FIXED_CLOCK
 	);
@@ -217,6 +221,51 @@ class AuctionBidServiceTest {
 		assertThat(((InvalidAuctionRequestException) result).getMessage()).isEqualTo("이미 종료된 경매입니다.");
 		verify(auctionRedisService, never()).bid(anyLong(), any(BigDecimal.class), anyLong());
 		verify(bidRepository, never()).save(any(Bid.class));
+	}
+
+	@Test
+	@DisplayName("추월 입찰은 이전 최고 입찰자의 예치금을 환불 대기로 바꾸고 커밋 이후 환불 이벤트를 발행한다")
+	void bidRequestsPreviousHighestBidderRefundWithoutDirectWalletRefund() {
+		Long auctionId = 1L;
+		Long sellerId = 10L;
+		Long bidderId = 30L;
+		Long previousBidderId = 20L;
+		Auction auction = auction(sellerId);
+		AuctionPayment previousPayment = AuctionPayment.reserve(
+			auction,
+			previousBidderId,
+			sellerId,
+			101000L,
+			OffsetDateTime.now(FIXED_CLOCK).minusMinutes(1)
+		);
+		when(auctionRepository.findWithLockByAuctionIdAndDeletedAtIsNullAndProductDeletedAtIsNull(auctionId))
+			.thenReturn(Optional.of(auction));
+		when(memberRepository.findByMemberIdAndDeletedAtIsNull(bidderId))
+			.thenReturn(Optional.of(verifiedMember("bidder30")));
+		when(walletService.reserveAuctionBid(bidderId, 102000L, auctionId)).thenReturn(0L);
+		when(auctionRedisService.bid(auctionId, new BigDecimal("102000"), bidderId))
+			.thenReturn(new BidScriptResult(
+				BidScriptStatus.SUCCESS,
+				previousBidderId,
+				new BigDecimal("101000")
+			));
+		when(auctionPaymentRepository.save(any(AuctionPayment.class))).thenAnswer(invocation -> invocation.getArgument(0));
+		when(auctionPaymentRepository.findFirstByAuctionAuctionIdAndBidderIdAndStatusAndDeletedAtIsNullOrderByReservedAtDescAuctionPaymentIdDesc(
+			auctionId,
+			previousBidderId,
+			AuctionPaymentStatus.RESERVED
+		)).thenReturn(Optional.of(previousPayment));
+		when(bidRepository.save(any(Bid.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+		auctionBidService.bid(auctionId, bidderId, new BigDecimal("102000"));
+
+		assertThat(previousPayment.getStatus()).isEqualTo(AuctionPaymentStatus.REFUND_PENDING);
+		assertThat(previousPayment.getRefundRequestedAt()).isEqualTo(OffsetDateTime.now(FIXED_CLOCK));
+		verify(walletService, never()).refundAuctionPayment(anyLong(), anyLong(), anyLong());
+		ArgumentCaptor<Object> eventCaptor = ArgumentCaptor.forClass(Object.class);
+		verify(applicationEventPublisher).publishEvent(eventCaptor.capture());
+		assertThat(eventCaptor.getValue())
+			.isInstanceOf(com.dealit.dealit.domain.auction.event.AuctionRefundRequestedEvent.class);
 	}
 
 	@Test

--- a/src/test/java/com/dealit/dealit/domain/auction/AuctionIntegrationTest.java
+++ b/src/test/java/com/dealit/dealit/domain/auction/AuctionIntegrationTest.java
@@ -372,6 +372,43 @@ class AuctionIntegrationTest {
 	}
 
 	@Test
+	@DisplayName("경매 등록은 60초 기간으로 1분 경매를 생성할 수 있다")
+	void createAuctionSupportsSixtySecondAuction() throws Exception {
+		mockMvc.perform(post("/api/v1/auction")
+				.header("Authorization", "Bearer " + accessToken)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{
+					  "name": "1 minute auction",
+					  "description": "One minute auction for quick bidding.",
+					  "saleType": "AUCTION",
+					  "categoryId": 21,
+					  "price": null,
+					  "startPrice": 500000,
+					  "minimumBidAmount": 5000,
+					  "auctionDurationDays": null,
+					  "auctionDurationSeconds": 60,
+					  "images": [
+					    {
+					      "imageId": %d,
+					      "imageUrl": "http://localhost:8080/uploads/auction/images/test-image.jpg",
+					      "sortOrder": 1
+					    }
+					  ],
+					  "location": "서울 마포구",
+					  "draftId": null
+					}
+					""".formatted(uploadedImage.getImageId())))
+			.andExpect(status().isCreated())
+			.andExpect(jsonPath("$.auction.startAt").value(notNullValue()))
+			.andExpect(jsonPath("$.auction.endAt").value(notNullValue()));
+
+		var auction = auctionRepository.findAll().getFirst();
+		assertThat(Duration.between(auction.getAuctionStartAt(), auction.getAuctionEndAt()))
+			.isEqualTo(Duration.ofSeconds(60));
+	}
+
+	@Test
 	@DisplayName("경매 등록은 테스트용 소수 day 기간으로 10초 경매를 생성할 수 있다")
 	void createAuctionSupportsFractionalDurationDaysForTenSecondAuction() throws Exception {
 		mockMvc.perform(post("/api/v1/auction")

--- a/src/test/java/com/dealit/dealit/domain/auction/AuctionRefundServiceTest.java
+++ b/src/test/java/com/dealit/dealit/domain/auction/AuctionRefundServiceTest.java
@@ -1,0 +1,106 @@
+package com.dealit.dealit.domain.auction;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.dealit.dealit.domain.auction.entity.Auction;
+import com.dealit.dealit.domain.auction.entity.AuctionPayment;
+import com.dealit.dealit.domain.auction.repository.AuctionPaymentRepository;
+import com.dealit.dealit.domain.auction.service.AuctionRefundService;
+import com.dealit.dealit.domain.product.ProductSaleType;
+import com.dealit.dealit.domain.product.ProductStatus;
+import com.dealit.dealit.domain.product.entity.Product;
+import com.dealit.dealit.domain.wallet.service.WalletService;
+import java.math.BigDecimal;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class AuctionRefundServiceTest {
+
+	private static final Clock FIXED_CLOCK = Clock.fixed(Instant.parse("2026-05-02T00:00:00Z"), ZoneOffset.UTC);
+
+	private final AuctionPaymentRepository auctionPaymentRepository = mock(AuctionPaymentRepository.class);
+	private final WalletService walletService = mock(WalletService.class);
+	private final AuctionRefundService auctionRefundService = new AuctionRefundService(
+		auctionPaymentRepository,
+		walletService,
+		FIXED_CLOCK
+	);
+
+	@Test
+	@DisplayName("환불 대기 결제는 지갑 환불 후 환불 완료 상태로 변경한다")
+	void refundPendingPaymentCompletesRefund() {
+		Long paymentId = 1L;
+		Long bidderId = 20L;
+		Auction auction = auction(10L);
+		AuctionPayment payment = AuctionPayment.reserve(
+			auction,
+			bidderId,
+			10L,
+			101000L,
+			OffsetDateTime.now(FIXED_CLOCK).minusMinutes(1)
+		);
+		payment.requestRefund(OffsetDateTime.now(FIXED_CLOCK).minusSeconds(30));
+		when(auctionPaymentRepository.findByAuctionPaymentIdAndDeletedAtIsNull(paymentId))
+			.thenReturn(Optional.of(payment));
+
+		auctionRefundService.refundPendingPayment(paymentId);
+
+		assertThat(payment.getStatus()).isEqualTo(AuctionPaymentStatus.REFUNDED);
+		assertThat(payment.getRefundedAt()).isEqualTo(OffsetDateTime.now(FIXED_CLOCK));
+		verify(walletService).refundAuctionPayment(bidderId, 101000L, auction.getAuctionId());
+	}
+
+	@Test
+	@DisplayName("이미 환불 완료된 결제는 중복 환불하지 않는다")
+	void refundPendingPaymentIsIdempotentWhenAlreadyRefunded() {
+		Long paymentId = 1L;
+		AuctionPayment payment = AuctionPayment.reserve(
+			auction(10L),
+			20L,
+			10L,
+			101000L,
+			OffsetDateTime.now(FIXED_CLOCK).minusMinutes(1)
+		);
+		payment.requestRefund(OffsetDateTime.now(FIXED_CLOCK).minusSeconds(30));
+		payment.completeRefund(OffsetDateTime.now(FIXED_CLOCK).minusSeconds(10));
+		when(auctionPaymentRepository.findByAuctionPaymentIdAndDeletedAtIsNull(paymentId))
+			.thenReturn(Optional.of(payment));
+
+		auctionRefundService.refundPendingPayment(paymentId);
+
+		verify(walletService, never()).refundAuctionPayment(anyLong(), anyLong(), anyLong());
+	}
+
+	private Auction auction(Long sellerId) {
+		Product product = Product.create(
+			"auction product",
+			"description",
+			ProductSaleType.AUCTION,
+			21L,
+			sellerId,
+			BigDecimal.ZERO,
+			false,
+			"서울 마포구",
+			null,
+			ProductStatus.ON_SALE
+		);
+		return Auction.create(
+			product,
+			new BigDecimal("100000"),
+			new BigDecimal("1000"),
+			OffsetDateTime.now(FIXED_CLOCK).minusDays(1),
+			OffsetDateTime.now(FIXED_CLOCK).plusDays(1),
+			AuctionStatus.ONGOING
+		);
+	}
+}


### PR DESCRIPTION
### 🚀 Summary

<!-- 작업 내용에 대한 간략한 설명을 써주세요. -->
- 경매 보증금 제도 
- 추월 시 환불 프로세스구현 
---

### ✨ Description

<!-- 상세한 설명, 기능의 사용법, 주의 사항 실행 결과(이미지 첨부 가능) 등을 보여주세요. -->
### 작업 내용
경매 입찰 보증금 처리

입찰 시 입찰자의 Dealit Pay 잔액을 검증하고 입찰 금액만큼 차감
<img width="703" height="118" alt="스크린샷 2026-05-08 오후 10 30 17" src="https://github.com/user-attachments/assets/bf918b2c-b000-44fb-9c41-43ad965d6693" />


차감된 금액을 AuctionPayment로 생성하고 RESERVED 상태로 관리
<img width="1138" height="128" alt="스크린샷 2026-05-08 오후 10 45 53" src="https://github.com/user-attachments/assets/e245bc1c-b8b3-4576-995e-08c109688866" />


- Wallet.balance는 사용 가능 잔액만 유지하도록 처리 새로운 최고 입찰자가 발생하면 기존 최고 입찰자의 예치금을 즉시 환불
- 기존 최고 입찰자의 Wallet.balance 증가 기존 AuctionPayment 상태를 REFUNDED로 변경,현재 최고 입찰자만 RESERVED 상태 유지

- 낙찰 시 기존처럼 Auction.status = SUCCESSFUL_BID, Product.status = SOLD 처리

- 낙찰자의 예치금은 정산하지 않고 RESERVED 상태로 유지
- 1분 경매테스트 추가

자세한 사진은 프론트PR 확인


테스트

./gradlew compileJava compileTestJava test --tests com.dealit.dealit.domain.auction.AuctionBidServiceTest
./gradlew test --tests com.dealit.dealit.domain.auction.AuctionIntegrationTest.createAuctionSupportsSixtySecondAuction

채팅방 생성, 발송/수령 확인, 분쟁, 판매자 정산은 이번 PR 범위에서 제외

---

### 🎲 Issue Number

<!-- Please enter {Issue Number} below to automatically close the connected issue. -->

close #59 
