### PR TITLE
feat: 유찰 경매 재경매기능 추가

### DIFF
--- a/src/main/java/com/dealit/dealit/domain/auction/controller/AuctionManagementController.java
+++ b/src/main/java/com/dealit/dealit/domain/auction/controller/AuctionManagementController.java
@@ -6,8 +6,12 @@ import com.dealit.dealit.domain.auction.dto.AuctionListResponse;
 import com.dealit.dealit.domain.auction.dto.BidRequest;
 import com.dealit.dealit.domain.auction.dto.BidResponse;
 import com.dealit.dealit.domain.auction.dto.AuctionEditDetailResponse;
+import com.dealit.dealit.domain.auction.dto.CreateAuctionRequest;
+import com.dealit.dealit.domain.auction.dto.DeclineReauctionResponse;
 import com.dealit.dealit.domain.auction.dto.MyBuyingAuctionListResponse;
 import com.dealit.dealit.domain.auction.dto.MySellingAuctionListResponse;
+import com.dealit.dealit.domain.auction.dto.ReauctionPreviewResponse;
+import com.dealit.dealit.domain.auction.dto.ReauctionResponse;
 import com.dealit.dealit.domain.auction.dto.SearchCategoryOptionResponse;
 import com.dealit.dealit.domain.auction.dto.UpdateAuctionRequest;
 import com.dealit.dealit.domain.auction.service.AuctionBidService;
@@ -153,6 +157,35 @@ public class AuctionManagementController {
 		@PathVariable Long auctionId
 	) {
 		return auctionService.getAuctionEditDetail(member.memberId(), auctionId);
+	}
+
+	@Operation(summary = "재경매 미리보기", description = "유찰된 본인 경매를 재등록하기 위한 기존 상품 정보를 조회한다.")
+	@GetMapping("/auctions/{auctionId:\\d+}/reauction-preview")
+	public ReauctionPreviewResponse getReauctionPreview(
+		@AuthenticationPrincipal AuthenticatedMember member,
+		@PathVariable Long auctionId
+	) {
+		return auctionService.getReauctionPreview(member.memberId(), auctionId);
+	}
+
+	@Operation(summary = "재경매 등록", description = "유찰된 본인 경매를 바탕으로 새 경매를 등록한다.")
+	@PostMapping("/auctions/{auctionId:\\d+}/reauction")
+	@ResponseStatus(HttpStatus.CREATED)
+	public ReauctionResponse reauction(
+		@AuthenticationPrincipal AuthenticatedMember member,
+		@PathVariable Long auctionId,
+		@Valid @RequestBody CreateAuctionRequest request
+	) {
+		return auctionService.reauction(member.memberId(), auctionId, request);
+	}
+
+	@Operation(summary = "재경매 거절", description = "유찰된 경매의 재등록 대기를 종료한다.")
+	@PatchMapping("/auctions/{auctionId:\\d+}/reauction/decline")
+	public DeclineReauctionResponse declineReauction(
+		@AuthenticationPrincipal AuthenticatedMember member,
+		@PathVariable Long auctionId
+	) {
+		return auctionService.declineReauction(member.memberId(), auctionId);
 	}
 
 	@Operation(summary = "경매 수정", description = "입찰이 없는 현재 사용자의 경매를 수정한다.")

--- a/src/main/java/com/dealit/dealit/domain/auction/dto/DeclineReauctionResponse.java
+++ b/src/main/java/com/dealit/dealit/domain/auction/dto/DeclineReauctionResponse.java
@@ -1,0 +1,11 @@
+package com.dealit.dealit.domain.auction.dto;
+
+import com.dealit.dealit.domain.auction.AuctionStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "재경매 거절 응답")
+public record DeclineReauctionResponse(
+	Long auctionId,
+	AuctionStatus status
+) {
+}

--- a/src/main/java/com/dealit/dealit/domain/auction/dto/ReauctionPreviewResponse.java
+++ b/src/main/java/com/dealit/dealit/domain/auction/dto/ReauctionPreviewResponse.java
@@ -1,0 +1,28 @@
+package com.dealit.dealit.domain.auction.dto;
+
+import com.dealit.dealit.domain.auction.AuctionStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+import java.util.List;
+
+@Schema(description = "재경매 미리보기 응답")
+public record ReauctionPreviewResponse(
+	Long productId,
+	Long auctionId,
+	String name,
+	String description,
+	Long categoryId,
+	String categoryName,
+	String location,
+	List<AuctionEditDetailResponse.AuctionEditImageResponse> images,
+	BigDecimal startPrice,
+	BigDecimal minimumBidAmount,
+	long auctionDurationDays,
+	AuctionStatus auctionStatus,
+	OffsetDateTime noBidAt,
+	OffsetDateTime reauctionExpiresAt,
+	long remainingSeconds
+) {
+}

