### PR TITLE
fix: 경매 입찰 시 이전 입찰자 환불을 커밋 이후 처리하도록 분리

### DIFF
--- a/docs/auction-payment-status.md
+++ b/docs/auction-payment-status.md
@@ -1,0 +1,13 @@
+# Auction Payment Status
+
+경매 입찰 예치금과 정산 상태는 `AuctionPaymentStatus`로 관리한다.
+
+| Status | Description |
+| --- | --- |
+| `RESERVED` | 입찰 금액이 지갑에서 차감되어 예치 중인 상태 |
+| `REFUND_PENDING` | 더 높은 입찰로 추월되어 환불 처리가 대기 중인 상태 |
+| `REFUNDED` | 추월된 입찰 예치금이 지갑으로 환불 완료된 상태 |
+| `SETTLED` | 낙찰 금액이 판매자에게 정산 완료된 상태 |
+| `DISPUTED` | 문제 신고로 정산이 보류된 상태 |
+
+추월 입찰 발생 시 입찰 트랜잭션 안에서는 이전 최고 입찰자의 결제를 `REFUND_PENDING`으로만 변경한다. 실제 지갑 환불은 입찰 트랜잭션 커밋 이후 이벤트 리스너 또는 환불 스케줄러가 처리한다.

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1180,7 +1180,7 @@ paths:
       tags:
       - Auction
       summary: 경매 입찰
-      description: 서버 도착 시간 기준으로 입찰을 처리한다. 입찰 금액은 Dealit Pay에서 즉시 예치되고, 추월당한 기존 최고 입찰자의 예치금은 자동 환불된다.
+      description: 서버 도착 시간 기준으로 입찰을 처리한다. 입찰 금액은 Dealit Pay에서 즉시 예치되고, 추월당한 기존 최고 입찰자의 예치금은 커밋 이후 자동 환불 처리된다.
       operationId: bid
       parameters:
       - name: auctionId

--- a/src/main/java/com/dealit/dealit/domain/auction/AuctionPaymentStatus.java
+++ b/src/main/java/com/dealit/dealit/domain/auction/AuctionPaymentStatus.java
@@ -2,5 +2,8 @@ package com.dealit.dealit.domain.auction;
 
 public enum AuctionPaymentStatus {
 	RESERVED,
-	REFUNDED
+	REFUND_PENDING,
+	REFUNDED,
+	SETTLED,
+	DISPUTED
 }

