### PR TITLE
[feat] 구매중 경매 목록 기능 추가

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1131,51 +1131,51 @@ paths:
             '*/*':
               schema:
                 $ref: "#/components/schemas/LoginResponse"
-  /api/v1/auctions/popular:
-    get:
-      tags:
-      - Auction
-      summary: 실시간 인기 경매 목록 조회
-      description: 입찰 수를 등록 후 경과 시간으로 나눈 점수 기준으로 진행 중인 경매를 조회한다.
-      operationId: getPopularAuctions
-      parameters:
-      - name: limit
-        in: query
-        required: false
-        schema:
-          type: integer
-          format: int32
-          default: 4
-      responses:
-        "200":
-          description: 실시간 인기 경매 목록 조회 성공
-          content:
-            '*/*':
-              schema:
-                $ref: "#/components/schemas/AuctionListResponse"
-  /api/v1/auctions/closing-soon:
-    get:
-      tags:
-      - Auction
-      summary: 마감임박 경매 목록 조회
-      description: 현재 서버 시간 기준 종료 시각이 가까운 진행 중 경매를 조회한다.
-      operationId: getClosingSoonAuctions
-      parameters:
-      - name: limit
-        in: query
-        required: false
-        schema:
-          type: integer
-          format: int32
-          default: 3
-      responses:
-        "200":
-          description: 마감임박 경매 목록 조회 성공
-          content:
-            '*/*':
-              schema:
-                $ref: "#/components/schemas/AuctionListResponse"
   /api/v1/auctions/{auctionId}/bids:
+    get:
+      tags:
+      - Auction
+      summary: 경매 입찰 현황 조회
+      description: 경매 현재가와 입찰 내역을 최신순으로 조회한다.
+      operationId: getBidHistory
+      parameters:
+      - name: auctionId
+        in: path
+        required: true
+        schema:
+          type: integer
+          format: int64
+      responses:
+        "400":
+          description: Bad Request
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: Not Found
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "409":
+          description: Conflict
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "200":
+          description: OK
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/AuctionBidHistoryResponse"
     post:
       tags:
       - Auction
@@ -2148,6 +2148,96 @@ paths:
             '*/*':
               schema:
                 $ref: "#/components/schemas/ProductEditDetailResponse"
+  /api/v1/products/popular:
+    get:
+      tags:
+      - Product
+      summary: 실시간 인기 일반 상품 목록 조회
+      operationId: getPopularProducts
+      parameters:
+      - name: size
+        in: query
+        required: false
+        schema:
+          type: integer
+          format: int32
+          default: 10
+      responses:
+        "400":
+          description: Bad Request
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: Not Found
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "409":
+          description: Conflict
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "200":
+          description: 실시간 인기 일반 상품 목록 조회 성공
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/PopularProductListResponse"
+  /api/v1/products/hot-list:
+    get:
+      tags:
+      - Product
+      summary: 핫한 일반 상품 목록 조회
+      operationId: getHotListProducts
+      parameters:
+      - name: size
+        in: query
+        required: false
+        schema:
+          type: integer
+          format: int32
+          default: 8
+      responses:
+        "400":
+          description: Bad Request
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: Not Found
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "409":
+          description: Conflict
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "200":
+          description: 핫한 일반 상품 목록 조회 성공
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/HotListProductListResponse"
   /api/v1/products/categories:
     get:
       tags:
@@ -2343,6 +2433,59 @@ paths:
             '*/*':
               schema:
                 $ref: "#/components/schemas/MySellingAuctionListResponse"
+  /api/v1/mypage/auctions/buying:
+    get:
+      tags:
+      - Auction
+      summary: 내 구매중 경매 목록
+      description: 마이페이지 구매중 화면에서 현재 사용자가 입찰한 경매 목록을 조회합니다.
+      operationId: getMyBuyingAuctions
+      parameters:
+      - name: page
+        in: query
+        required: false
+        schema:
+          type: integer
+          format: int32
+          default: 0
+      - name: size
+        in: query
+        required: false
+        schema:
+          type: integer
+          format: int32
+          default: 20
+      responses:
+        "400":
+          description: Bad Request
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: Not Found
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "409":
+          description: Conflict
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "200":
+          description: 내 구매중 경매 목록 조회 성공
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/MyBuyingAuctionListResponse"
   /api/v1/members/nickname/check:
     get:
       tags:
@@ -2715,6 +2858,98 @@ paths:
             '*/*':
               schema:
                 $ref: "#/components/schemas/AuctionEditDetailResponse"
