### PR TITLE
[fix] 핫한 상품 로직 변경

### DIFF
--- a/src/main/java/com/dealit/dealit/domain/product/controller/ProductController.java
+++ b/src/main/java/com/dealit/dealit/domain/product/controller/ProductController.java
@@ -186,8 +186,9 @@ public class ProductController {
 	)
 	@GetMapping("/hot-list")
 	public HotListProductListResponse getHotListProducts(
+		@AuthenticationPrincipal AuthenticatedMember member,
 		@RequestParam(defaultValue = "8") int size
 	) {
-		return productService.getHotListProducts(size);
+		return productService.getHotListProducts(member.memberId(), size);
 	}
 }

--- a/src/main/java/com/dealit/dealit/domain/product/repository/ProductRepository.java
+++ b/src/main/java/com/dealit/dealit/domain/product/repository/ProductRepository.java
@@ -70,4 +70,11 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
 		Pageable pageable
 	);
 
+	@EntityGraph(attributePaths = {"images"})
+	List<Product> findAllBySaleTypeAndStatusAndDeletedAtIsNullAndCategoryIdIn(
+		ProductSaleType saleType,
+		ProductStatus status,
+		Collection<Long> categoryIds
+	);
+
 }

--- a/src/main/java/com/dealit/dealit/domain/product/service/ProductService.java
+++ b/src/main/java/com/dealit/dealit/domain/product/service/ProductService.java
@@ -5,6 +5,7 @@ import com.dealit.dealit.domain.auction.repository.CategoryRepository;
 import com.dealit.dealit.domain.auth.exception.InvalidCredentialsException;
 import com.dealit.dealit.domain.member.entity.Member;
 import com.dealit.dealit.domain.member.exception.EmailNotVerifiedException;
+import com.dealit.dealit.domain.member.repository.MemberInterestCategoryRepository;
 import com.dealit.dealit.domain.member.repository.MemberRepository;
 import com.dealit.dealit.domain.product.ProductSaleType;
 import com.dealit.dealit.domain.product.ProductStatus;
