### PR TITLE
[fix] 알림 오류 수정 및 딜릿머니 알림 추가

### DIFF
--- a/src/main/java/com/dealit/dealit/domain/notification/service/FcmNotificationService.java
+++ b/src/main/java/com/dealit/dealit/domain/notification/service/FcmNotificationService.java
@@ -13,12 +13,16 @@ import com.google.firebase.messaging.FirebaseMessagingException;
 import com.google.firebase.messaging.Message;
 import com.google.firebase.messaging.MessagingErrorCode;
 import com.google.firebase.messaging.Notification;
+import com.google.firebase.messaging.WebpushConfig;
+import com.google.firebase.messaging.WebpushFcmOptions;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.net.URI;
 import java.util.Map;
 
 @Service
@@ -29,6 +33,9 @@ public class FcmNotificationService {
 	private final FcmTokenRepository fcmTokenRepository;
 	private final MemberRepository memberRepository;
 	private final ObjectProvider<FirebaseMessaging> firebaseMessagingProvider;
+
+	@Value("${app.web.public-base-url:http://localhost:3000}")
+	private String webPublicBaseUrl;
 
 	@Transactional
 	public RegisterFcmTokenResponse registerToken(Long memberId, RegisterFcmTokenRequest request) {
@@ -102,6 +109,13 @@ public class FcmNotificationService {
 
 		if (data != null && !data.isEmpty()) {
 			messageBuilder.putAllData(data);
+			resolveTargetUrl(data).ifPresent(targetUrl ->
+				messageBuilder.setWebpushConfig(WebpushConfig.builder()
+					.setFcmOptions(WebpushFcmOptions.builder()
+						.setLink(targetUrl)
+						.build())
+					.build())
+			);
 		}
 
 		try {
@@ -122,5 +136,22 @@ public class FcmNotificationService {
 
 		String trimmed = value.trim();
 		return trimmed.isEmpty() ? null : trimmed;
+	}
+
+	private java.util.Optional<String> resolveTargetUrl(Map<String, String> data) {
+		String targetUrl = normalizeBlank(data.get("targetUrl"));
+		if (targetUrl == null) {
+			return java.util.Optional.empty();
+		}
+		if (targetUrl.startsWith("http://") || targetUrl.startsWith("https://")) {
+			return java.util.Optional.of(targetUrl);
+		}
+
+		String baseUrl = normalizeBlank(webPublicBaseUrl);
+		if (baseUrl == null) {
+			return java.util.Optional.empty();
+		}
+
+		return java.util.Optional.of(URI.create(baseUrl).resolve(targetUrl).toString());
 	}
 }

--- a/src/main/java/com/dealit/dealit/domain/purchase/service/PurchaseService.java
+++ b/src/main/java/com/dealit/dealit/domain/purchase/service/PurchaseService.java
@@ -7,6 +7,10 @@ import com.dealit.dealit.domain.chat.repository.ChatRoomRepository;
 import com.dealit.dealit.domain.member.entity.Member;
 import com.dealit.dealit.domain.member.exception.EmailNotVerifiedException;
 import com.dealit.dealit.domain.member.repository.MemberRepository;
+import com.dealit.dealit.domain.notification.dto.NotificationCreateRequest;
+import com.dealit.dealit.domain.notification.entity.InAppNotificationType;
+import com.dealit.dealit.domain.notification.service.FcmNotificationService;
+import com.dealit.dealit.domain.notification.service.NotificationCenterService;
 import com.dealit.dealit.domain.payment.service.ProductPaymentService;
 import com.dealit.dealit.domain.product.ProductSaleType;
 import com.dealit.dealit.domain.product.ProductStatus;
@@ -33,12 +37,15 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.util.Comparator;
+import java.util.Map;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@Slf4j
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class PurchaseService {
@@ -52,6 +59,8 @@ public class PurchaseService {
 	private final ProductPaymentService productPaymentService;
 	private final ImageUrlService imageUrlService;
 	private final ChatRoomRepository chatRoomRepository;
+	private final NotificationCenterService notificationCenterService;
+	private final FcmNotificationService fcmNotificationService;
 
 	@Transactional
 	public PurchaseResponse purchase(Long productId, Long buyerId, String idempotencyKey) {
@@ -101,6 +110,7 @@ public class PurchaseService {
 
 			product.markSold();
 			linkPurchaseChatRoomIfNeeded(purchase);
+			notifyPurchasePaid(purchase, product);
 			return toPurchaseResponse(purchase);
 		}
 
@@ -178,6 +188,7 @@ public class PurchaseService {
 		} catch (IllegalStateException exception) {
 			throw new PurchaseNotCompletableException(exception.getMessage());
 		}
+		notifyPurchaseShipped(purchase);
 		return toCompletionResponse(purchase);
 	}
 
@@ -259,6 +270,7 @@ public class PurchaseService {
 		purchase.complete();
 		markProductEnded(purchase);
 		settleIfNeeded(purchase, settlementReason);
+		notifyPurchaseReceived(purchase);
 	}
 
 	private int autoCompleteAndSettle(Purchase purchase, String settlementReason) {
@@ -305,6 +317,102 @@ public class PurchaseService {
 	private void markProductEnded(Purchase purchase) {
 		productRepository.findByProductIdAndDeletedAtIsNull(purchase.getProductId())
 			.ifPresent(Product::markTradeCompleted);
+	}
+
+	private void notifyPurchasePaid(Purchase purchase, Product product) {
+		String sellerTitle = "상품이 판매되었습니다.";
+		String sellerContent = "'" + product.getName() + "' 상품 결제가 완료되었어요. 물건을 보내주세요.";
+		sendTradeNotification(
+			purchase.getSellerId(),
+			sellerTitle,
+			sellerContent,
+			"PURCHASE_PAID",
+			purchase
+		);
+
+		String buyerTitle = "구매가 완료되었습니다.";
+		String buyerContent = "'" + product.getName() + "' 상품 구매가 완료되었어요. 판매자의 발송을 기다려주세요.";
+		sendTradeNotification(
+			purchase.getBuyerId(),
+			buyerTitle,
+			buyerContent,
+			"PURCHASE_COMPLETED",
+			purchase
+		);
+	}
+
+	private void notifyPurchaseShipped(Purchase purchase) {
+		String productName = resolveProductName(purchase);
+		String title = "상품이 발송되었습니다.";
+		String content = "'" + productName + "' 상품이 발송되었어요. 물건을 받으면 수령확정을 눌러주세요.";
+		sendTradeNotification(
+			purchase.getBuyerId(),
+			title,
+			content,
+			"PURCHASE_SHIPPED",
+			purchase
+		);
+	}
+
+	private void notifyPurchaseReceived(Purchase purchase) {
+		String productName = resolveProductName(purchase);
+		String title = "수령확정이 완료되었습니다.";
+		String content = "'" + productName + "' 상품 구매자가 수령확정을 완료했어요.";
+		sendTradeNotification(
+			purchase.getSellerId(),
+			title,
+			content,
+			"PURCHASE_RECEIVED",
+			purchase
+		);
+	}
+
+	private void sendTradeNotification(
+		Long receiverId,
+		String title,
+		String content,
+		String type,
+		Purchase purchase
+	) {
+		String targetUrl = "/products/" + purchase.getProductId()
+			+ "/receipt?purchaseId=" + purchase.getPurchaseId();
+
+		notificationCenterService.create(
+			receiverId,
+			new NotificationCreateRequest(
+				InAppNotificationType.TRADE,
+				title,
+				content,
+				"RECEIPT",
+				purchase.getPurchaseId(),
+				targetUrl
+			)
+		);
+
+		try {
+			int sentCount = fcmNotificationService.sendToMember(
+				receiverId,
+				title,
+				content,
+				Map.of(
+					"type", type,
+					"purchaseId", String.valueOf(purchase.getPurchaseId()),
+					"productId", String.valueOf(purchase.getProductId()),
+					"targetUrl", targetUrl
+				)
+			);
+			log.debug("Sent purchase push notification. type={}, purchaseId={}, receiverId={}, sentCount={}",
+				type, purchase.getPurchaseId(), receiverId, sentCount);
+		} catch (RuntimeException exception) {
+			log.warn("Failed to send purchase push notification. type={}, purchaseId={}, receiverId={}",
+				type, purchase.getPurchaseId(), receiverId, exception);
+		}
+	}
+
+	private String resolveProductName(Purchase purchase) {
+		return productRepository.findByProductIdAndDeletedAtIsNull(purchase.getProductId())
+			.map(Product::getName)
+			.orElse("구매한");
 	}
 
 	private PurchaseCompletionResponse toCompletionResponse(Purchase purchase) {

--- a/src/main/java/com/dealit/dealit/domain/wallet/service/WalletService.java
+++ b/src/main/java/com/dealit/dealit/domain/wallet/service/WalletService.java
@@ -2,6 +2,10 @@ package com.dealit.dealit.domain.wallet.service;
 
 import com.dealit.dealit.domain.auth.exception.InvalidCredentialsException;
 import com.dealit.dealit.domain.member.repository.MemberRepository;
+import com.dealit.dealit.domain.notification.dto.NotificationCreateRequest;
+import com.dealit.dealit.domain.notification.entity.InAppNotificationType;
+import com.dealit.dealit.domain.notification.service.FcmNotificationService;
+import com.dealit.dealit.domain.notification.service.NotificationCenterService;
 import com.dealit.dealit.domain.wallet.dto.WalletLedgerListResponse;
 import com.dealit.dealit.domain.wallet.dto.WalletLedgerResponse;
 import com.dealit.dealit.domain.wallet.dto.WalletResponse;
@@ -11,10 +15,14 @@ import com.dealit.dealit.domain.wallet.entity.WalletLedgerType;
 import com.dealit.dealit.domain.wallet.exception.InvalidWalletRequestException;
 import com.dealit.dealit.domain.wallet.repository.WalletLedgerRepository;
 import com.dealit.dealit.domain.wallet.repository.WalletRepository;
+import java.text.NumberFormat;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import java.util.Locale;
+import java.util.Map;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
@@ -22,15 +30,19 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@Slf4j
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class WalletService {
 
 	private static final ZoneId SEOUL_ZONE = ZoneId.of("Asia/Seoul");
+	private static final String WALLET_TARGET_URL = "/mypage";
 
 	private final WalletRepository walletRepository;
 	private final WalletLedgerRepository walletLedgerRepository;
 	private final MemberRepository memberRepository;
+	private final NotificationCenterService notificationCenterService;
+	private final FcmNotificationService fcmNotificationService;
 
 	@Transactional
 	public WalletResponse getMyWallet(Long memberId) {
@@ -128,9 +140,10 @@ public class WalletService {
 			throw new InvalidWalletRequestException(exception.getMessage());
 		}
 
-		walletLedgerRepository.save(
+		WalletLedger ledger = walletLedgerRepository.save(
 			WalletLedger.create(wallet, type, signedAmount, nextBalance, description)
 		);
+		sendWalletNotification(memberId, ledger);
 		return nextBalance;
 	}
 
@@ -157,6 +170,74 @@ public class WalletService {
 			ledger.getDescription(),
 			toSeoulOffsetDateTime(ledger.getCreatedAt())
 		);
+	}
+
+	private void sendWalletNotification(Long memberId, WalletLedger ledger) {
+		String title = getWalletNotificationTitle(ledger.getType());
+		String content = "%s %s 처리되었습니다. 현재 잔액은 %s입니다.".formatted(
+			getWalletLedgerTypeLabel(ledger.getType()),
+			formatWon(Math.abs(ledger.getAmount())),
+			formatWon(ledger.getBalanceAfter())
+		);
+
+		notificationCenterService.create(
+			memberId,
+			new NotificationCreateRequest(
+				InAppNotificationType.WALLET,
+				title,
+				content,
+				"WALLET",
+				ledger.getWalletLedgerId(),
+				WALLET_TARGET_URL
+			)
+		);
+
+		try {
+			int sentCount = fcmNotificationService.sendToMember(
+				memberId,
+				title,
+				content,
+				Map.of(
+					"type", "WALLET_UPDATED",
+					"ledgerId", String.valueOf(ledger.getWalletLedgerId()),
+					"ledgerType", ledger.getType().name(),
+					"targetUrl", WALLET_TARGET_URL
+				)
+			);
+			log.debug("Sent wallet push notification. memberId={}, ledgerId={}, sentCount={}",
+				memberId, ledger.getWalletLedgerId(), sentCount);
+		} catch (RuntimeException exception) {
+			log.warn("Failed to send wallet push notification. memberId={}, ledgerId={}",
+				memberId, ledger.getWalletLedgerId(), exception);
+		}
+	}
+
+	private String getWalletNotificationTitle(WalletLedgerType type) {
+		return switch (type) {
+			case TEMP_CHARGE -> "딜릿머니 충전 완료";
+			case REFUND, AUCTION_REFUND -> "딜릿머니 환불 완료";
+			case WITHDRAWAL -> "딜릿머니 출금 완료";
+			case PURCHASE -> "딜릿머니 결제 완료";
+			case SETTLEMENT, AUCTION_SETTLEMENT -> "딜릿머니 정산 완료";
+			case AUCTION_RESERVE -> "경매 예치금 차감 완료";
+		};
+	}
+
+	private String getWalletLedgerTypeLabel(WalletLedgerType type) {
+		return switch (type) {
+			case TEMP_CHARGE -> "충전";
+			case REFUND -> "환불";
+			case WITHDRAWAL -> "출금";
+			case PURCHASE -> "결제";
+			case SETTLEMENT -> "정산";
+			case AUCTION_RESERVE -> "경매 예치금";
+			case AUCTION_REFUND -> "경매 환불";
+			case AUCTION_SETTLEMENT -> "경매 정산";
+		};
+	}
+
+	private String formatWon(long amount) {
+		return NumberFormat.getNumberInstance(Locale.KOREA).format(amount) + "원";
 	}
 
 	private OffsetDateTime toSeoulOffsetDateTime(LocalDateTime dateTime) {

--- a/src/test/java/com/dealit/dealit/domain/chat/ChatRoomIntegrationTest.java
+++ b/src/test/java/com/dealit/dealit/domain/chat/ChatRoomIntegrationTest.java
@@ -77,7 +77,7 @@ class ChatRoomIntegrationTest {
         ChatRoom room = saveChatRoom(product);
         Purchase purchase = savePaidPurchase(product);
 
-        mockMvc.perform(get("/api/v1/chats/rooms/{roomId}", room.getRoomId())
+        mockMvc.perform(get("/api/v1/chats/rooms/{roomId}/trade-info", room.getRoomId())
                         .with(authentication(authenticatedMember(seller))))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.roomId").value(room.getRoomId()))
@@ -100,7 +100,7 @@ class ChatRoomIntegrationTest {
         ChatRoom room = saveChatRoom(product);
         savePaidPurchase(product);
 
-        mockMvc.perform(get("/api/v1/chats/rooms/{roomId}", room.getRoomId())
+        mockMvc.perform(get("/api/v1/chats/rooms/{roomId}/trade-info", room.getRoomId())
                         .with(authentication(authenticatedMember(buyer))))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.currentUserRole").value("BUYER"))
@@ -127,7 +127,7 @@ class ChatRoomIntegrationTest {
         purchase.markShipped();
         purchaseRepository.save(purchase);
 
-        mockMvc.perform(get("/api/v1/chats/rooms/{roomId}", room.getRoomId())
+        mockMvc.perform(get("/api/v1/chats/rooms/{roomId}/trade-info", room.getRoomId())
                         .with(authentication(authenticatedMember(buyer))))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.purchaseId").value(purchase.getPurchaseId()))

--- a/src/test/java/com/dealit/dealit/domain/chat/ChatServiceCreateRoomTest.java
+++ b/src/test/java/com/dealit/dealit/domain/chat/ChatServiceCreateRoomTest.java
@@ -138,6 +138,7 @@ class ChatServiceCreateRoomTest {
         ProductSummaryPort productSummaryPort = mock(ProductSummaryPort.class);
         AuctionPaymentRepository auctionPaymentRepository = mock(AuctionPaymentRepository.class);
         WalletService walletService = mock(WalletService.class);
+        PurchaseRepository purchaseRepository = mock(PurchaseRepository.class);
         EventStreamService eventStreamService = mock(EventStreamService.class);
         FcmNotificationService fcmNotificationService = mock(FcmNotificationService.class);
 
@@ -179,6 +180,7 @@ class ChatServiceCreateRoomTest {
                 productSummaryPort,
                 auctionPaymentRepository,
                 walletService,
+                purchaseRepository,
                 eventStreamService,
                 fcmNotificationService,
                 Clock.fixed(OffsetDateTime.parse("2026-05-10T13:00:00Z").toInstant(), java.time.ZoneOffset.UTC)
@@ -203,6 +205,7 @@ class ChatServiceCreateRoomTest {
         ProductSummaryPort productSummaryPort = mock(ProductSummaryPort.class);
         AuctionPaymentRepository auctionPaymentRepository = mock(AuctionPaymentRepository.class);
         WalletService walletService = mock(WalletService.class);
+        PurchaseRepository purchaseRepository = mock(PurchaseRepository.class);
         EventStreamService eventStreamService = mock(EventStreamService.class);
         FcmNotificationService fcmNotificationService = mock(FcmNotificationService.class);
 
@@ -241,6 +244,7 @@ class ChatServiceCreateRoomTest {
                 productSummaryPort,
                 auctionPaymentRepository,
                 walletService,
+                purchaseRepository,
                 eventStreamService,
                 fcmNotificationService,
                 Clock.fixed(OffsetDateTime.parse("2026-05-10T13:00:00Z").toInstant(), java.time.ZoneOffset.UTC)
@@ -265,6 +269,7 @@ class ChatServiceCreateRoomTest {
         ProductSummaryPort productSummaryPort = mock(ProductSummaryPort.class);
         AuctionPaymentRepository auctionPaymentRepository = mock(AuctionPaymentRepository.class);
         WalletService walletService = mock(WalletService.class);
+        PurchaseRepository purchaseRepository = mock(PurchaseRepository.class);
         EventStreamService eventStreamService = mock(EventStreamService.class);
         FcmNotificationService fcmNotificationService = mock(FcmNotificationService.class);
 
@@ -303,6 +308,7 @@ class ChatServiceCreateRoomTest {
                 productSummaryPort,
                 auctionPaymentRepository,
                 walletService,
+                purchaseRepository,
                 eventStreamService,
                 fcmNotificationService,
                 Clock.fixed(OffsetDateTime.parse("2026-05-10T13:00:00Z").toInstant(), java.time.ZoneOffset.UTC)
@@ -326,6 +332,7 @@ class ChatServiceCreateRoomTest {
         ProductSummaryPort productSummaryPort = mock(ProductSummaryPort.class);
         AuctionPaymentRepository auctionPaymentRepository = mock(AuctionPaymentRepository.class);
         WalletService walletService = mock(WalletService.class);
+        PurchaseRepository purchaseRepository = mock(PurchaseRepository.class);
         EventStreamService eventStreamService = mock(EventStreamService.class);
         FcmNotificationService fcmNotificationService = mock(FcmNotificationService.class);
 
@@ -364,6 +371,7 @@ class ChatServiceCreateRoomTest {
                 productSummaryPort,
                 auctionPaymentRepository,
                 walletService,
+                purchaseRepository,
                 eventStreamService,
                 fcmNotificationService,
                 Clock.fixed(OffsetDateTime.parse("2026-05-10T13:00:00Z").toInstant(), java.time.ZoneOffset.UTC)

--- a/src/test/java/com/dealit/dealit/domain/purchase/PurchaseIntegrationTest.java
+++ b/src/test/java/com/dealit/dealit/domain/purchase/PurchaseIntegrationTest.java
@@ -6,6 +6,7 @@ import com.dealit.dealit.domain.product.ProductSaleType;
 import com.dealit.dealit.domain.product.ProductStatus;
 import com.dealit.dealit.domain.product.entity.Product;
 import com.dealit.dealit.domain.product.repository.ProductRepository;
+import com.dealit.dealit.domain.notification.repository.InAppNotificationRepository;
 import com.dealit.dealit.domain.payment.repository.ProductPaymentRepository;
 import com.dealit.dealit.domain.payment.entity.ProductPaymentStatus;
 import com.dealit.dealit.domain.purchase.entity.Purchase;
@@ -64,6 +65,9 @@ class PurchaseIntegrationTest {
 	private ProductPaymentRepository productPaymentRepository;
 
 	@Autowired
+	private InAppNotificationRepository notificationRepository;
+
+	@Autowired
 	private WalletRepository walletRepository;
 
 	@Autowired
@@ -81,6 +85,7 @@ class PurchaseIntegrationTest {
 
 	@BeforeEach
 	void setUp() {
+		notificationRepository.deleteAll();
 		productPaymentRepository.deleteAll();
 		purchaseRepository.deleteAll();
 		walletLedgerRepository.deleteAll();
@@ -121,6 +126,10 @@ class PurchaseIntegrationTest {
 				assertThat(ledger.getBalanceAfter()).isEqualTo(20000);
 			});
 		assertThat(productRepository.findById(product.getProductId()).orElseThrow().getStatus()).isEqualTo(ProductStatus.SOLD);
+		assertThat(notificationRepository.countByMemberMemberIdAndReadAtIsNullAndDeletedAtIsNull(seller.getMemberId()))
+			.isEqualTo(1);
+		assertThat(notificationRepository.countByMemberMemberIdAndReadAtIsNullAndDeletedAtIsNull(buyer.getMemberId()))
+			.isEqualTo(3);
 		assertThat(purchaseRepository.findAll())
 			.singleElement()
 			.satisfies(purchase -> {
@@ -327,7 +336,7 @@ class PurchaseIntegrationTest {
 			.andExpect(jsonPath("$.amount").value(30000))
 			.andExpect(jsonPath("$.status").value("PAID"))
 			.andExpect(jsonPath("$.purchasedAt").exists())
-			.andExpect(jsonPath("$.chatRoomId").doesNotExist());
+			.andExpect(jsonPath("$.chatRoomId").isNumber());
 	}
 
 	@Test
@@ -403,6 +412,9 @@ class PurchaseIntegrationTest {
 			.andExpect(jsonPath("$.autoCompleteAt").exists())
 			.andExpect(jsonPath("$.completedAt").doesNotExist())
 			.andExpect(jsonPath("$.settledAt").doesNotExist());
+
+		assertThat(notificationRepository.countByMemberMemberIdAndReadAtIsNullAndDeletedAtIsNull(buyer.getMemberId()))
+			.isEqualTo(4);
 	}
 
 	@Test
@@ -435,6 +447,10 @@ class PurchaseIntegrationTest {
 		assertThat(walletRepository.findByMemberId(seller.getMemberId()).orElseThrow().getBalance()).isEqualTo(30000);
 		assertThat(countSettlementLedgers(seller.getMemberId())).isEqualTo(1);
 		assertThat(walletRepository.findByMemberId(buyer.getMemberId()).orElseThrow().getBalance()).isEqualTo(20000);
+		assertThat(notificationRepository.countByMemberMemberIdAndReadAtIsNullAndDeletedAtIsNull(seller.getMemberId()))
+			.isEqualTo(3);
+		assertThat(notificationRepository.countByMemberMemberIdAndReadAtIsNullAndDeletedAtIsNull(buyer.getMemberId()))
+			.isEqualTo(4);
 	}
 
 	@Test

--- a/src/test/java/com/dealit/dealit/domain/wallet/WalletIntegrationTest.java
+++ b/src/test/java/com/dealit/dealit/domain/wallet/WalletIntegrationTest.java
@@ -3,6 +3,7 @@ package com.dealit.dealit.domain.wallet;
 import com.dealit.dealit.domain.member.entity.Member;
 import com.dealit.dealit.domain.member.repository.MemberRepository;
 import com.dealit.dealit.domain.notification.repository.FcmTokenRepository;
+import com.dealit.dealit.domain.notification.repository.InAppNotificationRepository;
 import com.dealit.dealit.domain.wallet.repository.WalletLedgerRepository;
 import com.dealit.dealit.domain.wallet.repository.WalletRepository;
 import com.dealit.dealit.global.security.jwt.JwtService;
@@ -36,6 +37,9 @@ class WalletIntegrationTest {
 	private FcmTokenRepository fcmTokenRepository;
 
 	@Autowired
+	private InAppNotificationRepository notificationRepository;
+
+	@Autowired
 	private WalletRepository walletRepository;
 
 	@Autowired
@@ -51,6 +55,7 @@ class WalletIntegrationTest {
 
 	@BeforeEach
 	void setUp() {
+		notificationRepository.deleteAll();
 		walletLedgerRepository.deleteAll();
 		walletRepository.deleteAll();
 		fcmTokenRepository.deleteAll();
@@ -100,6 +105,10 @@ class WalletIntegrationTest {
 			.andExpect(jsonPath("$.content[0].type").value("TEMP_CHARGE"))
 			.andExpect(jsonPath("$.content[0].amount").value(30000))
 			.andExpect(jsonPath("$.content[0].balanceAfter").value(30000));
+
+		Member member = memberRepository.findAll().getFirst();
+		assertThat(notificationRepository.countByMemberMemberIdAndReadAtIsNullAndDeletedAtIsNull(member.getMemberId()))
+			.isEqualTo(1);
 	}
 
 	@Test
@@ -124,6 +133,10 @@ class WalletIntegrationTest {
 			.andExpect(jsonPath("$.content[0].amount").value(-25000))
 			.andExpect(jsonPath("$.content[1].type").value("REFUND"))
 			.andExpect(jsonPath("$.content[1].amount").value(10000));
+
+		Member member = memberRepository.findAll().getFirst();
+		assertThat(notificationRepository.countByMemberMemberIdAndReadAtIsNullAndDeletedAtIsNull(member.getMemberId()))
+			.isEqualTo(3);
 	}
 
 	@Test


### PR DESCRIPTION
### 🚀 Summary

<!-- 작업 내용에 대한 간략한 설명을 써주세요. -->
  일반 상품 구매와 딜릿머니 변동에 대한 알림센터/FCM 알림을 추가하고, FCM 푸쉬 클릭 시
  target 페이지로 이동할 수 있도록 WebPush link 처리를 수정했습니다.
---

### ✨ Description

<!-- 상세한 설명, 기능의 사용법, 주의 사항 실행 결과(이미지 첨부 가능) 등을 보여주세요. -->
 - 일반 상품 구매 알림 추가
      - 구매 완료 시 구매자/판매자에게 알림센터 + FCM 발송
      - 판매자 발송 처리 시 구매자에게 발송 알림 발송
      - 구매자 수령확정 시 판매자에게 수령확정 알림 발송
      - 알림 클릭 이동 경로: /products/{productId}/receipt?purchaseId={purchaseId}
  - 딜릿머니 알림 추가
      - 충전, 환불, 출금, 결제, 정산, 경매 예치금/환불/정산 발생 시 알림센터 + FCM 발송
      - 알림 클릭 이동 경로: /mypage
  - FCM WebPush link 처리
      - FCM 데이터의 targetUrl을 WebPush fcmOptions.link로 설정
      - 상대 경로는 app.web.public-base-url 기준으로 절대 URL 변환
  - 테스트
      - 구매/딜릿머니 알림 추가에 맞춰 관련 테스트 기대값 수정
        --tests Chat 통과
---

### 🎲 Issue Number

<!-- Please enter {Issue Number} below to automatically close the connected issue. -->

close #73 
