### PR TITLE
fix: 경매 입찰 실패 사유별 에러 코드 세분화

### DIFF
--- a/src/main/java/com/dealit/dealit/domain/auction/exception/AuctionBidException.java
+++ b/src/main/java/com/dealit/dealit/domain/auction/exception/AuctionBidException.java
@@ -1,0 +1,30 @@
+package com.dealit.dealit.domain.auction.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class AuctionBidException extends AuctionException {
+
+	private AuctionBidException(String code, String message, HttpStatus status) {
+		super(code, message, status);
+	}
+
+	public static AuctionBidException auctionEnded() {
+		return new AuctionBidException("AUCTION_ENDED", "이미 종료된 경매입니다.", HttpStatus.CONFLICT);
+	}
+
+	public static AuctionBidException priceBelowMinimum() {
+		return new AuctionBidException(
+			"BID_PRICE_BELOW_MINIMUM",
+			"최소 입찰 금액을 충족해야 합니다.",
+			HttpStatus.BAD_REQUEST
+		);
+	}
+
+	public static AuctionBidException priceChanged() {
+		return new AuctionBidException(
+			"BID_PRICE_CHANGED",
+			"최고 입찰가가 변경되었습니다. 다시 확인 후 입찰해주세요.",
+			HttpStatus.CONFLICT
+		);
+	}
+}

--- a/src/main/java/com/dealit/dealit/domain/auction/service/AuctionBidService.java
+++ b/src/main/java/com/dealit/dealit/domain/auction/service/AuctionBidService.java
@@ -15,6 +15,7 @@ import com.dealit.dealit.domain.auction.entity.Category;
 import com.dealit.dealit.domain.auction.entity.Bid;
 import com.dealit.dealit.domain.auction.event.AuctionEventPublisher;
 import com.dealit.dealit.domain.auction.event.AuctionRefundRequestedEvent;
+import com.dealit.dealit.domain.auction.exception.AuctionBidException;
 import com.dealit.dealit.domain.auction.exception.AuctionNotFoundException;
 import com.dealit.dealit.domain.auction.exception.InvalidAuctionRequestException;
 import com.dealit.dealit.domain.auction.redis.AuctionRedisService;