+  /api/v1/auctions/popular:
+    get:
+      tags:
+      - Auction
+      summary: 실시간 인기 경매 목록 조회
+      description: 입찰 수를 등록 후 경과 시간으로 나눈 점수 기준으로 진행 중인 경매를 조회한다.
+      operationId: getPopularAuctions
+      parameters:
+      - name: limit
+        in: query
+        required: false
+        schema:
+          type: integer
+          format: int32
+          default: 4
+      responses:
+        "400":
+          description: Bad Request
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: Not Found
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "409":
+          description: Conflict
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "200":
+          description: 실시간 인기 경매 목록 조회 성공
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/AuctionListResponse"
+  /api/v1/auctions/closing-soon:
+    get:
+      tags:
+      - Auction
+      summary: 마감임박 경매 목록 조회
+      description: 현재 서버 시간 기준 종료 시각이 가까운 진행 중 경매를 조회한다.
+      operationId: getClosingSoonAuctions
+      parameters:
+      - name: limit
+        in: query
+        required: false
+        schema:
+          type: integer
+          format: int32
+          default: 3
+      responses:
+        "400":
+          description: Bad Request
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: Not Found
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "409":
+          description: Conflict
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "200":
+          description: 마감임박 경매 목록 조회 성공
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/AuctionListResponse"
   /api/v1/auction/categories:
     get:
       tags:
@@ -2796,6 +3031,47 @@ paths:
             '*/*':
               schema:
                 $ref: "#/components/schemas/DeleteProductImageResponse"
+  /api/v1/mypage/auctions/buying/{auctionId}:
+    delete:
+      tags:
+      - Auction
+      summary: 내 구매중 종료 경매 숨김
+      description: 마이페이지 구매중 화면에서 종료된 경매 내역을 현재 사용자에게만 숨깁니다.
+      operationId: hideEndedBuyingAuction
+      parameters:
+      - name: auctionId
+        in: path
+        required: true
+        schema:
+          type: integer
+          format: int64
+      responses:
+        "400":
+          description: Bad Request
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: Not Found
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "409":
+          description: 진행 중인 경매는 숨김 불가
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "204":
+          description: 내 구매중 종료 경매 숨김 성공
   /api/v1/chats/messages/{messageId}:
     delete:
       tags:
@@ -4435,6 +4711,122 @@ components:
           type: string
           description: 거래 위치
           example: 서울 강남구
+    PopularProductItemResponse:
+      type: object
+      description: 실시간 인기 일반 상품 항목
+      properties:
+        productId:
+          type: integer
+          format: int64
+          description: 상품 ID
+          example: 1
+        name:
+          type: string
+          description: 상품명
+          example: 맥북에어입니다.
+        thumbnailUrl:
+          type: string
+          description: 대표 이미지 URL
+          example: http://localhost:8080/uploads/product/images/1.jpg
+        price:
+          type: number
+          description: 가격
+          example: 30000
+        location:
+          type: string
+          description: 거래 위치
+          example: 서울 강남구
+        categoryName:
+          type: string
+          description: 카테고리명
+          example: 디지털기기
+        viewCount:
+          type: integer
+          format: int64
+          description: 조회수
+          example: 120
+        createdAt:
+          type: string
+          format: date-time
+          description: 등록 시각
+          example: 2026-05-03T12:00:00+09:00
+        popularScore:
+          type: number
+          format: double
+          description: 실시간 인기 점수
+          example: "30.0"
+    PopularProductListResponse:
+      type: object
+      description: 실시간 인기 일반 상품 목록 응답
+      properties:
+        content:
+          type: array
+          description: 실시간 인기 일반 상품 목록
+          items:
+            $ref: "#/components/schemas/PopularProductItemResponse"
+    HotListProductItemResponse:
+      type: object
+      description: 핫한 일반 상품 항목
+      properties:
+        productId:
+          type: integer
+          format: int64
+          description: 상품 ID
+          example: 1
+        name:
+          type: string
+          description: 상품명
+          example: 맥북 에어
+        thumbnailUrl:
+          type: string
+          description: 대표 이미지 URL
+          example: http://localhost:8080/uploads/product/images/1.jpg
+        price:
+          type: number
+          description: 가격
+          example: 30000
+        location:
+          type: string
+          description: 거래 위치
+          example: 서울 강남구
+        categoryName:
+          type: string
+          description: 카테고리명
+          example: 디지털기기
+        viewCount:
+          type: integer
+          format: int64
+          description: 조회수
+          example: 120
+        favoriteCount:
+          type: integer
+          format: int64
+          description: 찜 수
+          example: 15
+        hotScore:
+          type: number
+          format: double
+          description: 핫리스트 점수
+          example: "45.5"
+        rank:
+          type: integer
+          format: int32
+          description: 핫리스트 순위
+          example: 1
+        createdAt:
+          type: string
+          format: date-time
+          description: 등록 시각
+          example: 2026-05-03T12:00:00+09:00
+    HotListProductListResponse:
+      type: object
+      description: 핫한 일반 상품 목록 응답
+      properties:
+        content:
+          type: array
+          description: 핫한 일반 상품 목록
+          items:
+            $ref: "#/components/schemas/HotListProductItemResponse"
     CategoryOptionResponse:
       type: object
       description: 카테고리 선택 옵션
@@ -4760,6 +5152,71 @@ components:
           type: boolean
           description: 다음 페이지 존재 여부
           example: false
