### PR TITLE
[fix] 채팅, 딜릿머니, 경매 상세 UX 수정

### DIFF
--- a/src/main/java/com/dealit/dealit/domain/auction/dto/AuctionBidHistoryResponse.java
+++ b/src/main/java/com/dealit/dealit/domain/auction/dto/AuctionBidHistoryResponse.java
@@ -15,6 +15,7 @@ public record AuctionBidHistoryResponse(
 		Long bidId,
 		Long bidderId,
 		String bidderNickname,
+		String bidderProfileImageUrl,
 		BigDecimal bidPrice,
 		LocalDateTime bidAt,
 		boolean highest

--- a/src/main/java/com/dealit/dealit/domain/auction/event/AuctionEventPublisher.java
+++ b/src/main/java/com/dealit/dealit/domain/auction/event/AuctionEventPublisher.java
@@ -18,7 +18,7 @@ public class AuctionEventPublisher {
 	private final EventStreamService eventStreamService;
 
 	public void publishBidUpdated(Long auctionId, BigDecimal currentPrice, Long bidderId, OffsetDateTime serverTime) {
-		eventStreamService.publishRemote(
+		eventStreamService.publish(
 			bidderId,
 			"BID_UPDATED",
 			new AuctionEventPayload.BidUpdated(auctionId, currentPrice, bidderId, serverTime)
@@ -35,7 +35,7 @@ public class AuctionEventPublisher {
 		if (previousBidderId == null || previousBidderId.equals(newBidderId)) {
 			return;
 		}
-		eventStreamService.publishRemote(
+		eventStreamService.publish(
 			previousBidderId,
 			"OUTBID",
 			new AuctionEventPayload.Outbid(auctionId, previousBidderId, newBidderId, currentPrice, serverTime)
@@ -53,7 +53,7 @@ public class AuctionEventPublisher {
 		if (receiverId == null) {
 			return;
 		}
-		eventStreamService.publishRemote(
+		eventStreamService.publish(
 			receiverId,
 			"AUCTION_ENDED",
 			new AuctionEventPayload.AuctionEnded(auctionId, winnerId, finalPrice, status, serverTime)
@@ -72,7 +72,7 @@ public class AuctionEventPublisher {
 		if (sellerId == null) {
 			return;
 		}
-		eventStreamService.publishRemote(
+		eventStreamService.publish(
 			sellerId,
 			"BID_RECEIVED",
 			new AuctionEventPayload.BidReceived(auctionId, bidderId, currentPrice, bidCount, firstBid, serverTime)
@@ -93,7 +93,7 @@ public class AuctionEventPublisher {
 			if (receiverId == null) {
 				continue;
 			}
-			eventStreamService.publishRemote(
+			eventStreamService.publish(
 				receiverId,
 				"AUCTION_BID_UPDATED",
 				new AuctionEventPayload.AuctionBidUpdated(

--- a/src/main/java/com/dealit/dealit/domain/auction/service/AuctionBidService.java
+++ b/src/main/java/com/dealit/dealit/domain/auction/service/AuctionBidService.java
@@ -107,6 +107,7 @@ public class AuctionBidService {
 				bid.getBidId(),
 				bid.getBidderId(),
 				resolveBidderNickname(membersById.get(bid.getBidderId()), bid.getBidderId()),
+				resolveBidderProfileImageUrl(membersById.get(bid.getBidderId())),
 				bid.getBidPrice(),
 				bid.getCreatedAt(),
 				auction.getWinnerId() == null
@@ -267,6 +268,13 @@ public class AuctionBidService {
 			return "입찰자 #" + bidderId;
 		}
 		return bidder.getNickname();
+	}
+
+	private String resolveBidderProfileImageUrl(Member bidder) {
+		if (bidder == null || bidder.getProfileImage() == null || bidder.getProfileImage().isBlank()) {
+			return null;
+		}
+		return imageUrlService.toPublicUrl(bidder.getProfileImage());
 	}
 
 	private BigDecimal resolveDisplayCurrentPrice(Auction auction, BigDecimal currentPrice) {

--- a/src/main/java/com/dealit/dealit/domain/chat/controller/ChatController.java
+++ b/src/main/java/com/dealit/dealit/domain/chat/controller/ChatController.java
@@ -18,6 +18,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -36,6 +37,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class ChatController {
 
     private final ChatService chatService;
+    private final SimpMessagingTemplate messagingTemplate;
 
     @Operation(summary = "채팅방 생성")
     @PostMapping("/rooms")
@@ -76,9 +78,12 @@ public class ChatController {
             @Valid @RequestBody SendChatMessageRequest request,
             @AuthenticationPrincipal(expression = "memberId") Long currentUserId
     ) {
+        SendChatMessageResponse response = chatService.sendMessage(roomId, request, currentUserId);
+        messagingTemplate.convertAndSend("/topic/chats/rooms/" + roomId, response);
+
         return ResponseEntity
                 .status(HttpStatus.CREATED)
-                .body(chatService.sendMessage(roomId, request, currentUserId));
+                .body(response);
     }
 
     @Operation(summary = "채팅방 읽음 처리")

--- a/src/main/java/com/dealit/dealit/domain/chat/dto/ChatMessageResponse.java
+++ b/src/main/java/com/dealit/dealit/domain/chat/dto/ChatMessageResponse.java
@@ -10,5 +10,6 @@ public record ChatMessageResponse(
         ChatMessageType messageType,
         String content,
         boolean isRead,
-        LocalDateTime sentAt
+        LocalDateTime sentAt,
+        String senderType
 ) {}

--- a/src/main/java/com/dealit/dealit/domain/chat/dto/ChatRoomListItemResponse.java
+++ b/src/main/java/com/dealit/dealit/domain/chat/dto/ChatRoomListItemResponse.java
@@ -21,7 +21,9 @@ public record ChatRoomListItemResponse(
     public record ProductInfo(
             Long productId,
             String name,
-            String thumbnailUrl
+            String thumbnailUrl,
+            String saleType,
+            Long auctionId
     ) {}
 
     public record LastMessageInfo(

--- a/src/main/java/com/dealit/dealit/domain/chat/dto/CreateChatRoomResponse.java
+++ b/src/main/java/com/dealit/dealit/domain/chat/dto/CreateChatRoomResponse.java
@@ -18,6 +18,7 @@ public record CreateChatRoomResponse(
             String name,
             String thumbnailUrl,
             String saleType,
+            Long auctionId,
             String status
     ) {}
 

--- a/src/main/java/com/dealit/dealit/domain/chat/dto/SendChatMessageResponse.java
+++ b/src/main/java/com/dealit/dealit/domain/chat/dto/SendChatMessageResponse.java
@@ -7,6 +7,7 @@ public record SendChatMessageResponse(
         Long messageId,
         Long roomId,
         Long senderId,
+        String senderNickname,
         ChatMessageType messageType,
         String content,
         boolean isRead,

--- a/src/main/java/com/dealit/dealit/domain/chat/service/ChatService.java
+++ b/src/main/java/com/dealit/dealit/domain/chat/service/ChatService.java
@@ -80,8 +80,9 @@ public class ChatService {
             return buildCreateRoomResponse(existingRoom.get(), currentUserId, sellerId, buyerId, existingRoom.get().getCreatedAt());
         }
 
+        ProductSummaryPort.ProductSummary product = resolveProductSummaryOrFallback(request.productId());
         ChatRoom saved = chatRoomRepository.save(
-                ChatRoom.create(sellerId, buyerId, request.productId(), ChatType.GENERAL)
+                ChatRoom.create(sellerId, buyerId, request.productId(), resolveChatType(product))
         );
         LocalDateTime now = LocalDateTime.now();
 
@@ -105,12 +106,13 @@ public class ChatService {
 
         return new CreateChatRoomResponse(
                 room.getRoomId(),
-                room.getChatType(),
+                resolveChatType(product),
                 new CreateChatRoomResponse.ProductInfo(
                         product.productId(),
                         product.name(),
                         product.thumbnailUrl(),
-                        "GENERAL",
+                        product.saleType(),
+                        product.auctionId(),
                         "ACTIVE"
                 ),
                 List.of(
@@ -188,7 +190,10 @@ public class ChatService {
                         message.getMessageType(),
                         message.getContent(),
                         message.isRead(),
-                        message.getSentAt()
+                        message.getSentAt(),
+                        message.getMessageType().name().equals("SYSTEM")
+                                ? "SYSTEM"
+                                : message.getSenderId().equals(currentUserId) ? "ME" : "OTHER"
                 ))
                 .toList();
 
@@ -232,6 +237,7 @@ public class ChatService {
                 saved.getMessageId(),
                 saved.getRoomId(),
                 saved.getSenderId(),
+                saved.getSenderNickname(),
                 saved.getMessageType(),
                 saved.getContent(),
                 saved.isRead(),
@@ -455,9 +461,11 @@ public class ChatService {
                 new ChatRoomListItemResponse.ProductInfo(
                         product.productId(),
                         product.name(),
-                        product.thumbnailUrl()
+                        product.thumbnailUrl(),
+                        product.saleType(),
+                        product.auctionId()
                 ),
-                room.getChatType(),
+                resolveChatType(product),
                 lastMessageInfo,
                 unreadCount,
                 updatedAt
@@ -472,8 +480,12 @@ public class ChatService {
         try {
             return productSummaryPort.getSummaryByProductId(productId);
         } catch (ProductNotFoundException exception) {
-            return new ProductSummaryPort.ProductSummary(productId, null, null);
+            return new ProductSummaryPort.ProductSummary(productId, null, null, "REGULAR", null);
         }
+    }
+
+    private ChatType resolveChatType(ProductSummaryPort.ProductSummary product) {
+        return "AUCTION".equals(product.saleType()) ? ChatType.AUCTION : ChatType.GENERAL;
     }
 
     private MemberSnapshot resolveMemberSnapshot(Long memberId) {

--- a/src/main/java/com/dealit/dealit/domain/chat/service/ProductSummaryAdapter.java
+++ b/src/main/java/com/dealit/dealit/domain/chat/service/ProductSummaryAdapter.java
@@ -19,6 +19,8 @@ public class ProductSummaryAdapter implements ProductSummaryPort {
                 SELECT
                     p.product_id,
                     p.name,
+                    p.sale_type,
+                    a.auction_id,
                     (
                         SELECT pi.image_url
                         FROM product_image pi
@@ -28,6 +30,9 @@ public class ProductSummaryAdapter implements ProductSummaryPort {
                         LIMIT 1
                     ) AS thumbnail_url
                 FROM product p
+                LEFT JOIN auction a
+                  ON a.product_id = p.product_id
+                 AND a.deleted_at IS NULL
                 WHERE p.product_id = :productId
                   AND p.deleted_at IS NULL
                 """;
@@ -43,7 +48,9 @@ public class ProductSummaryAdapter implements ProductSummaryPort {
                         return new ProductSummary(
                                 rs.getLong("product_id"),
                                 rs.getString("name"),
-                                rs.getString("thumbnail_url")
+                                rs.getString("thumbnail_url"),
+                                rs.getString("sale_type"),
+                                rs.getObject("auction_id", Long.class)
                         );
                     }
             );

--- a/src/main/java/com/dealit/dealit/domain/chat/service/ProductSummaryPort.java
+++ b/src/main/java/com/dealit/dealit/domain/chat/service/ProductSummaryPort.java
@@ -6,6 +6,12 @@ public interface ProductSummaryPort {
     record ProductSummary(
             Long productId,
             String name,
-            String thumbnailUrl
-    ) {}
+            String thumbnailUrl,
+            String saleType,
+            Long auctionId
+    ) {
+        public ProductSummary(Long productId, String name, String thumbnailUrl) {
+            this(productId, name, thumbnailUrl, "REGULAR", null);
+        }
+    }
 }

--- a/src/main/java/com/dealit/dealit/domain/notification/service/FcmNotificationService.java
+++ b/src/main/java/com/dealit/dealit/domain/notification/service/FcmNotificationService.java
@@ -64,7 +64,7 @@ public class FcmNotificationService {
 			.orElseGet(() -> new DeleteFcmTokenResponse(false));
 	}
 
-	@Transactional
+	@Transactional(noRollbackFor = NotificationException.class)
 	public int sendToMember(Long memberId, String title, String body, Map<String, String> data) {
 		FirebaseMessaging firebaseMessaging = firebaseMessagingProvider.getIfAvailable();
 

--- a/src/main/java/com/dealit/dealit/global/event/controller/EventStreamController.java
+++ b/src/main/java/com/dealit/dealit/global/event/controller/EventStreamController.java
@@ -5,7 +5,9 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.server.ResponseStatusException;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -24,6 +26,9 @@ public class EventStreamController {
     public SseEmitter subscribe(
             @AuthenticationPrincipal(expression = "memberId") Long currentUserId
     ) {
+        if (currentUserId == null) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "인증 사용자 정보가 없습니다.");
+        }
         return eventStreamService.subscribe(currentUserId);
     }
 }

--- a/src/main/java/com/dealit/dealit/global/event/service/EventStreamService.java
+++ b/src/main/java/com/dealit/dealit/global/event/service/EventStreamService.java
@@ -52,6 +52,10 @@ public class EventStreamService {
         sendToUser(userId, eventName, payload);
     }
 
+    public void publish(Long userId, String eventName, Object payload) {
+        publishToUser(userId, eventName, payload);
+    }
+
     private void publishToUser(Long userId, String eventName, Object payload) {
         sendToUser(userId, eventName, payload);
         redisEventPublisher.ifPresent(publisher -> publisher.publish(userId, eventName, payload));
@@ -69,7 +73,7 @@ public class EventStreamService {
                     .id(emitterId)
                     .name(eventName)
                     .data(payload));
-        } catch (IOException | IllegalStateException exception) {
+        } catch (IOException | RuntimeException exception) {
             emitterRepository.remove(userId, emitterId);
         }
     }


### PR DESCRIPTION
### 🚀 Summary

  채팅, 경매 입찰 기록, 실시간 이벤트 응답에 필요한 정보를 백엔드에서 정확히 내려주도록 수정했습니다.

 ---

  ### ✨ Description


  1. 채팅 메시지 응답에 본인 메시지인지 구분할 수 있는 정보를 추가했습니다.
  2. 채팅 전송 응답에 보낸 사람 닉네임을 추가했습니다.
  3. 채팅방 상품 정보에 판매 유형과 경매 ID를 추가했습니다.
  4. 경매 상품 채팅방은 채팅방 목록에서 경매로 구분되도록 수정했습니다.
  5. REST로 보낸 채팅 메시지도 WebSocket으로 실시간 전달되도록 수정했습니다.
  6. 경매 입찰 기록 응답에 입찰자 프로필 이미지 URL을 추가했습니다.
  7. 경매 실시간 이벤트가 서버 간 전파 경로를 제대로 타도록 수정했습니다.
  8. 인증되지 않은 실시간 이벤트 연결 요청은 명확히 거절하도록 수정했습니다.
  9. 푸시 알림 실패가 채팅 전송 자체를 실패시키지 않도록 수정했습니다.
### 🎲 Issue Number

<!-- Please enter {Issue Number} below to automatically close the connected issue. -->

close #66