@@ -148,13 +149,13 @@ public class AuctionBidService {
 			throw new InvalidAuctionRequestException("자신이 등록한 경매에는 입찰할 수 없습니다.");
 		}
 		if (!auction.isOngoing()) {
-			throw new InvalidAuctionRequestException("이미 종료된 경매입니다.");
+			throw AuctionBidException.auctionEnded();
 		}
 		if (!auction.getEndsAt().isAfter(serverTime())) {
-			throw new InvalidAuctionRequestException("이미 종료된 경매입니다.");
+			throw AuctionBidException.auctionEnded();
 		}
 		if (bidPrice.compareTo(auction.getCurrentPrice().add(auction.getMinimumBidAmount())) < 0) {
-			throw new InvalidAuctionRequestException("최소 입찰 금액을 충족해야 합니다.");
+			throw AuctionBidException.priceBelowMinimum();
 		}
 		Member bidder = loadActiveMember(bidderId);
 		if (!bidder.isVerified()) {
@@ -166,8 +167,8 @@ public class AuctionBidService {
 
 		BidScriptResult result = auctionRedisService.bid(auctionId, bidPrice, bidderId);
 		switch (result.status()) {
-			case AUCTION_ENDED -> throw new InvalidAuctionRequestException("이미 종료된 경매입니다.");
-			case BID_TOO_LOW -> throw new InvalidAuctionRequestException("현재가보다 높은 금액만 입찰할 수 있습니다.");
+			case AUCTION_ENDED -> throw AuctionBidException.auctionEnded();
+			case BID_TOO_LOW -> throw AuctionBidException.priceChanged();
 			case SAME_BIDDER -> throw new InvalidAuctionRequestException("현재 최고 입찰자는 다시 입찰할 수 없습니다.");
 			case SUCCESS -> {
 				try {

--- a/src/main/java/com/dealit/dealit/domain/wallet/exception/InsufficientWalletBalanceException.java
+++ b/src/main/java/com/dealit/dealit/domain/wallet/exception/InsufficientWalletBalanceException.java
@@ -1,0 +1,10 @@
+package com.dealit.dealit.domain.wallet.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class InsufficientWalletBalanceException extends WalletException {
+
+	public InsufficientWalletBalanceException() {
+		super(HttpStatus.CONFLICT, "INSUFFICIENT_BALANCE", "딜릿머니 잔액이 부족합니다.");
+	}
+}

--- a/src/main/java/com/dealit/dealit/domain/wallet/service/WalletService.java
+++ b/src/main/java/com/dealit/dealit/domain/wallet/service/WalletService.java
@@ -12,6 +12,7 @@ import com.dealit.dealit.domain.wallet.dto.WalletResponse;
 import com.dealit.dealit.domain.wallet.entity.Wallet;
 import com.dealit.dealit.domain.wallet.entity.WalletLedger;
 import com.dealit.dealit.domain.wallet.entity.WalletLedgerType;
+import com.dealit.dealit.domain.wallet.exception.InsufficientWalletBalanceException;
 import com.dealit.dealit.domain.wallet.exception.InvalidWalletRequestException;
 import com.dealit.dealit.domain.wallet.repository.WalletLedgerRepository;
 import com.dealit.dealit.domain.wallet.repository.WalletRepository;
@@ -83,7 +84,19 @@ public class WalletService {
 
 	@Transactional
 	public long reserveAuctionBid(Long memberId, long amount, Long auctionId) {
-		return applyForAuction(memberId, -amount, WalletLedgerType.AUCTION_RESERVE, "경매 입찰 예치금 차감: auctionId=%d".formatted(auctionId));
+		try {
+			return applyForAuction(
+				memberId,
+				-amount,
+				WalletLedgerType.AUCTION_RESERVE,
+				"경매 입찰 예치금 차감: auctionId=%d".formatted(auctionId)
+			);
+		} catch (InvalidWalletRequestException exception) {
+			if ("잔액이 부족합니다.".equals(exception.getMessage())) {
+				throw new InsufficientWalletBalanceException();
+			}
+			throw exception;
+		}
 	}
 
 	@Transactional

--- a/src/test/java/com/dealit/dealit/domain/auction/AuctionBidServiceTest.java
+++ b/src/test/java/com/dealit/dealit/domain/auction/AuctionBidServiceTest.java
@@ -15,6 +15,8 @@ import com.dealit.dealit.domain.auction.entity.Auction;
 import com.dealit.dealit.domain.auction.entity.AuctionPayment;
 import com.dealit.dealit.domain.auction.entity.Bid;
 import com.dealit.dealit.domain.auction.event.AuctionEventPublisher;
+import com.dealit.dealit.domain.auction.exception.AuctionBidException;
+import com.dealit.dealit.domain.auction.exception.AuctionException;
 import com.dealit.dealit.domain.auction.exception.InvalidAuctionRequestException;
 import com.dealit.dealit.domain.auction.redis.AuctionRedisService;
 import com.dealit.dealit.domain.auction.redis.AuctionRedisService.AuctionState;
@@ -220,7 +222,12 @@ class AuctionBidServiceTest {
 			List<Object> results = List.of(futures.get(0).get(), futures.get(1).get());
 
 			assertThat(results.stream().filter(BidResponse.class::isInstance)).hasSize(1);
-			assertThat(results.stream().filter(InvalidAuctionRequestException.class::isInstance)).hasSize(1);
+			assertThat(results.stream().filter(AuctionBidException.class::isInstance)).hasSize(1);
+			assertThat(results.stream()
+				.filter(AuctionBidException.class::isInstance)
+				.map(AuctionBidException.class::cast)
+				.map(AuctionBidException::getCode))
+				.containsExactly("BID_PRICE_CHANGED");
 			assertThat(auction.getCurrentPrice()).isIn(new BigDecimal("101000"), new BigDecimal("101500"));
 			verify(bidRepository, times(1)).save(any(Bid.class));
 			verify(auctionNotificationService, times(1)).notifyBidReceived(
@@ -249,12 +256,37 @@ class AuctionBidServiceTest {
 		Object result;
 		try {
 			result = auctionBidService.bid(auctionId, 20L, new BigDecimal("101000"));
-		} catch (InvalidAuctionRequestException exception) {
+		} catch (AuctionBidException exception) {
 			result = exception;
 		}
 
-		assertThat(result).isInstanceOf(InvalidAuctionRequestException.class);
-		assertThat(((InvalidAuctionRequestException) result).getMessage()).isEqualTo("이미 종료된 경매입니다.");
+		assertThat(result).isInstanceOf(AuctionBidException.class);
+		assertThat(((AuctionBidException) result).getCode()).isEqualTo("AUCTION_ENDED");
+		assertThat(((AuctionBidException) result).getMessage()).isEqualTo("이미 종료된 경매입니다.");
+		verify(auctionRedisService, never()).bid(anyLong(), any(BigDecimal.class), anyLong());
+		verify(bidRepository, never()).save(any(Bid.class));
+	}
+
+	@Test
+	@DisplayName("최소 입찰가보다 낮으면 입찰을 거절한다")
+	void bidFailsWhenBidPriceIsBelowMinimum() {
+		Long auctionId = 1L;
+		Auction auction = auction(10L);
+		when(auctionRepository.findWithLockByAuctionIdAndDeletedAtIsNullAndProductDeletedAtIsNull(auctionId))
+			.thenReturn(Optional.of(auction));
+
+		Object result;
+		try {
+			result = auctionBidService.bid(auctionId, 20L, new BigDecimal("100999"));
+		} catch (AuctionBidException exception) {
+			result = exception;
+		}
+
+		assertThat(result).isInstanceOf(AuctionBidException.class);
+		assertThat(((AuctionBidException) result).getCode()).isEqualTo("BID_PRICE_BELOW_MINIMUM");
+		assertThat(((AuctionBidException) result).getMessage()).isEqualTo("최소 입찰 금액을 충족해야 합니다.");
+		verify(memberRepository, never()).findByMemberIdAndDeletedAtIsNull(anyLong());
+		verify(walletService, never()).reserveAuctionBid(anyLong(), anyLong(), anyLong());
 		verify(auctionRedisService, never()).bid(anyLong(), any(BigDecimal.class), anyLong());
 		verify(bidRepository, never()).save(any(Bid.class));
 	}
@@ -355,7 +387,7 @@ class AuctionBidServiceTest {
 		start.await();
 		try {
 			return auctionBidService.bid(auctionId, bidderId, bidPrice);
-		} catch (InvalidAuctionRequestException exception) {
+		} catch (AuctionException exception) {
 			return exception;
 		}
 	}


### PR DESCRIPTION
### 🚀 Summary

<!-- 작업 내용에 대한 간략한 설명을 써주세요. -->
- 경매종료, 최소입찰가 미달(애초에 버튼이 막힘 그래도 오류로 처리는 해놓음), 동시입찰시, 잔액부족, 이메일 미인증
---

### ✨ Description

<!-- 상세한 설명, 기능의 사용법, 주의 사항 실행 결과(이미지 첨부 가능) 등을 보여주세요. -->
## 작업 내용
- 경매 입찰 실패 사유별 에러 코드를 세분화했습니다.
- 동시 입찰로 최고입찰가가 변경된 경우 `BID_PRICE_CHANGED`를 반환하도록 변경했습니다.
- 경매 입찰 예치금 부족 시 `INSUFFICIENT_BALANCE`를 반환하도록 분리했습니다.
- 관련 입찰 서비스 테스트를 보강했습니다.

## 응답 코드
- `AUCTION_ENDED`: 경매 종료
- `BID_PRICE_BELOW_MINIMUM`: 최소 입찰가 미달
- `BID_PRICE_CHANGED`: 동시 입찰/최고입찰가 변경
- `INSUFFICIENT_BALANCE`: 딜릿머니 잔액 부족
- `EMAIL_NOT_VERIFIED`: 이메일 미인증, 기존 코드 사용
---

### 🎲 Issue Number

<!-- Please enter {Issue Number} below to automatically close the connected issue. -->

close #77 