+    MyBuyingAuctionItemResponse:
+      type: object
+      properties:
+        productId:
+          type: integer
+          format: int64
+        auctionId:
+          type: integer
+          format: int64
+        name:
+          type: string
+        thumbnailUrl:
+          type: string
+        categoryName:
+          type: string
+        location:
+          type: string
+        myBidAmount:
+          type: number
+        currentHighestBidAmount:
+          type: number
+        buyingStatus:
+          type: string
+          enum:
+          - LEADING
+          - OUTBID
+          - ENDED
+        auctionStatus:
+          type: string
+          enum:
+          - DRAFT
+          - ONGOING
+          - ENDED
+          - NO_BID
+          - SUCCESSFUL_BID
+        bidCount:
+          type: integer
+          format: int32
+        bidderCount:
+          type: integer
+          format: int32
+        endsAt:
+          type: string
+          format: date-time
+        lastBidAt:
+          type: string
+          format: date-time
+    MyBuyingAuctionListResponse:
+      type: object
+      properties:
+        content:
+          type: array
+          items:
+            $ref: "#/components/schemas/MyBuyingAuctionItemResponse"
+        page:
+          type: integer
+          format: int32
+        size:
+          type: integer
+          format: int32
+        totalElements:
+          type: integer
+          format: int64
+        hasNext:
+          type: boolean
     NicknameCheckResponse:
       type: object
       properties:
@@ -4939,93 +5396,6 @@ components:
           type: boolean
           description: 이메일 인증 여부
           example: false
-    AuctionListResponse:
-      type: object
-      description: 경매 상품 목록 응답
-      properties:
-        content:
-          type: array
-          description: 경매 상품 목록
-          items:
-            $ref: "#/components/schemas/AuctionListItemResponse"
-    AuctionListItemResponse:
-      type: object
-      description: 경매 상품 목록 항목
-      properties:
-        auctionId:
-          type: integer
-          format: int64
-          description: 경매 ID
-          example: 1
-        productId:
-          type: integer
-          format: int64
-          description: 상품 ID
-          example: 1
-        title:
-          type: string
-          description: 상품명
-          example: 맥북 에어 경매
-        thumbnailUrl:
-          type: string
-          description: 대표 이미지 URL
-          example: http://localhost:8080/uploads/auction/images/1.jpg
-        startPrice:
-          type: number
-          description: 시작가
-          example: 10000
-        currentPrice:
-          type: number
-          description: 현재 입찰가
-          example: 35000
-        bidCount:
-          type: integer
-          format: int64
-          description: 입찰 수
-          example: 12
-        endAt:
-          type: string
-          format: date-time
-          description: 경매 종료 시각
-          example: 2026-05-06T18:00:00+09:00
-        auctionStatus:
-          type: string
-          description: 경매 상태
-          enum:
-          - DRAFT
-          - ONGOING
-          - ENDED
-          - NO_BID
-          - SUCCESSFUL_BID
-          example: ONGOING
-        location:
-          type: string
-          description: 거래 위치
-          example: 서울 강남구
-        categoryName:
-          type: string
-          description: 카테고리명
-          example: 디지털기기
-        sellerId:
-          type: integer
-          format: int64
-          description: 판매자 회원 ID
-          example: 10
-        popularScore:
-          type: number
-          format: double
-          description: 경매 인기 점수
-          example: 4.5
-        rank:
-          type: integer
-          format: int32
-          description: 순위
-          example: 1
-        createdAt:
-          type: string
-          format: date-time
-          description: 등록 시각
-          example: 2026-05-03T12:00:00+09:00
     AuctionDetailResponse:
       type: object
       properties:
@@ -5094,6 +5464,126 @@ components:
         sortOrder:
           type: integer
           format: int32