@@ -84,6 +85,7 @@ public class ProductService {
 	private final ProductDraftRepository productDraftRepository;
 	private final CategoryRepository categoryRepository;
 	private final MemberRepository memberRepository;
+	private final MemberInterestCategoryRepository memberInterestCategoryRepository;
 	private final ProductImageStorage productImageStorage;
 	private final ImageUrlService imageUrlService;
 	private final ObjectMapper objectMapper;
@@ -165,12 +167,9 @@ public class ProductService {
 		return new PopularProductListResponse(content);
 	}
 
-	public HotListProductListResponse getHotListProducts(int size) {
+	public HotListProductListResponse getHotListProducts(Long memberId, int size) {
 		int normalizedSize = Math.min(Math.max(size, 1), 100);
-		List<Product> products = productRepository.findAllBySaleTypeAndStatusAndDeletedAtIsNull(
-			ProductSaleType.REGULAR,
-			ProductStatus.ON_SALE
-		);
+		List<Product> products = loadHotListCandidateProducts(memberId);
 
 		Map<Long, String> categoryNamesById = loadCategoryNames(products);
 		List<Product> rankedProducts = products.stream()
@@ -188,6 +187,38 @@ public class ProductService {
 		}
 
 		return new HotListProductListResponse(content);
+	}
+
+	private List<Product> loadHotListCandidateProducts(Long memberId) {
+		Set<Long> interestCategoryIds = resolveInterestCategoryIds(memberId);
+		if (interestCategoryIds.isEmpty()) {
+			return productRepository.findAllBySaleTypeAndStatusAndDeletedAtIsNull(
+				ProductSaleType.REGULAR,
+				ProductStatus.ON_SALE
+			);
+		}
+
+		return productRepository.findAllBySaleTypeAndStatusAndDeletedAtIsNullAndCategoryIdIn(
+			ProductSaleType.REGULAR,
+			ProductStatus.ON_SALE,
+			interestCategoryIds
+		);
+	}
+
+	private Set<Long> resolveInterestCategoryIds(Long memberId) {
+		List<Long> topLevelCategoryIds = memberInterestCategoryRepository
+			.findAllByMemberIdOrderByCategoryIdAsc(memberId)
+			.stream()
+			.map(memberInterestCategory -> memberInterestCategory.getCategoryId())
+			.toList();
+		if (topLevelCategoryIds.isEmpty()) {
+			return Set.of();
+		}
+
+		Set<Long> categoryIds = new LinkedHashSet<>();
+		categoryRepository.findAllById(topLevelCategoryIds)
+			.forEach(category -> categoryIds.addAll(resolveSearchableCategoryIds(category)));
+		return categoryIds;
 	}
 
 	public ProductEditDetailResponse getProductEditDetail(Long memberId, Long productId) {

--- a/src/test/java/com/dealit/dealit/domain/product/HotListProductIntegrationTest.java
+++ b/src/test/java/com/dealit/dealit/domain/product/HotListProductIntegrationTest.java
@@ -1,0 +1,134 @@
+package com.dealit.dealit.domain.product;
+
+import com.dealit.dealit.domain.member.entity.Member;
+import com.dealit.dealit.domain.member.entity.MemberInterestCategory;
+import com.dealit.dealit.domain.member.repository.MemberInterestCategoryRepository;
+import com.dealit.dealit.domain.member.repository.MemberRepository;
+import com.dealit.dealit.domain.product.entity.Product;
+import com.dealit.dealit.domain.product.repository.ProductRepository;
+import com.dealit.dealit.global.security.AuthenticatedMember;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class HotListProductIntegrationTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private ProductRepository productRepository;
+
+	@Autowired
+	private MemberRepository memberRepository;
+
+	@Autowired
+	private MemberInterestCategoryRepository memberInterestCategoryRepository;
+
+	private Member member;
+
+	@BeforeEach
+	void setUp() {
+		memberInterestCategoryRepository.deleteAll();
+		productRepository.deleteAll();
+		memberRepository.deleteAll();
+
+		member = memberRepository.save(Member.create(
+			"hot-list-user",
+			"password",
+			"hot-list@example.com",
+			null,
+			"hot-list-user"
+		));
+		member.assignDefaultNickname();
+		member.verifyEmail();
+		member.updateLocation("Seoul");
+		member = memberRepository.save(member);
+	}
+
+	@Test
+	@DisplayName("hot-list uses the current member's interest categories")
+	void getHotListProductsUsesMemberInterestCategories() throws Exception {
+		memberInterestCategoryRepository.save(MemberInterestCategory.create(member.getMemberId(), 1L));
+
+		saveProductWithCounts("interest electronics product", 19L, 5, 2, 2);
+		saveProductWithCounts("non interest fashion product", 28L, 100, 20, 1);
+
+		mockMvc.perform(get("/api/v1/products/hot-list")
+				.with(authentication(authenticatedMember()))
+				.param("size", "8"))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.content", hasSize(1)))
+			.andExpect(jsonPath("$.content[0].name").value("interest electronics product"))
+			.andExpect(jsonPath("$.content[0].rank").value(1));
+	}
+
+	@Test
+	@DisplayName("hot-list falls back to all products when the member has no interest categories")
+	void getHotListProductsFallsBackToAllProductsWhenNoInterestCategories() throws Exception {
+		saveProductWithCounts("low score product", 19L, 2, 0, 1);
+		saveProductWithCounts("high score product", 28L, 10, 5, 1);
+
+		mockMvc.perform(get("/api/v1/products/hot-list")
+				.with(authentication(authenticatedMember()))
+				.param("size", "2"))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.content", hasSize(2)))
+			.andExpect(jsonPath("$.content[0].name").value("high score product"))
+			.andExpect(jsonPath("$.content[0].rank").value(1))
+			.andExpect(jsonPath("$.content[1].name").value("low score product"))
+			.andExpect(jsonPath("$.content[1].rank").value(2));
+	}
+
+	private Product saveProductWithCounts(String name, Long categoryId, int viewCount, int favoriteCount, int elapsedHours) {
+		Product product = productRepository.save(Product.create(
+			name,
+			"hot-list test product",
+			ProductSaleType.REGULAR,
+			categoryId,
+			member.getMemberId(),
+			BigDecimal.valueOf(10000),
+			false,
+			"Seoul",
+			null,
+			ProductStatus.ON_SALE
+		));
+		ReflectionTestUtils.setField(product, "createdAt", LocalDateTime.now().minusHours(elapsedHours));
+		ReflectionTestUtils.setField(product, "updatedAt", LocalDateTime.now().minusHours(elapsedHours));
+		for (int count = 0; count < viewCount; count++) {
+			product.increaseViewCount();
+		}
+		for (int count = 0; count < favoriteCount; count++) {
+			product.increaseFavoriteCount();
+		}
+		return productRepository.save(product);
+	}
+
+	private UsernamePasswordAuthenticationToken authenticatedMember() {
+		AuthenticatedMember principal = new AuthenticatedMember(member.getMemberId(), member.getLoginId(), "ROLE_USER");
+		return new UsernamePasswordAuthenticationToken(
+			principal,
+			null,
+			List.of(new SimpleGrantedAuthority("ROLE_USER"))
+		);
+	}
+}


### PR DESCRIPTION
### Summary

핫한 상품 목록 API가 로그인 사용자의 관심 카테고리를 기준으로 상품 후보군을 필터링하도록 변경했습니다.

---

### Description

- `GET /api/v1/products/hot-list`의 URL, query parameter, 응답 DTO 구조는 그대로 유지했습니다.
- 컨트롤러에서 `@AuthenticationPrincipal`로 현재 로그인 사용자의 `memberId`를 서비스에 전달하도록 수정했습니다.
- 핫한 상품 점수 공식은 기존과 동일하게 유지했습니다.
  - `viewCount + favoriteCount * 3`
  - 등록 후 경과 시간 기준 보정
- 변경된 부분은 점수 계산 대상 후보군입니다.
  - 관심 카테고리가 있는 사용자: 관심 카테고리 및 그 하위 카테고리에 속한 일반 판매 `ON_SALE` 상품만 대상으로 계산
  - 관심 카테고리가 없는 사용자: 기존처럼 전체 일반 판매 `ON_SALE` 상품을 대상으로 계산
- 관심 카테고리 기반 조회를 위해 `categoryIdIn` 조건의 상품 목록 조회 repository 메서드를 추가했습니다.
- 관심 카테고리 필터링과 fallback 동작을 검증하는 통합 테스트를 추가했습니다.

<img width="958" height="1299" alt="카테고리 기반 핫한상품" src="https://github.com/user-attachments/assets/f436defa-84c5-4c08-b1e3-25376a62bebd" />

---

### Issue Number

close #{Issue Number}