### PR TITLE
[feat] 경매 찜기능 추가

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1,1 +1,1 @@
-{"timestamp":1778848249.896457975,"status":401,"code":"AUTHENTICATION_REQUIRED","message":"인증이 필요합니다.","errors":[]}
+{"timestamp":1778929096.734645968,"status":401,"code":"AUTHENTICATION_REQUIRED","message":"인증이 필요합니다.","errors":[]}

--- a/src/main/java/com/dealit/dealit/domain/auction/controller/AuctionManagementController.java
+++ b/src/main/java/com/dealit/dealit/domain/auction/controller/AuctionManagementController.java
@@ -62,8 +62,11 @@ public class AuctionManagementController {
 
 	@Operation(summary = "경매 상세 조회", description = "경매 현재가와 서버 시간을 조회한다.")
 	@GetMapping("/auctions/{auctionId:\\d+}")
-	public AuctionDetailResponse getAuction(@PathVariable Long auctionId) {
-		return auctionBidService.getAuction(auctionId);
+	public AuctionDetailResponse getAuction(
+		@AuthenticationPrincipal AuthenticatedMember member,
+		@PathVariable Long auctionId
+	) {
+		return auctionBidService.getAuction(auctionId, member == null ? null : member.memberId());
 	}
 
 	@Operation(summary = "경매 입찰", description = "서버 도착 시간 기준으로 입찰을 처리한다.")

--- a/src/main/java/com/dealit/dealit/domain/auction/dto/AuctionDetailResponse.java
+++ b/src/main/java/com/dealit/dealit/domain/auction/dto/AuctionDetailResponse.java
@@ -24,7 +24,9 @@ public record AuctionDetailResponse(
 	OffsetDateTime startAt,
 	OffsetDateTime endsAt,
 	OffsetDateTime serverTime,
-	AuctionStatus status
+	AuctionStatus status,
+	boolean liked,
+	long favoriteCount
 ) {
 	public record ImageResponse(
 		Long imageId,

--- a/src/main/java/com/dealit/dealit/domain/auction/repository/AuctionBidCountProjection.java
+++ b/src/main/java/com/dealit/dealit/domain/auction/repository/AuctionBidCountProjection.java
@@ -1,0 +1,8 @@
+package com.dealit.dealit.domain.auction.repository;
+
+public interface AuctionBidCountProjection {
+
+	Long getAuctionId();
+
+	long getBidCount();
+}

--- a/src/main/java/com/dealit/dealit/domain/auction/repository/AuctionRepository.java
+++ b/src/main/java/com/dealit/dealit/domain/auction/repository/AuctionRepository.java
@@ -47,6 +47,9 @@ public interface AuctionRepository extends JpaRepository<Auction, Long> {
 	@EntityGraph(attributePaths = {"product", "product.images"})
 	List<Auction> findAllByAuctionIdInAndDeletedAtIsNullAndProductDeletedAtIsNull(Collection<Long> auctionIds);
 
+	@EntityGraph(attributePaths = {"product", "product.images"})
+	List<Auction> findAllByProductProductIdInAndDeletedAtIsNullAndProductDeletedAtIsNull(Collection<Long> productIds);
+
 	@EntityGraph(attributePaths = {"product"})
 	List<Auction> findAllByStatusAndEndsAtBetweenAndDeletedAtIsNullAndProductDeletedAtIsNull(
 		AuctionStatus status,

--- a/src/main/java/com/dealit/dealit/domain/auction/repository/BidRepository.java
+++ b/src/main/java/com/dealit/dealit/domain/auction/repository/BidRepository.java
@@ -1,6 +1,7 @@
 package com.dealit.dealit.domain.auction.repository;
 
 import com.dealit.dealit.domain.auction.entity.Bid;
+import java.util.Collection;
 import java.util.List;
 import java.time.OffsetDateTime;
 import org.springframework.data.domain.Page;
@@ -41,6 +42,16 @@ public interface BidRepository extends JpaRepository<Bid, Long> {
 
 	@Query("select count(distinct b.bidderId) from Bid b where b.auction.auctionId = :auctionId")
 	long countDistinctBidderIdByAuctionId(Long auctionId);
+
+	@Query("""
+		select b.auction.auctionId as auctionId,
+			count(b) as bidCount
+		from Bid b
+		where b.auction.auctionId in :auctionIds
+			and b.deletedAt is null
+		group by b.auction.auctionId
+		""")
+	List<AuctionBidCountProjection> countByAuctionIds(@Param("auctionIds") Collection<Long> auctionIds);
 
 	@Query(
 		value = """

--- a/src/main/java/com/dealit/dealit/domain/auction/service/AuctionBidService.java
+++ b/src/main/java/com/dealit/dealit/domain/auction/service/AuctionBidService.java
@@ -33,6 +33,7 @@ import com.dealit.dealit.domain.member.repository.MemberRepository;
 import com.dealit.dealit.domain.product.entity.Product;
 import com.dealit.dealit.domain.product.entity.ProductImage;
 import com.dealit.dealit.domain.wallet.service.WalletService;
+import com.dealit.dealit.domain.wishlist.service.WishlistService;
 import com.dealit.dealit.global.service.ImageUrlService;
 import java.math.BigDecimal;
 import java.time.Clock;
@@ -66,10 +67,15 @@ public class AuctionBidService {
 	private final AuctionNotificationService auctionNotificationService;
 	private final ApplicationEventPublisher applicationEventPublisher;
 	private final ChatRoomRepository chatRoomRepository;
+	private final WishlistService wishlistService;
 	private final ImageUrlService imageUrlService;
 	private final Clock clock;
 
 	public AuctionDetailResponse getAuction(Long auctionId) {
+		return getAuction(auctionId, null);
+	}
+
+	public AuctionDetailResponse getAuction(Long auctionId, Long memberId) {
 		Auction auction = loadAuctionDetail(auctionId);
 		Product product = auction.getProduct();
 		BigDecimal currentPrice = auction.getCurrentPrice();
@@ -105,7 +111,9 @@ public class AuctionBidService {
 			auction.getAuctionStartAt(),
 			auction.getEndsAt(),
 			serverTime(),
-			auction.getStatus()
+			auction.getStatus(),
+			memberId != null && wishlistService.isLiked(memberId, product.getProductId()),
+			product.getFavoriteCount()
 		);
 	}
 

--- a/src/main/java/com/dealit/dealit/domain/wishlist/controller/WishlistController.java
+++ b/src/main/java/com/dealit/dealit/domain/wishlist/controller/WishlistController.java
@@ -57,8 +57,8 @@ public class WishlistController {
 		return wishlistService.getMyWishlist(member.memberId(), page, size);
 	}
 
-	@Operation(summary = "??寃쎈ℓ 李?紐⑸줉 議고쉶")
-	@ApiResponse(responseCode = "200", description = "??寃쎈ℓ 李?紐⑸줉 議고쉶 ?깃났")
+	@Operation(summary = "내 경매 찜 목록 조회")
+	@ApiResponse(responseCode = "200", description = "내 경매 찜 목록 조회 성공")
 	@GetMapping("/mypage/wishlist/auctions")
 	public MyAuctionWishlistListResponse getMyAuctionWishlist(
 		@AuthenticationPrincipal AuthenticatedMember member,

--- a/src/main/java/com/dealit/dealit/domain/wishlist/controller/WishlistController.java
+++ b/src/main/java/com/dealit/dealit/domain/wishlist/controller/WishlistController.java
@@ -1,5 +1,6 @@
 package com.dealit.dealit.domain.wishlist.controller;
 
+import com.dealit.dealit.domain.wishlist.dto.MyAuctionWishlistListResponse;
 import com.dealit.dealit.domain.wishlist.dto.MyWishlistListResponse;
 import com.dealit.dealit.domain.wishlist.dto.WishlistToggleResponse;
 import com.dealit.dealit.domain.wishlist.service.WishlistService;
@@ -54,5 +55,16 @@ public class WishlistController {
 		@RequestParam(defaultValue = "20") int size
 	) {
 		return wishlistService.getMyWishlist(member.memberId(), page, size);
+	}
+
+	@Operation(summary = "??寃쎈ℓ 李?紐⑸줉 議고쉶")
+	@ApiResponse(responseCode = "200", description = "??寃쎈ℓ 李?紐⑸줉 議고쉶 ?깃났")
+	@GetMapping("/mypage/wishlist/auctions")
+	public MyAuctionWishlistListResponse getMyAuctionWishlist(
+		@AuthenticationPrincipal AuthenticatedMember member,
+		@RequestParam(defaultValue = "0") int page,
+		@RequestParam(defaultValue = "20") int size
+	) {
+		return wishlistService.getMyAuctionWishlist(member.memberId(), page, size);
 	}
 }

--- a/src/main/java/com/dealit/dealit/domain/wishlist/dto/MyAuctionWishlistItemResponse.java
+++ b/src/main/java/com/dealit/dealit/domain/wishlist/dto/MyAuctionWishlistItemResponse.java
@@ -1,0 +1,21 @@
+package com.dealit.dealit.domain.wishlist.dto;
+
+import com.dealit.dealit.domain.auction.AuctionStatus;
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+
+public record MyAuctionWishlistItemResponse(
+	Long auctionId,
+	Long productId,
+	String name,
+	String thumbnailUrl,
+	String categoryName,
+	String location,
+	long favoriteCount,
+	BigDecimal currentPrice,
+	int bidCount,
+	AuctionStatus auctionStatus,
+	OffsetDateTime endedAt,
+	OffsetDateTime likedAt
+) {
+}

--- a/src/main/java/com/dealit/dealit/domain/wishlist/dto/MyAuctionWishlistListResponse.java
+++ b/src/main/java/com/dealit/dealit/domain/wishlist/dto/MyAuctionWishlistListResponse.java
@@ -1,0 +1,12 @@
+package com.dealit.dealit.domain.wishlist.dto;
+
+import java.util.List;
+
+public record MyAuctionWishlistListResponse(
+	List<MyAuctionWishlistItemResponse> content,
+	int page,
+	int size,
+	long totalElements,
+	boolean hasNext
+) {
+}

--- a/src/main/java/com/dealit/dealit/domain/wishlist/repository/WishlistRepository.java
+++ b/src/main/java/com/dealit/dealit/domain/wishlist/repository/WishlistRepository.java
@@ -1,5 +1,6 @@
 package com.dealit.dealit.domain.wishlist.repository;
 
+import com.dealit.dealit.domain.product.ProductSaleType;
 import com.dealit.dealit.domain.wishlist.entity.Wishlist;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -20,4 +21,11 @@ public interface WishlistRepository extends JpaRepository<Wishlist, Long> {
 
 	@EntityGraph(attributePaths = {"product", "product.images"})
 	Page<Wishlist> findAllByMemberIdAndDeletedAtIsNullAndProductDeletedAtIsNull(Long memberId, Pageable pageable);
+
+	@EntityGraph(attributePaths = {"product", "product.images"})
+	Page<Wishlist> findAllByMemberIdAndProductSaleTypeAndDeletedAtIsNullAndProductDeletedAtIsNull(
+		Long memberId,
+		ProductSaleType saleType,
+		Pageable pageable
+	);
 }

--- a/src/main/java/com/dealit/dealit/domain/wishlist/service/WishlistService.java
+++ b/src/main/java/com/dealit/dealit/domain/wishlist/service/WishlistService.java
@@ -3,6 +3,7 @@ package com.dealit.dealit.domain.wishlist.service;
 import com.dealit.dealit.domain.auth.exception.InvalidCredentialsException;
 import com.dealit.dealit.domain.auction.entity.Auction;
 import com.dealit.dealit.domain.auction.entity.Category;
+import com.dealit.dealit.domain.auction.repository.AuctionBidCountProjection;
 import com.dealit.dealit.domain.auction.repository.AuctionRepository;
 import com.dealit.dealit.domain.auction.repository.BidRepository;
 import com.dealit.dealit.domain.auction.repository.CategoryRepository;
@@ -135,8 +136,14 @@ public class WishlistService {
 
 		Map<Long, String> categoryNamesById = loadCategoryNames(wishlistPage.getContent());
 		Map<Long, Auction> auctionsByProductId = loadAuctionsByProductId(wishlistPage.getContent());
+		Map<Long, Long> bidCountsByAuctionId = loadBidCountsByAuctionId(auctionsByProductId);
 		List<MyAuctionWishlistItemResponse> content = wishlistPage.getContent().stream()
-			.map(wishlist -> toMyAuctionWishlistItemResponse(wishlist, auctionsByProductId, categoryNamesById))
+			.map(wishlist -> toMyAuctionWishlistItemResponse(
+				wishlist,
+				auctionsByProductId,
+				bidCountsByAuctionId,
+				categoryNamesById
+			))
 			.toList();
 
 		return new MyAuctionWishlistListResponse(
@@ -238,6 +245,21 @@ public class WishlistService {
 		return auctionsByProductId;
 	}
 
+	private Map<Long, Long> loadBidCountsByAuctionId(Map<Long, Auction> auctionsByProductId) {
+		Set<Long> auctionIds = auctionsByProductId.values().stream()
+			.map(Auction::getAuctionId)
+			.collect(java.util.stream.Collectors.toSet());
+
+		Map<Long, Long> bidCountsByAuctionId = new HashMap<>();
+		if (auctionIds.isEmpty()) {
+			return bidCountsByAuctionId;
+		}
+		bidRepository.countByAuctionIds(auctionIds).forEach(count ->
+			bidCountsByAuctionId.put(count.getAuctionId(), count.getBidCount())
+		);
+		return bidCountsByAuctionId;
+	}
+
 	private MyWishlistItemResponse toMyWishlistItemResponse(Wishlist wishlist, Map<Long, String> categoryNamesById) {
 		Product product = wishlist.getProduct();
 		return new MyWishlistItemResponse(
@@ -257,6 +279,7 @@ public class WishlistService {
 	private MyAuctionWishlistItemResponse toMyAuctionWishlistItemResponse(
 		Wishlist wishlist,
 		Map<Long, Auction> auctionsByProductId,
+		Map<Long, Long> bidCountsByAuctionId,
 		Map<Long, String> categoryNamesById
 	) {
 		Product product = wishlist.getProduct();
@@ -270,7 +293,7 @@ public class WishlistService {
 			product.getLocation(),
 			product.getFavoriteCount(),
 			auction == null ? null : auction.getCurrentPrice(),
-			auction == null ? 0 : (int) bidRepository.countByAuctionAuctionId(auction.getAuctionId()),
+			auction == null ? 0 : bidCountsByAuctionId.getOrDefault(auction.getAuctionId(), 0L).intValue(),
 			auction == null ? null : auction.getStatus(),
 			auction == null ? null : auction.getEndsAt(),
 			toSeoulOffsetDateTime(wishlist.getCreatedAt())

--- a/src/main/java/com/dealit/dealit/domain/wishlist/service/WishlistService.java
+++ b/src/main/java/com/dealit/dealit/domain/wishlist/service/WishlistService.java
@@ -1,7 +1,10 @@
 package com.dealit.dealit.domain.wishlist.service;
 
 import com.dealit.dealit.domain.auth.exception.InvalidCredentialsException;
+import com.dealit.dealit.domain.auction.entity.Auction;
 import com.dealit.dealit.domain.auction.entity.Category;
+import com.dealit.dealit.domain.auction.repository.AuctionRepository;
+import com.dealit.dealit.domain.auction.repository.BidRepository;
 import com.dealit.dealit.domain.auction.repository.CategoryRepository;
 import com.dealit.dealit.domain.member.entity.Member;
 import com.dealit.dealit.domain.member.repository.MemberRepository;
@@ -9,11 +12,14 @@ import com.dealit.dealit.domain.notification.dto.NotificationCreateRequest;
 import com.dealit.dealit.domain.notification.entity.InAppNotificationType;
 import com.dealit.dealit.domain.notification.service.FcmNotificationService;
 import com.dealit.dealit.domain.notification.service.NotificationCenterService;
+import com.dealit.dealit.domain.product.ProductSaleType;
 import com.dealit.dealit.domain.product.ProductStatus;
 import com.dealit.dealit.domain.product.entity.Product;
 import com.dealit.dealit.domain.product.entity.ProductImage;
 import com.dealit.dealit.domain.product.exception.InvalidProductRequestException;
 import com.dealit.dealit.domain.product.repository.ProductRepository;
+import com.dealit.dealit.domain.wishlist.dto.MyAuctionWishlistItemResponse;
+import com.dealit.dealit.domain.wishlist.dto.MyAuctionWishlistListResponse;
 import com.dealit.dealit.domain.wishlist.dto.MyWishlistItemResponse;
 import com.dealit.dealit.domain.wishlist.dto.MyWishlistListResponse;
 import com.dealit.dealit.domain.wishlist.dto.WishlistToggleResponse;
@@ -47,6 +53,8 @@ public class WishlistService {
 
 	private final WishlistRepository wishlistRepository;
 	private final ProductRepository productRepository;
+	private final AuctionRepository auctionRepository;
+	private final BidRepository bidRepository;
 	private final MemberRepository memberRepository;
 	private final CategoryRepository categoryRepository;
 	private final ImageUrlService imageUrlService;
@@ -105,6 +113,33 @@ public class WishlistService {
 			.toList();
 
 		return new MyWishlistListResponse(
+			content,
+			wishlistPage.getNumber(),
+			wishlistPage.getSize(),
+			wishlistPage.getTotalElements(),
+			wishlistPage.hasNext()
+		);
+	}
+
+	public MyAuctionWishlistListResponse getMyAuctionWishlist(Long memberId, int page, int size) {
+		loadActiveMember(memberId);
+		int normalizedPage = Math.max(page, 0);
+		int normalizedSize = Math.min(Math.max(size, 1), 100);
+
+		Page<Wishlist> wishlistPage = wishlistRepository
+			.findAllByMemberIdAndProductSaleTypeAndDeletedAtIsNullAndProductDeletedAtIsNull(
+				memberId,
+				ProductSaleType.AUCTION,
+				PageRequest.of(normalizedPage, normalizedSize, Sort.by(Sort.Direction.DESC, "createdAt"))
+			);
+
+		Map<Long, String> categoryNamesById = loadCategoryNames(wishlistPage.getContent());
+		Map<Long, Auction> auctionsByProductId = loadAuctionsByProductId(wishlistPage.getContent());
+		List<MyAuctionWishlistItemResponse> content = wishlistPage.getContent().stream()
+			.map(wishlist -> toMyAuctionWishlistItemResponse(wishlist, auctionsByProductId, categoryNamesById))
+			.toList();
+
+		return new MyAuctionWishlistListResponse(
 			content,
 			wishlistPage.getNumber(),
 			wishlistPage.getSize(),
@@ -189,6 +224,20 @@ public class WishlistService {
 		return categoryNamesById;
 	}
 
+	private Map<Long, Auction> loadAuctionsByProductId(List<Wishlist> wishlists) {
+		Set<Long> productIds = wishlists.stream()
+			.map(wishlist -> wishlist.getProduct().getProductId())
+			.collect(java.util.stream.Collectors.toSet());
+
+		Map<Long, Auction> auctionsByProductId = new HashMap<>();
+		if (productIds.isEmpty()) {
+			return auctionsByProductId;
+		}
+		auctionRepository.findAllByProductProductIdInAndDeletedAtIsNullAndProductDeletedAtIsNull(productIds)
+			.forEach(auction -> auctionsByProductId.put(auction.getProduct().getProductId(), auction));
+		return auctionsByProductId;
+	}
+
 	private MyWishlistItemResponse toMyWishlistItemResponse(Wishlist wishlist, Map<Long, String> categoryNamesById) {
 		Product product = wishlist.getProduct();
 		return new MyWishlistItemResponse(
@@ -201,6 +250,29 @@ public class WishlistService {
 			categoryNamesById.getOrDefault(product.getCategoryId(), ""),
 			product.getLocation(),
 			product.getFavoriteCount(),
+			toSeoulOffsetDateTime(wishlist.getCreatedAt())
+		);
+	}
+
+	private MyAuctionWishlistItemResponse toMyAuctionWishlistItemResponse(
+		Wishlist wishlist,
+		Map<Long, Auction> auctionsByProductId,
+		Map<Long, String> categoryNamesById
+	) {
+		Product product = wishlist.getProduct();
+		Auction auction = auctionsByProductId.get(product.getProductId());
+		return new MyAuctionWishlistItemResponse(
+			auction == null ? null : auction.getAuctionId(),
+			product.getProductId(),
+			product.getName(),
+			resolveThumbnailUrl(product),
+			categoryNamesById.getOrDefault(product.getCategoryId(), ""),
+			product.getLocation(),
+			product.getFavoriteCount(),
+			auction == null ? null : auction.getCurrentPrice(),
+			auction == null ? 0 : (int) bidRepository.countByAuctionAuctionId(auction.getAuctionId()),
+			auction == null ? null : auction.getStatus(),
+			auction == null ? null : auction.getEndsAt(),
 			toSeoulOffsetDateTime(wishlist.getCreatedAt())
 		);
 	}

--- a/src/test/java/com/dealit/dealit/domain/auction/AuctionBidServiceTest.java
+++ b/src/test/java/com/dealit/dealit/domain/auction/AuctionBidServiceTest.java
@@ -34,6 +34,7 @@ import com.dealit.dealit.domain.product.ProductSaleType;
 import com.dealit.dealit.domain.product.ProductStatus;
 import com.dealit.dealit.domain.product.entity.Product;
 import com.dealit.dealit.domain.wallet.service.WalletService;
+import com.dealit.dealit.domain.wishlist.service.WishlistService;
 import com.dealit.dealit.global.service.ImageUrlService;
 import java.math.BigDecimal;
 import java.time.Clock;
@@ -71,6 +72,7 @@ class AuctionBidServiceTest {
 	private final AuctionNotificationService auctionNotificationService = mock(AuctionNotificationService.class);
 	private final ApplicationEventPublisher applicationEventPublisher = mock(ApplicationEventPublisher.class);
 	private final ChatRoomRepository chatRoomRepository = mock(ChatRoomRepository.class);
+	private final WishlistService wishlistService = mock(WishlistService.class);
 	private final ImageUrlService imageUrlService = mock(ImageUrlService.class);
 
 	private final AuctionBidService auctionBidService = new AuctionBidService(
@@ -85,6 +87,7 @@ class AuctionBidServiceTest {
 		auctionNotificationService,
 		applicationEventPublisher,
 		chatRoomRepository,
+		wishlistService,
 		imageUrlService,
 		FIXED_CLOCK
 	);


### PR DESCRIPTION
### 🚀 Summary

경매 상품 찜 목록 조회 기능을 추가하고, 경매 상세 조회 응답에 찜 정보를 추가했습니다.

---

### ✨ Description

기존 찜 기능은 `Product` 기준으로 동작하고 있어 일반상품과 경매상품 모두 찜 추가/취소가 가능했습니다.

이번 작업에서는 프론트에서 마이페이지 경매 찜 목록을 별도로 구성할 수 있도록 경매 찜 목록 조회 API를 추가했습니다.

- 경매 찜 목록 조회 API 추가
  - `GET /api/v1/mypage/wishlist/auctions`

- 경매 상세 조회 응답에 찜 정보 추가
  - `liked`
  - `favoriteCount`

- 기존 찜 추가/취소 API는 그대로 재사용
  - `POST /api/v1/wishlist/{productId}`
  - `DELETE /api/v1/wishlist/{productId}`

- 기존 `wishlist`, `product`, `auction` 구조를 활용
  - 별도 DB 테이블 추가 없음


---

### 🎲 Issue Number

<!-- Please enter {Issue Number} below to automatically close the connected issue. -->

close #80 