+    AuctionBidHistoryResponse:
+      type: object
+      properties:
+        auctionId:
+          type: integer
+          format: int64
+        currentPrice:
+          type: number
+        bidCount:
+          type: integer
+          format: int64
+        bids:
+          type: array
+          items:
+            $ref: "#/components/schemas/BidHistoryItem"
+    BidHistoryItem:
+      type: object
+      properties:
+        bidId:
+          type: integer
+          format: int64
+        bidderId:
+          type: integer
+          format: int64
+        bidderNickname:
+          type: string
+        bidPrice:
+          type: number
+        bidAt:
+          type: string
+          format: date-time
+        highest:
+          type: boolean
+    AuctionListItemResponse:
+      type: object
+      description: 경매 상품 목록 항목
+      properties:
+        auctionId:
+          type: integer
+          format: int64
+          description: 경매 ID
+          example: 1
+        productId:
+          type: integer
+          format: int64
+          description: 상품 ID
+          example: 1
+        title:
+          type: string
+          description: 상품명
+          example: 맥북 에어 경매
+        thumbnailUrl:
+          type: string
+          description: 대표 이미지 URL
+          example: http://localhost:8080/uploads/auction/images/1.jpg
+        startPrice:
+          type: number
+          description: 시작가
+          example: 10000
+        currentPrice:
+          type: number
+          description: 현재 입찰가
+          example: 35000
+        bidCount:
+          type: integer
+          format: int64
+          description: 입찰 수
+          example: 12
+        endAt:
+          type: string
+          format: date-time
+          description: 경매 종료 시각
+          example: 2026-05-06T18:00:00+09:00
+        auctionStatus:
+          type: string
+          description: 경매 상태
+          enum:
+          - DRAFT
+          - ONGOING
+          - ENDED
+          - NO_BID
+          - SUCCESSFUL_BID
+          example: ONGOING
+        location:
+          type: string
+          description: 거래 위치
+          example: 서울 강남구
+        categoryName:
+          type: string
+          description: 카테고리명
+          example: 디지털기기
+        sellerId:
+          type: integer
+          format: int64
+          description: 판매자 회원 ID
+          example: 10
+        popularScore:
+          type: number
+          format: double
+          description: 경매 인기 점수
+          example: "4.5"
+        rank:
+          type: integer
+          format: int32
+          description: 순위
+          example: 1
+        createdAt:
+          type: string
+          format: date-time
+          description: 등록 시각
+          example: 2026-05-03T12:00:00+09:00
+    AuctionListResponse:
+      type: object
+      description: 경매 상품 목록 응답
+      properties:
+        content:
+          type: array
+          description: 경매 상품 목록
+          items:
+            $ref: "#/components/schemas/AuctionListItemResponse"
     DeleteProductImageResponse:
       type: object
       description: 일반 상품 이미지 삭제 응답

--- a/src/main/java/com/dealit/dealit/domain/auction/BuyingAuctionStatus.java
+++ b/src/main/java/com/dealit/dealit/domain/auction/BuyingAuctionStatus.java
@@ -1,0 +1,7 @@
+package com.dealit.dealit.domain.auction;
+
+public enum BuyingAuctionStatus {
+	LEADING,
+	OUTBID,
+	ENDED
+}

--- a/src/main/java/com/dealit/dealit/domain/auction/controller/AuctionManagementController.java
+++ b/src/main/java/com/dealit/dealit/domain/auction/controller/AuctionManagementController.java
@@ -6,9 +6,11 @@ import com.dealit.dealit.domain.auction.dto.AuctionListResponse;
 import com.dealit.dealit.domain.auction.dto.BidRequest;
 import com.dealit.dealit.domain.auction.dto.BidResponse;
 import com.dealit.dealit.domain.auction.dto.AuctionEditDetailResponse;
+import com.dealit.dealit.domain.auction.dto.MyBuyingAuctionListResponse;
 import com.dealit.dealit.domain.auction.dto.MySellingAuctionListResponse;
 import com.dealit.dealit.domain.auction.dto.UpdateAuctionRequest;
 import com.dealit.dealit.domain.auction.service.AuctionBidService;
+import com.dealit.dealit.domain.auction.service.AuctionBuyingService;
 import com.dealit.dealit.domain.auction.service.AuctionService;
 import com.dealit.dealit.global.security.AuthenticatedMember;
 import io.swagger.v3.oas.annotations.Operation;