--- a/src/main/java/com/dealit/dealit/domain/auction/dto/ReauctionResponse.java
+++ b/src/main/java/com/dealit/dealit/domain/auction/dto/ReauctionResponse.java
@@ -1,0 +1,11 @@
+package com.dealit.dealit.domain.auction.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "재경매 등록 응답")
+public record ReauctionResponse(
+	Long sourceAuctionId,
+	Long productId,
+	Long auctionId
+) {
+}

--- a/src/main/java/com/dealit/dealit/domain/auction/entity/Auction.java
+++ b/src/main/java/com/dealit/dealit/domain/auction/entity/Auction.java
@@ -64,6 +64,15 @@ public class Auction extends BaseEntity {
 	@Column(name = "ends_at", nullable = false)
 	private OffsetDateTime endsAt;
 
+	@Column(name = "no_bid_at")
+	private OffsetDateTime noBidAt;
+
+	@Column(name = "reauction_expires_at")
+	private OffsetDateTime reauctionExpiresAt;
+
+	@Column(name = "reauctioned_at")
+	private OffsetDateTime reauctionedAt;
+
 	@Enumerated(EnumType.STRING)
 	@Column(name = "status", nullable = false, length = 30)
 	private AuctionStatus status;
@@ -122,10 +131,25 @@ public class Auction extends BaseEntity {
 		this.status = AuctionStatus.SUCCESSFUL_BID;
 	}
 
-	public void completeWithoutBid() {
+	public void completeWithoutBid(OffsetDateTime noBidAt, OffsetDateTime reauctionExpiresAt) {
 		this.finalPrice = null;
 		this.winnerId = null;
+		this.noBidAt = noBidAt;
+		this.reauctionExpiresAt = reauctionExpiresAt;
 		this.status = AuctionStatus.NO_BID;
+	}
+
+	public void declineReauction() {
+		this.status = AuctionStatus.ENDED;
+	}
+
+	public void markReauctioned(OffsetDateTime reauctionedAt) {
+		this.reauctionedAt = reauctionedAt;
+		this.status = AuctionStatus.ENDED;
+	}
+
+	public void expireReauction() {
+		this.status = AuctionStatus.ENDED;
 	}
 
 	public boolean isOngoing() {

--- a/src/main/java/com/dealit/dealit/domain/auction/repository/AuctionRepository.java
+++ b/src/main/java/com/dealit/dealit/domain/auction/repository/AuctionRepository.java
@@ -26,6 +26,13 @@ public interface AuctionRepository extends JpaRepository<Auction, Long> {
 	);
 
 	@EntityGraph(attributePaths = {"product", "product.images"})
+	Page<Auction> findAllByProductMemberIdAndStatusInAndDeletedAtIsNullAndProductDeletedAtIsNull(
+		Long memberId,
+		Collection<AuctionStatus> statuses,
+		Pageable pageable
+	);
+
+	@EntityGraph(attributePaths = {"product", "product.images"})
 	Optional<Auction> findByAuctionIdAndProductMemberIdAndDeletedAtIsNullAndProductDeletedAtIsNull(
 		Long auctionId,
 		Long memberId
@@ -89,6 +96,12 @@ public interface AuctionRepository extends JpaRepository<Auction, Long> {
 		AuctionStatus status,
 		OffsetDateTime startsAt,
 		OffsetDateTime endsAt
+	);
+
+	@EntityGraph(attributePaths = {"product"})
+	List<Auction> findAllByStatusAndReauctionExpiresAtLessThanEqualAndDeletedAtIsNullAndProductDeletedAtIsNull(
+		AuctionStatus status,
+		OffsetDateTime now
 	);
 
 	@Query(value = """

--- a/src/main/java/com/dealit/dealit/domain/auction/scheduler/ReauctionExpirationScheduler.java
+++ b/src/main/java/com/dealit/dealit/domain/auction/scheduler/ReauctionExpirationScheduler.java
@@ -1,0 +1,32 @@
+package com.dealit.dealit.domain.auction.scheduler;
+
+import com.dealit.dealit.domain.auction.AuctionStatus;
+import com.dealit.dealit.domain.auction.entity.Auction;
+import com.dealit.dealit.domain.auction.repository.AuctionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Clock;
+import java.time.OffsetDateTime;
+
+@Component
+@RequiredArgsConstructor
+public class ReauctionExpirationScheduler {
+
+	private final AuctionRepository auctionRepository;
+	private final Clock clock;
+
+	@Transactional
+	@Scheduled(fixedDelayString = "${app.auction.reauction-expiration-scheduler-delay-ms:3600000}")
+	public void expireReauctionCandidates() {
+		OffsetDateTime now = OffsetDateTime.now(clock);
+		for (Auction auction : auctionRepository.findAllByStatusAndReauctionExpiresAtLessThanEqualAndDeletedAtIsNullAndProductDeletedAtIsNull(
+			AuctionStatus.NO_BID,
+			now
+		)) {
+			auction.expireReauction();
+		}
+	}
+}

--- a/src/main/java/com/dealit/dealit/domain/auction/service/AuctionBidService.java
+++ b/src/main/java/com/dealit/dealit/domain/auction/service/AuctionBidService.java
@@ -233,9 +233,9 @@ public class AuctionBidService {
 
 		AuctionState state = auctionRedisService.getState(auctionId);
 		if (state.highestBidderId() == null) {
-			auction.completeWithoutBid();
-			auction.getProduct().markEnded();
-			auction.softDelete();
+			OffsetDateTime noBidAt = serverTime();
+			auction.completeWithoutBid(noBidAt, noBidAt.plusDays(3));
+			auction.getProduct().markEndedWithoutDelete();
 			auctionRedisService.removeEnding(auctionId);
 			auctionRedisService.deleteState(auctionId);
 			auctionRedisService.removeClosingSoonNotified(auctionId);

--- a/src/main/java/com/dealit/dealit/domain/auction/service/AuctionService.java
+++ b/src/main/java/com/dealit/dealit/domain/auction/service/AuctionService.java
@@ -9,6 +9,7 @@ import com.dealit.dealit.domain.auction.dto.AuctionListResponse;
 import com.dealit.dealit.domain.auction.dto.CategoryOptionResponse;
 import com.dealit.dealit.domain.auction.dto.CreateAuctionRequest;
 import com.dealit.dealit.domain.auction.dto.CreateAuctionResponse;
+import com.dealit.dealit.domain.auction.dto.DeclineReauctionResponse;
 import com.dealit.dealit.domain.auction.dto.DeleteAuctionImageResponse;
 import com.dealit.dealit.domain.auction.dto.MySellingAuctionItemResponse;
 import com.dealit.dealit.domain.auction.dto.MySellingAuctionListResponse;
@@ -17,6 +18,8 @@ import com.dealit.dealit.domain.auction.dto.RecommendCategoryRequest;
 import com.dealit.dealit.domain.auction.dto.RecommendCategoryResponse;
 import com.dealit.dealit.domain.auction.dto.RecommendPriceRequest;
 import com.dealit.dealit.domain.auction.dto.RecommendPriceResponse;
+import com.dealit.dealit.domain.auction.dto.ReauctionPreviewResponse;
+import com.dealit.dealit.domain.auction.dto.ReauctionResponse;
 import com.dealit.dealit.domain.auction.dto.SaveAuctionDraftRequest;
 import com.dealit.dealit.domain.auction.dto.SaveAuctionDraftResponse;
 import com.dealit.dealit.domain.auction.dto.SearchCategoryOptionResponse;
@@ -28,6 +31,7 @@ import com.dealit.dealit.domain.auction.entity.Category;
 import com.dealit.dealit.domain.auth.exception.InvalidCredentialsException;
 import com.dealit.dealit.domain.auction.exception.AuctionAccessDeniedException;
 import com.dealit.dealit.domain.auction.exception.AuctionAlreadyBiddedException;
+import com.dealit.dealit.domain.auction.exception.AuctionConflictException;
 import com.dealit.dealit.domain.auction.exception.AuctionImageNotFoundException;
 import com.dealit.dealit.domain.auction.exception.AuctionProductNotFoundException;
 import com.dealit.dealit.domain.auction.exception.InvalidAuctionRequestException;
@@ -176,9 +180,9 @@ public class AuctionService {
 		loadActiveMember(memberId);
 		int normalizedPage = Math.max(page, 0);
 		int normalizedSize = Math.min(Math.max(size, 1), 100);
-		Page<Auction> auctionPage = auctionRepository.findAllByProductMemberIdAndStatusAndDeletedAtIsNullAndProductDeletedAtIsNull(
+		Page<Auction> auctionPage = auctionRepository.findAllByProductMemberIdAndStatusInAndDeletedAtIsNullAndProductDeletedAtIsNull(
 			memberId,
-			AuctionStatus.ONGOING,
+			List.of(AuctionStatus.ONGOING, AuctionStatus.NO_BID),
 			PageRequest.of(normalizedPage, normalizedSize, Sort.by(Sort.Direction.DESC, "createdAt"))
 		);
 
@@ -256,16 +260,6 @@ public class AuctionService {
 		int bidCount = getBidCount(auction);
 		Category category = categoryRepository.findById(product.getCategoryId()).orElse(null);
 
-		List<AuctionEditImageResponse> images = product.getImages().stream()
-			.filter(image -> image.getImageUrl() != null && !image.getImageUrl().isBlank())
-			.sorted(this::compareImagesBySortOrder)
-			.map(image -> new AuctionEditImageResponse(
-				image.getImageId(),
-				imageUrlService.toPublicUrl(image.getImageUrl()),
-				image.getSortOrder()
-			))
-			.toList();
-
 		return new AuctionEditDetailResponse(
 			product.getProductId(),
 			auction.getAuctionId(),
@@ -274,7 +268,7 @@ public class AuctionService {
 			product.getCategoryId(),
 			category == null ? "" : category.getNameKo(),
 			product.getLocation(),
-			images,
+			toAuctionEditImageResponses(product),
 			auction.getStartPrice(),
 			auction.getMinimumBidAmount(),
 			resolveAuctionDurationDays(auction),
@@ -283,6 +277,92 @@ public class AuctionService {
 			getBidderCount(auction),
 			bidCount == 0
 		);
+	}
+
+	public ReauctionPreviewResponse getReauctionPreview(Long memberId, Long auctionId) {
+		loadActiveMember(memberId);
+		Auction auction = loadReauctionCandidate(memberId, auctionId);
+		Product product = auction.getProduct();
+		Category category = categoryRepository.findById(product.getCategoryId()).orElse(null);
+		OffsetDateTime now = OffsetDateTime.now(clock);
+
+		return new ReauctionPreviewResponse(
+			product.getProductId(),
+			auction.getAuctionId(),
+			product.getName(),
+			product.getDescription(),
+			product.getCategoryId(),
+			category == null ? "" : category.getNameKo(),
+			product.getLocation(),
+			toAuctionEditImageResponses(product),
+			auction.getStartPrice(),
+			auction.getMinimumBidAmount(),
+			resolveAuctionDurationDays(auction),
+			auction.getStatus(),
+			toSeoulOffsetDateTime(auction.getNoBidAt()),
+			toSeoulOffsetDateTime(auction.getReauctionExpiresAt()),
+			Math.max(0L, Duration.between(now, auction.getReauctionExpiresAt()).getSeconds())
+		);
+	}
+
+	@Transactional
+	public ReauctionResponse reauction(Long memberId, Long auctionId, CreateAuctionRequest request) {
+		validateReauctionRequestBySaleType(request);
+		validateCategorySelection(request.categoryId());
+		Member member = loadActiveMember(memberId);
+		Auction sourceAuction = loadReauctionCandidate(memberId, auctionId);
+		Product sourceProduct = sourceAuction.getProduct();
+		OffsetDateTime now = OffsetDateTime.now(clock);
+		AuctionPeriod auctionPeriod = resolveReauctionPeriod(request, sourceAuction, now);
+		BigDecimal minimumBidAmount = resolveMinimumBidAmount(request.startPrice(), request.minimumBidAmount());
+
+		Product product = productRepository.save(
+			Product.create(
+				request.name().trim(),
+				request.description().trim(),
+				com.dealit.dealit.domain.product.ProductSaleType.AUCTION,
+				request.categoryId(),
+				member.getMemberId(),
+				request.startPrice(),
+				false,
+				request.location().trim(),
+				request.draftId(),
+				ProductStatus.ON_SALE
+			)
+		);
+
+		Auction auction = auctionRepository.save(
+			Auction.create(
+				product,
+				request.startPrice(),
+				minimumBidAmount,
+				auctionPeriod.startAt(),
+				auctionPeriod.endAt(),
+				determineStatus(auctionPeriod.endAt(), now)
+			)
+		);
+		auctionRedisService.initialize(auction);
+
+		List<ProductImage> nextImages = loadRequestedReauctionImages(member.getMemberId(), sourceProduct, request.images());
+		for (int index = 0; index < request.images().size(); index++) {
+			ProductImagePayload imagePayload = request.images().get(index);
+			ProductImage image = nextImages.get(index);
+			product.attachImage(image, imagePayload.sortOrder());
+		}
+		productImageRepository.saveAll(nextImages);
+
+		sourceAuction.markReauctioned(now);
+		applicationEventPublisher.publishEvent(new AuctionSearchIndexRequestedEvent(auction.getAuctionId()));
+
+		return new ReauctionResponse(sourceAuction.getAuctionId(), product.getProductId(), auction.getAuctionId());
+	}
+
+	@Transactional
+	public DeclineReauctionResponse declineReauction(Long memberId, Long auctionId) {
+		loadActiveMember(memberId);
+		Auction auction = loadReauctionCandidate(memberId, auctionId);
+		auction.declineReauction();
+		return new DeclineReauctionResponse(auction.getAuctionId(), auction.getStatus());
 	}
 
 	@Transactional
@@ -351,6 +431,18 @@ public class AuctionService {
 		productImageRepository.saveAll(removedImages);
 	}
 
+	private List<AuctionEditImageResponse> toAuctionEditImageResponses(Product product) {
+		return product.getImages().stream()
+			.filter(image -> image.getImageUrl() != null && !image.getImageUrl().isBlank())
+			.sorted(this::compareImagesBySortOrder)
+			.map(image -> new AuctionEditImageResponse(
+				image.getImageId(),
+				imageUrlService.toPublicUrl(image.getImageUrl()),
+				image.getSortOrder()
+			))
+			.toList();
+	}
+
 	private List<ProductImage> toOrderedProductImages(
 		Product product,
 		List<ProductImagePayload> imagePayloads,
@@ -377,6 +469,21 @@ public class AuctionService {
 			.orElseThrow(() -> new AuctionProductNotFoundException("존재하지 않는 경매 상품입니다."));
 		if (!auction.getProduct().getMemberId().equals(memberId)) {
 			throw new AuctionAccessDeniedException("본인이 등록한 경매만 접근할 수 있습니다.");
+		}
+		return auction;
+	}
+
+	private Auction loadReauctionCandidate(Long memberId, Long auctionId) {
+		Auction auction = loadOwnedAuction(memberId, auctionId);
+		if (auction.getStatus() != AuctionStatus.NO_BID) {
+			throw new AuctionConflictException("재경매 대기 상태의 경매만 재등록할 수 있습니다.");
+		}
+		if (auction.getReauctionedAt() != null) {
+			throw new AuctionConflictException("이미 재경매 등록이 완료된 경매입니다.");
+		}
+		OffsetDateTime expiresAt = auction.getReauctionExpiresAt();
+		if (expiresAt == null || !expiresAt.isAfter(OffsetDateTime.now(clock))) {
+			throw new AuctionConflictException("재경매 가능 기간이 지났습니다.");
 		}
 		return auction;
 	}
@@ -779,6 +886,49 @@ public class AuctionService {
 		return imagesById;
 	}
 
+	private List<ProductImage> loadRequestedReauctionImages(
+		Long memberId,
+		Product sourceProduct,
+		List<ProductImagePayload> imagePayloads
+	) {
+		List<Long> imageIds = imagePayloads.stream()
+			.map(ProductImagePayload::imageId)
+			.toList();
+
+		List<ProductImage> images = productImageRepository.findAllByImageIdInAndDeletedAtIsNull(imageIds);
+		if (images.size() != imageIds.size()) {
+			throw new AuctionImageNotFoundException("존재하지 않는 이미지가 포함되어 있습니다.");
+		}
+
+		Map<Long, ProductImage> imagesById = new LinkedHashMap<>();
+		for (ProductImage image : images) {
+			if (!image.getMemberId().equals(memberId)) {
+				throw new AuctionAccessDeniedException("본인이 업로드한 이미지만 사용할 수 있습니다.");
+			}
+			imagesById.put(image.getImageId(), image);
+		}
+		validateDuplicateImageIds(imageIds, imagesById.keySet());
+
+		return imagePayloads.stream()
+			.map(imagePayload -> toReusableReauctionImage(imagesById.get(imagePayload.imageId()), sourceProduct))
+			.toList();
+	}
+
+	private ProductImage toReusableReauctionImage(ProductImage image, Product sourceProduct) {
+		if (image.getProduct() == null) {
+			return image;
+		}
+		if (!image.getProduct().getProductId().equals(sourceProduct.getProductId())) {
+			throw new InvalidAuctionRequestException("이미 다른 상품에 연결된 이미지가 포함되어 있습니다.");
+		}
+
+		return ProductImage.createTemporary(
+			image.getImageUrl(),
+			image.getOriginalFileName(),
+			image.getMemberId()
+		);
+	}
+
 	private Map<Long, ProductImage> loadRequestedProductImagesForUpdate(
 		Product product,
 		List<ProductImagePayload> imagePayloads
@@ -870,6 +1020,26 @@ public class AuctionService {
 		}
 	}
 
+	private void validateReauctionRequestBySaleType(CreateAuctionRequest request) {
+		if (request.saleType() != ProductSaleType.AUCTION) {
+			throw new InvalidAuctionRequestException("경매 등록에서는 AUCTION 판매 유형만 허용됩니다.");
+		}
+
+		if (request.startPrice() == null) {
+			throw new InvalidAuctionRequestException("경매 판매에서는 시작가가 필수입니다.");
+		}
+		if (request.startPrice().signum() <= 0) {
+			throw new InvalidAuctionRequestException("시작가는 0보다 커야 합니다.");
+		}
+		resolveMinimumBidAmount(request.startPrice(), request.minimumBidAmount());
+		if (request.auctionDurationDays() != null && request.auctionDurationDays().signum() <= 0) {
+			throw new InvalidAuctionRequestException("경매 진행 기간은 0보다 커야 합니다.");
+		}
+		if (request.auctionDurationSeconds() != null && request.auctionDurationSeconds() <= 0) {
+			throw new InvalidAuctionRequestException("경매 진행 기간(초)은 0보다 커야 합니다.");
+		}
+	}
+
 	private void validateUpdateAuctionRequest(UpdateAuctionRequest request) {
 		if (request.startPrice().signum() <= 0) {
 			throw new InvalidAuctionRequestException("시작가는 0보다 커야 합니다.");
@@ -901,6 +1071,18 @@ public class AuctionService {
 			endAt = startAt.plus(toDurationFromDays(request.auctionDurationDays()));
 		}
 		return new AuctionPeriod(startAt, endAt);
+	}
+
+	private AuctionPeriod resolveReauctionPeriod(CreateAuctionRequest request, Auction sourceAuction, OffsetDateTime now) {
+		if (request.endsAt() != null || request.auctionDurationSeconds() != null || request.auctionDurationDays() != null) {
+			return resolveAuctionPeriod(request, now);
+		}
+
+		Duration sourceDuration = Duration.between(sourceAuction.getAuctionStartAt(), sourceAuction.getAuctionEndAt());
+		if (!sourceDuration.isPositive()) {
+			throw new InvalidAuctionRequestException("원본 경매 기간이 올바르지 않습니다.");
+		}
+		return new AuctionPeriod(now, now.plus(sourceDuration));
 	}
 
 	private Duration toDurationFromDays(BigDecimal auctionDurationDays) {

--- a/src/main/java/com/dealit/dealit/domain/product/entity/Product.java
+++ b/src/main/java/com/dealit/dealit/domain/product/entity/Product.java
@@ -177,6 +177,10 @@ public class Product extends BaseEntity {
 		softDelete();
 	}
 
+	public void markEndedWithoutDelete() {
+		this.status = ProductStatus.ENDED;
+	}
+
 	public void markTradeCompleted() {
 		this.status = ProductStatus.ENDED;
 	}

--- a/src/test/java/com/dealit/dealit/domain/auction/AuctionBidServiceTest.java
+++ b/src/test/java/com/dealit/dealit/domain/auction/AuctionBidServiceTest.java
@@ -109,8 +109,10 @@ class AuctionBidServiceTest {
 
 		assertThat(auction.getStatus()).isEqualTo(AuctionStatus.NO_BID);
 		assertThat(auction.getProduct().getStatus()).isEqualTo(ProductStatus.ENDED);
-		assertThat(auction.getDeletedAt()).isNotNull();
-		assertThat(auction.getProduct().getDeletedAt()).isNotNull();
+		assertThat(auction.getDeletedAt()).isNull();
+		assertThat(auction.getProduct().getDeletedAt()).isNull();
+		assertThat(auction.getNoBidAt()).isEqualTo(OffsetDateTime.parse("2026-05-02T00:00:00Z"));
+		assertThat(auction.getReauctionExpiresAt()).isEqualTo(OffsetDateTime.parse("2026-05-05T00:00:00Z"));
 		assertThat(auction.getWinnerId()).isNull();
 		assertThat(auction.getFinalPrice()).isNull();
 		verify(auctionRedisService).removeEnding(auctionId);

--- a/src/test/java/com/dealit/dealit/domain/auction/AuctionIntegrationTest.java
+++ b/src/test/java/com/dealit/dealit/domain/auction/AuctionIntegrationTest.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
+import java.time.OffsetDateTime;
 import java.util.Comparator;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -406,6 +407,148 @@ class AuctionIntegrationTest {
 		var auction = auctionRepository.findAll().getFirst();
 		assertThat(Duration.between(auction.getAuctionStartAt(), auction.getAuctionEndAt()))
 			.isEqualTo(Duration.ofSeconds(60));
+	}
+
+	@Test
+	@DisplayName("재경매 그대로 올리기는 원본 경매 기간을 담은 요청값으로 다시 등록한다")
+	void reauctionSameKeepsSourceAuctionDurationFromRequest() throws Exception {
+		mockMvc.perform(post("/api/v1/auction")
+				.header("Authorization", "Bearer " + accessToken)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{
+					  "name": "Original auction",
+					  "description": "Original seven day auction.",
+					  "saleType": "AUCTION",
+					  "categoryId": 21,
+					  "price": null,
+					  "startPrice": 500000,
+					  "minimumBidAmount": 5000,
+					  "auctionDurationDays": 7,
+					  "images": [
+					    {
+					      "imageId": %d,
+					      "imageUrl": "http://localhost:8080/uploads/auction/images/test-image.jpg",
+					      "sortOrder": 1
+					    }
+					  ],
+					  "location": "서울 마포구",
+					  "draftId": null
+					}
+					""".formatted(uploadedImage.getImageId())))
+			.andExpect(status().isCreated());
+
+		var sourceAuction = auctionRepository.findAll().getFirst();
+		sourceAuction.completeWithoutBid(OffsetDateTime.now(), OffsetDateTime.now().plusDays(3));
+		auctionRepository.save(sourceAuction);
+
+		mockMvc.perform(post("/api/v1/auctions/{auctionId}/reauction", sourceAuction.getAuctionId())
+				.header("Authorization", "Bearer " + accessToken)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{
+					  "name": "Original auction",
+					  "description": "Original seven day auction.",
+					  "saleType": "AUCTION",
+					  "categoryId": 21,
+					  "price": null,
+					  "startPrice": 500000,
+					  "minimumBidAmount": 5000,
+					  "auctionDurationDays": 7,
+					  "images": [
+					    {
+					      "imageId": %d,
+					      "imageUrl": "http://localhost:8080/uploads/auction/images/test-image.jpg",
+					      "sortOrder": 1
+					    }
+					  ],
+					  "location": "서울 마포구",
+					  "draftId": null
+					}
+					""".formatted(uploadedImage.getImageId())))
+			.andExpect(status().isCreated());
+
+		var reauction = auctionRepository.findAll().stream()
+			.filter(auction -> !auction.getAuctionId().equals(sourceAuction.getAuctionId()))
+			.findFirst()
+			.orElseThrow();
+		assertThat(Duration.between(reauction.getAuctionStartAt(), reauction.getAuctionEndAt()))
+			.isEqualTo(Duration.ofDays(7));
+	}
+
+	@Test
+	@DisplayName("재경매 게시글 수정하기는 변경한 경매 값을 반영한다")
+	void reauctionEditAppliesChangedAuctionValues() throws Exception {
+		mockMvc.perform(post("/api/v1/auction")
+				.header("Authorization", "Bearer " + accessToken)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{
+					  "name": "Original auction",
+					  "description": "Original seven day auction.",
+					  "saleType": "AUCTION",
+					  "categoryId": 21,
+					  "price": null,
+					  "startPrice": 500000,
+					  "minimumBidAmount": 5000,
+					  "auctionDurationDays": 7,
+					  "images": [
+					    {
+					      "imageId": %d,
+					      "imageUrl": "http://localhost:8080/uploads/auction/images/test-image.jpg",
+					      "sortOrder": 1
+					    }
+					  ],
+					  "location": "서울 마포구",
+					  "draftId": null
+					}
+					""".formatted(uploadedImage.getImageId())))
+			.andExpect(status().isCreated());
+
+		var sourceAuction = auctionRepository.findAll().getFirst();
+		sourceAuction.completeWithoutBid(OffsetDateTime.now(), OffsetDateTime.now().plusDays(3));
+		auctionRepository.save(sourceAuction);
+
+		mockMvc.perform(post("/api/v1/auctions/{auctionId}/reauction", sourceAuction.getAuctionId())
+				.header("Authorization", "Bearer " + accessToken)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{
+					  "name": "Changed auction",
+					  "description": "Changed five day auction.",
+					  "saleType": "AUCTION",
+					  "categoryId": 21,
+					  "price": null,
+					  "startPrice": 300000,
+					  "minimumBidAmount": 3000,
+					  "auctionDurationDays": 5,
+					  "images": [
+					    {
+					      "imageId": %d,
+					      "imageUrl": "http://localhost:8080/uploads/auction/images/test-image.jpg",
+					      "sortOrder": 1
+					    }
+					  ],
+					  "location": "서울 강남구",
+					  "draftId": null
+					}
+					""".formatted(uploadedImage.getImageId())))
+			.andExpect(status().isCreated());
+
+		var reauctionId = auctionRepository.findAll().stream()
+			.filter(auction -> !auction.getAuctionId().equals(sourceAuction.getAuctionId()))
+			.map(auction -> auction.getAuctionId())
+			.findFirst()
+			.orElseThrow();
+		var reauction = auctionRepository.findByAuctionIdAndDeletedAtIsNullAndProductDeletedAtIsNull(reauctionId)
+			.orElseThrow();
+		assertThat(reauction.getProduct().getName()).isEqualTo("Changed auction");
+		assertThat(reauction.getProduct().getDescription()).isEqualTo("Changed five day auction.");
+		assertThat(reauction.getProduct().getLocation()).isEqualTo("서울 강남구");
+		assertThat(reauction.getStartPrice()).isEqualByComparingTo("300000");
+		assertThat(reauction.getMinimumBidAmount()).isEqualByComparingTo("3000");
+		assertThat(Duration.between(reauction.getAuctionStartAt(), reauction.getAuctionEndAt()))
+			.isEqualTo(Duration.ofDays(5));
 	}
 
 	@Test


### PR DESCRIPTION
### 🚀 Summary

<!-- 작업 내용에 대한 간략한 설명을 써주세요. -->
- 재경매 기능
---

### ✨ Description

<!-- 상세한 설명, 기능의 사용법, 주의 사항 실행 결과(이미지 첨부 가능) 등을 보여주세요. -->
## 작업 내용

- 유찰된 경매를 재등록할 수 있는 API를 추가했습니다.
  - `GET /api/v1/auctions/{auctionId}/reauction-preview`
  - `POST /api/v1/auctions/{auctionId}/reauction`
  - `PATCH /api/v1/auctions/{auctionId}/reauction/decline`


- 입찰 없이 종료된 경매는 즉시 soft delete하지 않고 `NO_BID` 상태로 유지하도록 변경했습니다.
  - 재경매 가능 시각 관리를 위해 `noBidAt`, `reauctionExpiresAt`, `reauctionedAt` 필드를 추가했습니다.
  - 유찰 후 3일 동안 재경매 대기 상태로 남습니다.

유찰시
<img width="458" height="76" alt="스크린샷 2026-05-18 오후 10 07 38" src="https://github.com/user-attachments/assets/509b482b-7165-4e46-87bf-cdc3052a25a4" />

재등록
<img width="485" height="77" alt="스크린샷 2026-05-18 오후 10 08 50" src="https://github.com/user-attachments/assets/195bec4e-09c1-4dde-8a4b-5b7044a30389" />

재경매 안하고 종료
<img width="521" height="111" alt="스크린샷 2026-05-18 오후 10 08 45" src="https://github.com/user-attachments/assets/567f75ac-9e41-4f20-8de2-f0fd019ee9e5" />


- 재경매 등록 로직을 추가했습니다.
  - 원본 경매의 상품 정보, 가격, 이미지 정보를 기반으로 새 경매를 생성합니다.
  - 요청에 경매 기간이 있으면 요청값을 반영합니다.
  - 요청에 경매 기간이 없으면 원본 경매 기간을 그대로 사용합니다.
  - 재경매 완료 시 원본 경매는 `ENDED` 처리하고 `reauctionedAt`을 기록합니다.

- 재경매 거절 및 만료 처리를 추가했습니다.
  - 판매자가 재등록을 거절하면 원본 경매를 `ENDED` 처리합니다.
  - 재경매 가능 기간이 지난 `NO_BID` 경매를 종료하는 스케줄러를 추가했습니다.

- 내 판매중 경매 목록에 재경매 대기 상태(`NO_BID`)도 포함되도록 변경했습니다.

## 테스트

- 입찰자 없이 경매 종료 시 유찰 상태와 재경매 가능 만료 시각이 저장되는지 검증했습니다.
- 재경매 그대로 올리기 시 원본 경매 기간이 유지되는지 검증했습니다.
- 재경매 게시글 수정하기 시 변경한 제목, 설명, 위치, 시작가, 입찰 단위, 기간이 반영되는지 검증했습니다.

---

### 🎲 Issue Number

<!-- Please enter {Issue Number} below to automatically close the connected issue. -->

close #87 