--- a/src/main/java/com/dealit/dealit/domain/auction/entity/AuctionPayment.java
+++ b/src/main/java/com/dealit/dealit/domain/auction/entity/AuctionPayment.java
@@ -55,8 +55,17 @@ public class AuctionPayment extends BaseEntity {
 	@Column(name = "reserved_at", nullable = false)
 	private OffsetDateTime reservedAt;
 
+	@Column(name = "refund_requested_at")
+	private OffsetDateTime refundRequestedAt;
+
 	@Column(name = "refunded_at")
 	private OffsetDateTime refundedAt;
+
+	@Column(name = "settled_at")
+	private OffsetDateTime settledAt;
+
+	@Column(name = "disputed_at")
+	private OffsetDateTime disputedAt;
 
 	private AuctionPayment(Auction auction, Long bidderId, Long sellerId, Long amount, OffsetDateTime reservedAt) {
 		this.auction = auction;
@@ -71,11 +80,23 @@ public class AuctionPayment extends BaseEntity {
 		return new AuctionPayment(auction, bidderId, sellerId, amount, reservedAt);
 	}
 
-	public boolean refund(OffsetDateTime refundedAt) {
-		if (status == AuctionPaymentStatus.REFUNDED) {
+	public boolean requestRefund(OffsetDateTime refundRequestedAt) {
+		if (status == AuctionPaymentStatus.REFUND_PENDING || status == AuctionPaymentStatus.REFUNDED) {
 			return false;
 		}
 		if (status != AuctionPaymentStatus.RESERVED) {
+			return false;
+		}
+		this.status = AuctionPaymentStatus.REFUND_PENDING;
+		this.refundRequestedAt = refundRequestedAt;
+		return true;
+	}
+
+	public boolean completeRefund(OffsetDateTime refundedAt) {
+		if (status == AuctionPaymentStatus.REFUNDED) {
+			return false;
+		}
+		if (status != AuctionPaymentStatus.REFUND_PENDING) {
 			return false;
 		}
 		this.status = AuctionPaymentStatus.REFUNDED;

--- a/src/main/java/com/dealit/dealit/domain/auction/event/AuctionRefundEventListener.java
+++ b/src/main/java/com/dealit/dealit/domain/auction/event/AuctionRefundEventListener.java
@@ -1,0 +1,31 @@
+package com.dealit.dealit.domain.auction.event;
+
+import com.dealit.dealit.domain.auction.service.AuctionRefundService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AuctionRefundEventListener {
+
+	private final AuctionRefundService auctionRefundService;
+
+	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+	public void refund(AuctionRefundRequestedEvent event) {
+		try {
+			auctionRefundService.refundPendingPayment(event.paymentId());
+		} catch (RuntimeException exception) {
+			log.warn(
+				"Auction refund event handling failed. paymentId={}, auctionId={}, bidderId={}",
+				event.paymentId(),
+				event.auctionId(),
+				event.bidderId(),
+				exception
+			);
+		}
+	}
+}

--- a/src/main/java/com/dealit/dealit/domain/auction/event/AuctionRefundRequestedEvent.java
+++ b/src/main/java/com/dealit/dealit/domain/auction/event/AuctionRefundRequestedEvent.java
@@ -1,0 +1,9 @@
+package com.dealit.dealit.domain.auction.event;
+
+public record AuctionRefundRequestedEvent(
+	Long auctionId,
+	Long bidderId,
+	Long paymentId,
+	Long amount
+) {
+}

--- a/src/main/java/com/dealit/dealit/domain/auction/repository/AuctionPaymentRepository.java
+++ b/src/main/java/com/dealit/dealit/domain/auction/repository/AuctionPaymentRepository.java
@@ -3,9 +3,14 @@ package com.dealit.dealit.domain.auction.repository;
 import com.dealit.dealit.domain.auction.AuctionPaymentStatus;
 import com.dealit.dealit.domain.auction.entity.AuctionPayment;
 import jakarta.persistence.LockModeType;
+import java.time.OffsetDateTime;
+import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface AuctionPaymentRepository extends JpaRepository<AuctionPayment, Long> {
 
@@ -14,5 +19,22 @@ public interface AuctionPaymentRepository extends JpaRepository<AuctionPayment, 
 		Long auctionId,
 		Long bidderId,
 		AuctionPaymentStatus status
+	);
+
+	@Lock(LockModeType.PESSIMISTIC_WRITE)
+	Optional<AuctionPayment> findByAuctionPaymentIdAndDeletedAtIsNull(Long auctionPaymentId);
+
+	@Query("""
+		SELECT p
+		FROM AuctionPayment p
+		WHERE p.status = :status
+		  AND p.refundRequestedAt < :threshold
+		  AND p.deletedAt IS NULL
+		ORDER BY p.refundRequestedAt ASC, p.auctionPaymentId ASC
+	""")
+	List<AuctionPayment> findRefundPendingBefore(
+		@Param("status") AuctionPaymentStatus status,
+		@Param("threshold") OffsetDateTime threshold,
+		Pageable pageable
 	);
 }

--- a/src/main/java/com/dealit/dealit/domain/auction/scheduler/AuctionRefundScheduler.java
+++ b/src/main/java/com/dealit/dealit/domain/auction/scheduler/AuctionRefundScheduler.java
@@ -1,0 +1,27 @@
+package com.dealit.dealit.domain.auction.scheduler;
+
+import com.dealit.dealit.domain.auction.service.AuctionRefundService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AuctionRefundScheduler {
+
+	private final AuctionRefundService auctionRefundService;
+
+	@Scheduled(fixedDelayString = "${app.auction.refund-scheduler-delay-ms:60000}")
+	public void refundStalePendingPayments() {
+		auctionRefundService.findStalePendingPaymentIds()
+			.forEach(paymentId -> {
+				try {
+					auctionRefundService.refundPendingPayment(paymentId);
+				} catch (RuntimeException exception) {
+					log.warn("Auction refund scheduler failed. paymentId={}", paymentId, exception);
+				}
+			});
+	}
+}

--- a/src/main/java/com/dealit/dealit/domain/auction/service/AuctionBidService.java
+++ b/src/main/java/com/dealit/dealit/domain/auction/service/AuctionBidService.java
@@ -14,6 +14,7 @@ import com.dealit.dealit.domain.auction.entity.AuctionPayment;
 import com.dealit.dealit.domain.auction.entity.Category;
 import com.dealit.dealit.domain.auction.entity.Bid;
 import com.dealit.dealit.domain.auction.event.AuctionEventPublisher;
+import com.dealit.dealit.domain.auction.event.AuctionRefundRequestedEvent;
 import com.dealit.dealit.domain.auction.exception.AuctionNotFoundException;
 import com.dealit.dealit.domain.auction.exception.InvalidAuctionRequestException;
 import com.dealit.dealit.domain.auction.redis.AuctionRedisService;
@@ -41,6 +42,7 @@ import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.redis.RedisConnectionFailureException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -58,6 +60,7 @@ public class AuctionBidService {
 	private final WalletService walletService;
 	private final AuctionRedisService auctionRedisService;
 	private final AuctionEventPublisher auctionEventPublisher;
+	private final ApplicationEventPublisher applicationEventPublisher;
 	private final ImageUrlService imageUrlService;
 	private final Clock clock;
 
@@ -164,7 +167,7 @@ public class AuctionBidService {
 				try {
 					OffsetDateTime serverTime = serverTime();
 					auctionPaymentRepository.save(AuctionPayment.reserve(auction, bidderId, sellerId, bidAmount, serverTime));
-					refundPreviousHighestBidder(auctionId, result.previousBidderId(), serverTime);
+					requestPreviousHighestBidderRefund(auctionId, result.previousBidderId(), serverTime);
 					bidRepository.save(Bid.create(auction, bidderId, bidPrice));
 					auction.updateCurrentPrice(bidPrice);
 					long bidCount = bidRepository.countByAuctionAuctionId(auction.getAuctionId());
@@ -269,7 +272,7 @@ public class AuctionBidService {
 			.orElseThrow(() -> new InvalidAuctionRequestException("존재하지 않는 회원입니다."));
 	}
 
-	private void refundPreviousHighestBidder(Long auctionId, Long previousBidderId, OffsetDateTime refundedAt) {
+	private void requestPreviousHighestBidderRefund(Long auctionId, Long previousBidderId, OffsetDateTime refundRequestedAt) {
 		if (previousBidderId == null) {
 			return;
 		}
@@ -280,8 +283,13 @@ public class AuctionBidService {
 				AuctionPaymentStatus.RESERVED
 			)
 			.orElseThrow(() -> new InvalidAuctionRequestException("이전 최고 입찰자의 예치금을 찾을 수 없습니다."));
-		if (previousPayment.refund(refundedAt)) {
-			walletService.refundAuctionPayment(previousPayment.getBidderId(), previousPayment.getAmount(), auctionId);
+		if (previousPayment.requestRefund(refundRequestedAt)) {
+			applicationEventPublisher.publishEvent(new AuctionRefundRequestedEvent(
+				auctionId,
+				previousPayment.getBidderId(),
+				previousPayment.getAuctionPaymentId(),
+				previousPayment.getAmount()
+			));
 		}
 	}
 

--- a/src/main/java/com/dealit/dealit/domain/auction/service/AuctionRefundService.java
+++ b/src/main/java/com/dealit/dealit/domain/auction/service/AuctionRefundService.java
@@ -1,0 +1,58 @@
+package com.dealit.dealit.domain.auction.service;
+
+import com.dealit.dealit.domain.auction.AuctionPaymentStatus;
+import com.dealit.dealit.domain.auction.entity.AuctionPayment;
+import com.dealit.dealit.domain.auction.repository.AuctionPaymentRepository;
+import com.dealit.dealit.domain.wallet.service.WalletService;
+import java.time.Clock;
+import java.time.OffsetDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AuctionRefundService {
+
+	private static final int REFUND_BATCH_SIZE = 100;
+
+	private final AuctionPaymentRepository auctionPaymentRepository;
+	private final WalletService walletService;
+	private final Clock clock;
+
+	@Transactional
+	public void refundPendingPayment(Long paymentId) {
+		AuctionPayment payment = auctionPaymentRepository.findByAuctionPaymentIdAndDeletedAtIsNull(paymentId)
+			.orElse(null);
+		if (payment == null || payment.getStatus() == AuctionPaymentStatus.REFUNDED) {
+			return;
+		}
+		if (payment.getStatus() != AuctionPaymentStatus.REFUND_PENDING) {
+			return;
+		}
+
+		OffsetDateTime refundedAt = OffsetDateTime.now(clock);
+		if (payment.completeRefund(refundedAt)) {
+			walletService.refundAuctionPayment(
+				payment.getBidderId(),
+				payment.getAmount(),
+				payment.getAuction().getAuctionId()
+			);
+		}
+	}
+
+	public List<Long> findStalePendingPaymentIds() {
+		OffsetDateTime threshold = OffsetDateTime.now(clock).minusSeconds(10);
+		return auctionPaymentRepository.findRefundPendingBefore(
+				AuctionPaymentStatus.REFUND_PENDING,
+				threshold,
+				PageRequest.of(0, REFUND_BATCH_SIZE)
+			)
+			.stream()
+			.map(AuctionPayment::getAuctionPaymentId)
+			.toList();
+	}
+}

--- a/src/test/java/com/dealit/dealit/domain/auction/AuctionBidServiceTest.java
+++ b/src/test/java/com/dealit/dealit/domain/auction/AuctionBidServiceTest.java
@@ -48,6 +48,8 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
@@ -63,6 +65,7 @@ class AuctionBidServiceTest {
 	private final WalletService walletService = mock(WalletService.class);
 	private final AuctionRedisService auctionRedisService = mock(AuctionRedisService.class);
 	private final AuctionEventPublisher auctionEventPublisher = mock(AuctionEventPublisher.class);
+	private final ApplicationEventPublisher applicationEventPublisher = mock(ApplicationEventPublisher.class);
 	private final ImageUrlService imageUrlService = mock(ImageUrlService.class);
 
 	private final AuctionBidService auctionBidService = new AuctionBidService(
@@ -74,6 +77,7 @@ class AuctionBidServiceTest {
 		walletService,
 		auctionRedisService,
 		auctionEventPublisher,
+		applicationEventPublisher,
 		imageUrlService,
 		FIXED_CLOCK
 	);
@@ -217,6 +221,51 @@ class AuctionBidServiceTest {
 		assertThat(((InvalidAuctionRequestException) result).getMessage()).isEqualTo("이미 종료된 경매입니다.");
 		verify(auctionRedisService, never()).bid(anyLong(), any(BigDecimal.class), anyLong());
 		verify(bidRepository, never()).save(any(Bid.class));
+	}
+
+	@Test
+	@DisplayName("추월 입찰은 이전 최고 입찰자의 예치금을 환불 대기로 바꾸고 커밋 이후 환불 이벤트를 발행한다")
+	void bidRequestsPreviousHighestBidderRefundWithoutDirectWalletRefund() {
+		Long auctionId = 1L;
+		Long sellerId = 10L;
+		Long bidderId = 30L;
+		Long previousBidderId = 20L;
+		Auction auction = auction(sellerId);
+		AuctionPayment previousPayment = AuctionPayment.reserve(
+			auction,
+			previousBidderId,
+			sellerId,
+			101000L,
+			OffsetDateTime.now(FIXED_CLOCK).minusMinutes(1)
+		);
+		when(auctionRepository.findWithLockByAuctionIdAndDeletedAtIsNullAndProductDeletedAtIsNull(auctionId))
+			.thenReturn(Optional.of(auction));
+		when(memberRepository.findByMemberIdAndDeletedAtIsNull(bidderId))
+			.thenReturn(Optional.of(verifiedMember("bidder30")));
+		when(walletService.reserveAuctionBid(bidderId, 102000L, auctionId)).thenReturn(0L);
+		when(auctionRedisService.bid(auctionId, new BigDecimal("102000"), bidderId))
+			.thenReturn(new BidScriptResult(
+				BidScriptStatus.SUCCESS,
+				previousBidderId,
+				new BigDecimal("101000")
+			));
+		when(auctionPaymentRepository.save(any(AuctionPayment.class))).thenAnswer(invocation -> invocation.getArgument(0));
+		when(auctionPaymentRepository.findFirstByAuctionAuctionIdAndBidderIdAndStatusAndDeletedAtIsNullOrderByReservedAtDescAuctionPaymentIdDesc(
+			auctionId,
+			previousBidderId,
+			AuctionPaymentStatus.RESERVED
+		)).thenReturn(Optional.of(previousPayment));
+		when(bidRepository.save(any(Bid.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+		auctionBidService.bid(auctionId, bidderId, new BigDecimal("102000"));
+
+		assertThat(previousPayment.getStatus()).isEqualTo(AuctionPaymentStatus.REFUND_PENDING);
+		assertThat(previousPayment.getRefundRequestedAt()).isEqualTo(OffsetDateTime.now(FIXED_CLOCK));
+		verify(walletService, never()).refundAuctionPayment(anyLong(), anyLong(), anyLong());
+		ArgumentCaptor<Object> eventCaptor = ArgumentCaptor.forClass(Object.class);
+		verify(applicationEventPublisher).publishEvent(eventCaptor.capture());
+		assertThat(eventCaptor.getValue())
+			.isInstanceOf(com.dealit.dealit.domain.auction.event.AuctionRefundRequestedEvent.class);
 	}
 
 	@Test

--- a/src/test/java/com/dealit/dealit/domain/auction/AuctionRefundServiceTest.java
+++ b/src/test/java/com/dealit/dealit/domain/auction/AuctionRefundServiceTest.java
@@ -1,0 +1,106 @@
+package com.dealit.dealit.domain.auction;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.dealit.dealit.domain.auction.entity.Auction;
+import com.dealit.dealit.domain.auction.entity.AuctionPayment;
+import com.dealit.dealit.domain.auction.repository.AuctionPaymentRepository;
+import com.dealit.dealit.domain.auction.service.AuctionRefundService;
+import com.dealit.dealit.domain.product.ProductSaleType;
+import com.dealit.dealit.domain.product.ProductStatus;
+import com.dealit.dealit.domain.product.entity.Product;
+import com.dealit.dealit.domain.wallet.service.WalletService;
+import java.math.BigDecimal;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class AuctionRefundServiceTest {
+
+	private static final Clock FIXED_CLOCK = Clock.fixed(Instant.parse("2026-05-02T00:00:00Z"), ZoneOffset.UTC);
+
+	private final AuctionPaymentRepository auctionPaymentRepository = mock(AuctionPaymentRepository.class);
+	private final WalletService walletService = mock(WalletService.class);
+	private final AuctionRefundService auctionRefundService = new AuctionRefundService(
+		auctionPaymentRepository,
+		walletService,
+		FIXED_CLOCK
+	);
+
+	@Test
+	@DisplayName("환불 대기 결제는 지갑 환불 후 환불 완료 상태로 변경한다")
+	void refundPendingPaymentCompletesRefund() {
+		Long paymentId = 1L;
+		Long bidderId = 20L;
+		Auction auction = auction(10L);
+		AuctionPayment payment = AuctionPayment.reserve(
+			auction,
+			bidderId,
+			10L,
+			101000L,
+			OffsetDateTime.now(FIXED_CLOCK).minusMinutes(1)
+		);
+		payment.requestRefund(OffsetDateTime.now(FIXED_CLOCK).minusSeconds(30));
+		when(auctionPaymentRepository.findByAuctionPaymentIdAndDeletedAtIsNull(paymentId))
+			.thenReturn(Optional.of(payment));
+
+		auctionRefundService.refundPendingPayment(paymentId);
+
+		assertThat(payment.getStatus()).isEqualTo(AuctionPaymentStatus.REFUNDED);
+		assertThat(payment.getRefundedAt()).isEqualTo(OffsetDateTime.now(FIXED_CLOCK));
+		verify(walletService).refundAuctionPayment(bidderId, 101000L, auction.getAuctionId());
+	}
+
+	@Test
+	@DisplayName("이미 환불 완료된 결제는 중복 환불하지 않는다")
+	void refundPendingPaymentIsIdempotentWhenAlreadyRefunded() {
+		Long paymentId = 1L;
+		AuctionPayment payment = AuctionPayment.reserve(
+			auction(10L),
+			20L,
+			10L,
+			101000L,
+			OffsetDateTime.now(FIXED_CLOCK).minusMinutes(1)
+		);
+		payment.requestRefund(OffsetDateTime.now(FIXED_CLOCK).minusSeconds(30));
+		payment.completeRefund(OffsetDateTime.now(FIXED_CLOCK).minusSeconds(10));
+		when(auctionPaymentRepository.findByAuctionPaymentIdAndDeletedAtIsNull(paymentId))
+			.thenReturn(Optional.of(payment));
+
+		auctionRefundService.refundPendingPayment(paymentId);
+
+		verify(walletService, never()).refundAuctionPayment(anyLong(), anyLong(), anyLong());
+	}
+
+	private Auction auction(Long sellerId) {
+		Product product = Product.create(
+			"auction product",
+			"description",
+			ProductSaleType.AUCTION,
+			21L,
+			sellerId,
+			BigDecimal.ZERO,
+			false,
+			"서울 마포구",
+			null,
+			ProductStatus.ON_SALE
+		);
+		return Auction.create(
+			product,
+			new BigDecimal("100000"),
+			new BigDecimal("1000"),
+			OffsetDateTime.now(FIXED_CLOCK).minusDays(1),
+			OffsetDateTime.now(FIXED_CLOCK).plusDays(1),
+			AuctionStatus.ONGOING
+		);
+	}
+}


### PR DESCRIPTION
### 🚀 Summary

경매 입찰 트랜잭션에서 이전 최고 입찰자 Wallet 환불을 분리했습니다.

서로 다른 경매에서 동일 사용자들이 교차 입찰할 때 발생할 수 있는 Wallet 락 데드락을 방지하기 위해, 이전 최고 입찰자 환불은 `REFUND_PENDING` 상태로 기록한 뒤 커밋 이후 이벤트/스케줄러에서 처리하도록 변경했습니다.

---

### ✨ Description

#### 문제 상황

기존에는 입찰 성공 트랜잭션 안에서 다음 작업을 모두 처리했습니다.

- 현재 입찰자 Wallet 차감
- Redis 최고 입찰자 갱신
- 신규 `AuctionPayment` 저장
- 이전 최고 입찰자 Wallet 즉시 환불

이 구조에서는 서로 다른 경매에서 동일 사용자들이 교차 입찰할 때 Wallet 락 순서가 엇갈릴 수 있습니다.

예를 들어 동시에 아래 상황이 발생할 수 있습니다.

- 경매상품1: A가 이전 입찰자이고 B가 입찰
- 경매상품2: B가 이전 입찰자이고 A가 입찰

기존 구조에서는 다음처럼 처리될 수 있습니다.

경매상품1 트랜잭션: B Wallet 잠금 -> A Wallet 환불 시도
경매상품2 트랜잭션: A Wallet 잠금 -> B Wallet 환불 시도
이 경우 두 트랜잭션이 서로 상대 Wallet 락을 기다리면서 데드락이 발생할 수 있습니다.
변경 후 처리 흐름
입찰 트랜잭션 안에서는 현재 입찰자 Wallet만 처리하고, 이전 입찰자 Wallet 환불은 커밋 이후로 분리했습니다.
경매상품1 입찰 트랜잭션
1. B Wallet 차감
2. 경매상품1 Redis 최고 입찰자 B로 갱신
3. B의 AuctionPayment RESERVED 저장
4. A의 기존 AuctionPayment를 REFUND_PENDING으로 변경
5. 커밋

경매상품2 입찰 트랜잭션
1. A Wallet 차감
2. 경매상품2 Redis 최고 입찰자 A로 갱신
3. A의 AuctionPayment RESERVED 저장
4. B의 기존 AuctionPayment를 REFUND_PENDING으로 변경
5. 커밋
이제 입찰 트랜잭션 안에서는 다음처럼 각각 현재 입찰자의 Wallet만 잠급니다.
경매상품1 트랜잭션: B Wallet만 잠금
경매상품2 트랜잭션: A Wallet만 잠금
커밋 이후 환불 이벤트가 별도로 실행됩니다.

경매상품1 커밋 이후:
A의 REFUND_PENDING 결제를 찾아 A Wallet 환불
A 결제 상태 REFUNDED

경매상품2 커밋 이후:
B의 REFUND_PENDING 결제를 찾아 B Wallet 환불
B 결제 상태 REFUNDED

변경 사항
AuctionPaymentStatus에 REFUND_PENDING, SETTLED, DISPUTED 추가
AuctionPayment에 refundRequestedAt, settledAt, disputedAt 추가
이전 최고 입찰자 환불 로직을 즉시 Wallet 환불에서 REFUND_PENDING 상태 변경으로 수정
AuctionRefundRequestedEvent 추가
@TransactionalEventListener(phase = AFTER_COMMIT) 기반 환불 이벤트 리스너 추가
AuctionRefundService 추가
이벤트 처리 실패 대비 AuctionRefundScheduler 추가

이미 REFUNDED 상태인 결제는 다시 환불하지 않도록 멱등성 보장

경매 결제 상태 문서 추가

관련 단위 테스트 추가
기대 효과
입찰 트랜잭션에서 현재 입찰자 Wallet과 이전 최고 입찰자 Wallet을 함께 잠그지 않게 되어, 교차 입찰 상황에서 발생할 수 있는 Wallet 락 데드락을 방지합니다.
환불 이벤트 처리에 실패해도 REFUND_PENDING 상태로 남아 있으며, 스케줄러가 이후 다시 환불을 시도합니다.


요약
경매상품1: 기존 최고 입찰자 A, 새 입찰자 B
경매상품2: 기존 최고 입찰자 B, 새 입찰자 A
이럴때 wallet에 동시에 접근하기에 데드락이 발생하는 경우가 발생하여 fix하였습니다.
따라서,
환불은 입찰 트랜잭션 커밋 직후 이벤트 리스너에서 우선 처리합니다. 이벤트 처리 실패 등으로 `REFUND_PENDING` 상태가 남을 경우,
스케줄러가 기본 60초마다 실행되어 `REFUND_PENDING`으로 변경된 지 10초 이상 지난 결제를 재처리합니다.

테스트
./gradlew test --tests com.dealit.dealit.domain.auction.AuctionBidServiceTest --tests com.dealit.dealit.domain.auction.AuctionRefundServiceTest

---

### 🎲 Issue Number

<!-- Please enter {Issue Number} below to automatically close the connected issue. -->

close #61 