@@ -40,6 +42,7 @@ public class AuctionManagementController {
 
 	private final AuctionService auctionService;
 	private final AuctionBidService auctionBidService;
+	private final AuctionBuyingService auctionBuyingService;
 
 	@Operation(summary = "실시간 인기 경매 목록 조회", description = "입찰 수를 등록 후 경과 시간으로 나눈 점수 기준으로 진행 중인 경매를 조회한다.")
 	@ApiResponse(responseCode = "200", description = "실시간 인기 경매 목록 조회 성공",
@@ -89,6 +92,30 @@ public class AuctionManagementController {
 		@RequestParam(defaultValue = "20") int size
 	) {
 		return auctionService.getMySellingAuctionProducts(member.memberId(), page, size);
+	}
+
+	@Operation(summary = "내 구매중 경매 목록", description = "마이페이지 구매중 화면에서 현재 사용자가 입찰한 경매 목록을 조회합니다.")
+	@ApiResponse(responseCode = "200", description = "내 구매중 경매 목록 조회 성공",
+		content = @Content(schema = @Schema(implementation = MyBuyingAuctionListResponse.class)))
+	@GetMapping("/mypage/auctions/buying")
+	public MyBuyingAuctionListResponse getMyBuyingAuctions(
+		@AuthenticationPrincipal AuthenticatedMember member,
+		@RequestParam(defaultValue = "0") int page,
+		@RequestParam(defaultValue = "20") int size
+	) {
+		return auctionBuyingService.getMyBuyingAuctions(member.memberId(), page, size);
+	}
+
+	@Operation(summary = "내 구매중 종료 경매 숨김", description = "마이페이지 구매중 화면에서 종료된 경매 내역을 현재 사용자에게만 숨깁니다.")
+	@ApiResponse(responseCode = "204", description = "내 구매중 종료 경매 숨김 성공")
+	@ApiResponse(responseCode = "409", description = "진행 중인 경매는 숨김 불가")
+	@DeleteMapping("/mypage/auctions/buying/{auctionId:\\d+}")
+	@ResponseStatus(HttpStatus.NO_CONTENT)
+	public void hideEndedBuyingAuction(
+		@AuthenticationPrincipal AuthenticatedMember member,
+		@PathVariable Long auctionId
+	) {
+		auctionBuyingService.hideEndedBuyingAuction(member.memberId(), auctionId);
 	}
 
 	@Operation(summary = "경매 수정용 상세 조회", description = "현재 사용자가 등록한 경매의 수정 화면 데이터를 조회한다.")

--- a/src/main/java/com/dealit/dealit/domain/auction/dto/MyBuyingAuctionItemResponse.java
+++ b/src/main/java/com/dealit/dealit/domain/auction/dto/MyBuyingAuctionItemResponse.java
@@ -1,0 +1,24 @@
+package com.dealit.dealit.domain.auction.dto;
+
+import com.dealit.dealit.domain.auction.AuctionStatus;
+import com.dealit.dealit.domain.auction.BuyingAuctionStatus;
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+
+public record MyBuyingAuctionItemResponse(
+	Long productId,
+	Long auctionId,
+	String name,
+	String thumbnailUrl,
+	String categoryName,
+	String location,
+	BigDecimal myBidAmount,
+	BigDecimal currentHighestBidAmount,
+	BuyingAuctionStatus buyingStatus,
+	AuctionStatus auctionStatus,
+	int bidCount,
+	int bidderCount,
+	OffsetDateTime endsAt,
+	OffsetDateTime lastBidAt
+) {
+}

--- a/src/main/java/com/dealit/dealit/domain/auction/dto/MyBuyingAuctionListResponse.java
+++ b/src/main/java/com/dealit/dealit/domain/auction/dto/MyBuyingAuctionListResponse.java
@@ -1,0 +1,12 @@
+package com.dealit.dealit.domain.auction.dto;
+
+import java.util.List;
+
+public record MyBuyingAuctionListResponse(
+	List<MyBuyingAuctionItemResponse> content,
+	int page,
+	int size,
+	long totalElements,
+	boolean hasNext
+) {
+}

--- a/src/main/java/com/dealit/dealit/domain/auction/entity/BuyingAuctionHidden.java
+++ b/src/main/java/com/dealit/dealit/domain/auction/entity/BuyingAuctionHidden.java
@@ -1,0 +1,52 @@
+package com.dealit.dealit.domain.auction.entity;
+
+import com.dealit.dealit.global.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.SequenceGenerator;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(
+	name = "buying_auction_hidden",
+	uniqueConstraints = @UniqueConstraint(
+		name = "uk_buying_auction_hidden_member_auction",
+		columnNames = {"member_id", "auction_id"}
+	)
+)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SequenceGenerator(
+	name = "buying_auction_hidden_seq_generator",
+	sequenceName = "buying_auction_hidden_seq",
+	allocationSize = 1
+)
+public class BuyingAuctionHidden extends BaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "buying_auction_hidden_seq_generator")
+	@Column(name = "hidden_id")
+	private Long hiddenId;
+
+	@Column(name = "member_id", nullable = false)
+	private Long memberId;
+
+	@Column(name = "auction_id", nullable = false)
+	private Long auctionId;
+
+	private BuyingAuctionHidden(Long memberId, Long auctionId) {
+		this.memberId = memberId;
+		this.auctionId = auctionId;
+	}
+
+	public static BuyingAuctionHidden create(Long memberId, Long auctionId) {
+		return new BuyingAuctionHidden(memberId, auctionId);
+	}
+}

--- a/src/main/java/com/dealit/dealit/domain/auction/repository/BidRepository.java
+++ b/src/main/java/com/dealit/dealit/domain/auction/repository/BidRepository.java
@@ -2,12 +2,18 @@ package com.dealit.dealit.domain.auction.repository;
 
 import com.dealit.dealit.domain.auction.entity.Bid;
 import java.util.List;
+import java.time.OffsetDateTime;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface BidRepository extends JpaRepository<Bid, Long> {
 
 	boolean existsByAuctionAuctionId(Long auctionId);
+
+	boolean existsByAuctionAuctionIdAndBidderIdAndDeletedAtIsNull(Long auctionId, Long bidderId);
 
 	long countByAuctionAuctionId(Long auctionId);
 
@@ -15,4 +21,76 @@ public interface BidRepository extends JpaRepository<Bid, Long> {
 
 	@Query("select count(distinct b.bidderId) from Bid b where b.auction.auctionId = :auctionId")
 	long countDistinctBidderIdByAuctionId(Long auctionId);
+
+	@Query(
+		value = """
+			select
+				b.auction_id as auctionId,
+				max(b.bid_price) as myBidAmount,
+				max(b.created_at) as lastBidAt,
+				(
+					select b2.bidder_id
+					from bid b2
+					where b2.auction_id = b.auction_id
+						and b2.deleted_at is null
+					order by b2.bid_price desc, b2.created_at desc, b2.bid_id desc
+					limit 1
+				) as highestBidderId,
+				(
+					select b2.bid_price
+					from bid b2
+					where b2.auction_id = b.auction_id
+						and b2.deleted_at is null
+					order by b2.bid_price desc, b2.created_at desc, b2.bid_id desc
+					limit 1
+				) as highestBidAmount
+			from bid b
+			join auction a on a.auction_id = b.auction_id
+			join product p on p.product_id = a.product_id
+			where b.bidder_id = :memberId
+				and b.deleted_at is null
+				and a.deleted_at is null
+				and p.deleted_at is null
+				and not exists (
+					select 1
+					from buying_auction_hidden h
+					where h.member_id = :memberId
+						and h.auction_id = b.auction_id
+						and h.deleted_at is null
+				)
+			group by b.auction_id, a.status, a.ends_at
+			order by
+				case when a.status = 'ONGOING' and a.ends_at > :now then 0 else 1 end asc,
+				case when a.status = 'ONGOING' and a.ends_at > :now then a.ends_at end asc,
+				max(b.created_at) desc,
+				b.auction_id desc
+			""",
+		countQuery = """
+			select count(*)
+			from (
+				select b.auction_id
+				from bid b
+				join auction a on a.auction_id = b.auction_id
+				join product p on p.product_id = a.product_id
+				where b.bidder_id = :memberId
+					and b.deleted_at is null
+					and a.deleted_at is null
+					and p.deleted_at is null
+					and not exists (
+						select 1
+						from buying_auction_hidden h
+						where h.member_id = :memberId
+							and h.auction_id = b.auction_id
+							and h.deleted_at is null
+					)
+				group by b.auction_id
+			) buying_auctions
+			""",
+		nativeQuery = true
+	)
+	Page<MyBuyingAuctionProjection> findMyBuyingAuctions(
+		@Param("memberId") Long memberId,
+		@Param("now") OffsetDateTime now,
+		Pageable pageable
+	);
 }

--- a/src/main/java/com/dealit/dealit/domain/auction/repository/BuyingAuctionHiddenRepository.java
+++ b/src/main/java/com/dealit/dealit/domain/auction/repository/BuyingAuctionHiddenRepository.java
@@ -1,0 +1,9 @@
+package com.dealit.dealit.domain.auction.repository;
+
+import com.dealit.dealit.domain.auction.entity.BuyingAuctionHidden;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BuyingAuctionHiddenRepository extends JpaRepository<BuyingAuctionHidden, Long> {
+
+	boolean existsByMemberIdAndAuctionIdAndDeletedAtIsNull(Long memberId, Long auctionId);
+}

--- a/src/main/java/com/dealit/dealit/domain/auction/repository/MyBuyingAuctionProjection.java
+++ b/src/main/java/com/dealit/dealit/domain/auction/repository/MyBuyingAuctionProjection.java
@@ -1,0 +1,17 @@
+package com.dealit.dealit.domain.auction.repository;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+public interface MyBuyingAuctionProjection {
+
+	Long getAuctionId();
+
+	BigDecimal getMyBidAmount();
+
+	LocalDateTime getLastBidAt();
+
+	Long getHighestBidderId();
+
+	BigDecimal getHighestBidAmount();
+}

--- a/src/main/java/com/dealit/dealit/domain/auction/service/AuctionBuyingService.java
+++ b/src/main/java/com/dealit/dealit/domain/auction/service/AuctionBuyingService.java
@@ -1,0 +1,211 @@
+package com.dealit.dealit.domain.auction.service;
+
+import com.dealit.dealit.domain.auction.AuctionStatus;
+import com.dealit.dealit.domain.auction.BuyingAuctionStatus;
+import com.dealit.dealit.domain.auction.dto.MyBuyingAuctionItemResponse;
+import com.dealit.dealit.domain.auction.dto.MyBuyingAuctionListResponse;
+import com.dealit.dealit.domain.auction.entity.Auction;
+import com.dealit.dealit.domain.auction.entity.BuyingAuctionHidden;
+import com.dealit.dealit.domain.auction.entity.Category;
+import com.dealit.dealit.domain.auction.exception.AuctionConflictException;
+import com.dealit.dealit.domain.auction.exception.AuctionNotFoundException;
+import com.dealit.dealit.domain.auction.exception.InvalidAuctionRequestException;
+import com.dealit.dealit.domain.auction.repository.AuctionRepository;
+import com.dealit.dealit.domain.auction.repository.BidRepository;
+import com.dealit.dealit.domain.auction.repository.BuyingAuctionHiddenRepository;
+import com.dealit.dealit.domain.auction.repository.CategoryRepository;
+import com.dealit.dealit.domain.auction.repository.MyBuyingAuctionProjection;
+import com.dealit.dealit.domain.product.entity.Product;
+import com.dealit.dealit.domain.product.entity.ProductImage;
+import com.dealit.dealit.global.service.ImageUrlService;
+import java.math.BigDecimal;
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AuctionBuyingService {
+
+	private static final ZoneId SEOUL_ZONE = ZoneId.of("Asia/Seoul");
+
+	private final BidRepository bidRepository;
+	private final AuctionRepository auctionRepository;
+	private final CategoryRepository categoryRepository;
+	private final BuyingAuctionHiddenRepository buyingAuctionHiddenRepository;
+	private final ImageUrlService imageUrlService;
+	private final Clock clock;
+
+	public MyBuyingAuctionListResponse getMyBuyingAuctions(Long memberId, int page, int size) {
+		int normalizedPage = Math.max(page, 0);
+		int normalizedSize = Math.min(Math.max(size, 1), 100);
+		OffsetDateTime now = OffsetDateTime.now(clock);
+
+		Page<MyBuyingAuctionProjection> buyingPage = bidRepository.findMyBuyingAuctions(
+			memberId,
+			now,
+			PageRequest.of(normalizedPage, normalizedSize)
+		);
+
+		List<Long> auctionIds = buyingPage.getContent().stream()
+			.map(MyBuyingAuctionProjection::getAuctionId)
+			.toList();
+		Map<Long, Auction> auctionsById = loadAuctionsById(auctionIds);
+		Map<Long, String> categoryNamesById = loadCategoryNamesFromAuctions(auctionsById.values().stream().toList());
+
+		List<MyBuyingAuctionItemResponse> content = buyingPage.getContent().stream()
+			.map(projection -> toMyBuyingAuctionItem(memberId, projection, auctionsById, categoryNamesById, now))
+			.toList();
+
+		return new MyBuyingAuctionListResponse(
+			content,
+			buyingPage.getNumber(),
+			buyingPage.getSize(),
+			buyingPage.getTotalElements(),
+			buyingPage.hasNext()
+		);
+	}
+
+	@Transactional
+	public void hideEndedBuyingAuction(Long memberId, Long auctionId) {
+		if (!bidRepository.existsByAuctionAuctionIdAndBidderIdAndDeletedAtIsNull(auctionId, memberId)) {
+			throw new AuctionNotFoundException("Auction bid history not found.");
+		}
+
+		Auction auction = auctionRepository.findDetailByAuctionIdAndDeletedAtIsNullAndProductDeletedAtIsNull(auctionId)
+			.orElseThrow(() -> new AuctionNotFoundException("Auction not found."));
+		if (!isEnded(auction, OffsetDateTime.now(clock))) {
+			throw new AuctionConflictException("Only ended buying auctions can be hidden.");
+		}
+
+		if (buyingAuctionHiddenRepository.existsByMemberIdAndAuctionIdAndDeletedAtIsNull(memberId, auctionId)) {
+			return;
+		}
+		buyingAuctionHiddenRepository.save(BuyingAuctionHidden.create(memberId, auctionId));
+	}
+
+	private MyBuyingAuctionItemResponse toMyBuyingAuctionItem(
+		Long memberId,
+		MyBuyingAuctionProjection projection,
+		Map<Long, Auction> auctionsById,
+		Map<Long, String> categoryNamesById,
+		OffsetDateTime now
+	) {
+		Auction auction = auctionsById.get(projection.getAuctionId());
+		if (auction == null) {
+			throw new InvalidAuctionRequestException("Auction data is invalid.");
+		}
+
+		Product product = auction.getProduct();
+		return new MyBuyingAuctionItemResponse(
+			product.getProductId(),
+			auction.getAuctionId(),
+			product.getName(),
+			resolveThumbnailUrl(product),
+			categoryNamesById.getOrDefault(product.getCategoryId(), ""),
+			product.getLocation(),
+			projection.getMyBidAmount(),
+			resolveCurrentHighestBidAmount(auction, projection),
+			resolveBuyingStatus(memberId, auction, projection, now),
+			auction.getStatus(),
+			(int) bidRepository.countByAuctionAuctionId(auction.getAuctionId()),
+			(int) bidRepository.countDistinctBidderIdByAuctionId(auction.getAuctionId()),
+			toSeoulOffsetDateTime(auction.getAuctionEndAt()),
+			toSeoulOffsetDateTime(projection.getLastBidAt())
+		);
+	}
+
+	private BuyingAuctionStatus resolveBuyingStatus(
+		Long memberId,
+		Auction auction,
+		MyBuyingAuctionProjection projection,
+		OffsetDateTime now
+	) {
+		if (isEnded(auction, now)) {
+			return BuyingAuctionStatus.ENDED;
+		}
+		if (memberId.equals(projection.getHighestBidderId())) {
+			return BuyingAuctionStatus.LEADING;
+		}
+		return BuyingAuctionStatus.OUTBID;
+	}
+
+	private boolean isEnded(Auction auction, OffsetDateTime now) {
+		return auction.getStatus() != AuctionStatus.ONGOING || !auction.getAuctionEndAt().isAfter(now);
+	}
+
+	private BigDecimal resolveCurrentHighestBidAmount(Auction auction, MyBuyingAuctionProjection projection) {
+		if (auction.getCurrentPrice() != null && auction.getCurrentPrice().signum() > 0) {
+			return auction.getCurrentPrice();
+		}
+		if (projection.getHighestBidAmount() != null) {
+			return projection.getHighestBidAmount();
+		}
+		return auction.getStartPrice();
+	}
+
+	private Map<Long, Auction> loadAuctionsById(List<Long> auctionIds) {
+		Map<Long, Auction> auctionsById = new LinkedHashMap<>();
+		if (auctionIds.isEmpty()) {
+			return auctionsById;
+		}
+		auctionRepository.findAllByAuctionIdInAndDeletedAtIsNullAndProductDeletedAtIsNull(auctionIds)
+			.forEach(auction -> auctionsById.put(auction.getAuctionId(), auction));
+		return auctionsById;
+	}
+
+	private Map<Long, String> loadCategoryNamesFromAuctions(List<Auction> auctions) {
+		List<Long> categoryIds = auctions.stream()
+			.map(auction -> auction.getProduct().getCategoryId())
+			.distinct()
+			.toList();
+
+		Map<Long, String> categoryNamesById = new LinkedHashMap<>();
+		categoryRepository.findAllById(categoryIds)
+			.forEach(category -> categoryNamesById.put(category.getId(), resolveCategoryName(category)));
+		return categoryNamesById;
+	}
+
+	private String resolveCategoryName(Category category) {
+		return category.getNameKo() == null ? "" : category.getNameKo();
+	}
+
+	private String resolveThumbnailUrl(Product product) {
+		return product.getImages().stream()
+			.filter(image -> image.getImageUrl() != null && !image.getImageUrl().isBlank())
+			.sorted(this::compareImagesBySortOrder)
+			.map(image -> imageUrlService.toPublicUrl(image.getImageUrl()))
+			.findFirst()
+			.orElse(null);
+	}
+
+	private int compareImagesBySortOrder(ProductImage left, ProductImage right) {
+		int leftOrder = left.getSortOrder() == null ? Integer.MAX_VALUE : left.getSortOrder();
+		int rightOrder = right.getSortOrder() == null ? Integer.MAX_VALUE : right.getSortOrder();
+		return Integer.compare(leftOrder, rightOrder);
+	}
+
+	private OffsetDateTime toSeoulOffsetDateTime(LocalDateTime dateTime) {
+		if (dateTime == null) {
+			return null;
+		}
+		return dateTime.atZone(SEOUL_ZONE).toOffsetDateTime();
+	}
+
+	private OffsetDateTime toSeoulOffsetDateTime(OffsetDateTime dateTime) {
+		if (dateTime == null) {
+			return null;
+		}
+		return dateTime.atZoneSameInstant(SEOUL_ZONE).toOffsetDateTime();
+	}
+}


### PR DESCRIPTION
### 🚀 Summary

마이페이지 구매중 경매 목록 기능을 추가했습니다.
사용자가 입찰한 경매를 마이페이지에서 확인할 수 있고, 현재 입찰 상태를 LEADING, OUTBID, ENDED로 구분해서 내려줍니다.
종료된 경매는 사용자가 목록에서 숨길(삭제) 수 있도록 처리했습니다.

---

### ✨ Description

 내 구매중 경매 목록 조회 API 추가

GET /api/v1/mypage/auctions/buying?page=0&size=20
 구매중 경매 상태 구분 추가

LEADING: 내가 현재 최고 입찰자인 진행 중 경매
OUTBID: 다른 사용자가 더 높은 금액으로 추월한 진행 중 경매
ENDED: 종료된 경매

 종료된 구매중 경매 숨김 API 추가

DELETE /api/v1/mypage/auctions/buying/{auctionId}
 숨김 처리용 엔티티 추가

BuyingAuctionHidden
실제 경매/입찰 데이터는 삭제하지 않고 현재 사용자 목록에서만 제외

구매중 경매 조회용 쿼리 추가

사용자가 입찰한 경매를 경매 단위로 조회
현재 최고 입찰자와 최고 입찰가 계산
숨김 처리된 경매 제외

## 테스트 방법

스웨거 테스트 흐름:
1. 로그인 후 `Authorize`에 Bearer 토큰 입력
2. 다른 사용자가 등록한 경매에 입찰
3. `GET /api/v1/mypage/auctions/buying` 호출
4. 내가 1등이면 `LEADING`
5. 다른 사용자가 더 높은 금액으로 입찰하면 `OUTBID`
6. 경매가 종료되면 `ENDED`
7. 종료된 경매에 대해 `DELETE /api/v1/mypage/auctions/buying/{auctionId}` 호출
8. 다시 목록 조회 시 해당 경매가 빠지는지 확인
---

### 🎲 Issue Number

close #64 
