### PR TITLE
[feat] 경매 거래 진행 알림 추가

### DIFF
--- a/src/main/java/com/dealit/dealit/domain/auction/service/AuctionBidService.java
+++ b/src/main/java/com/dealit/dealit/domain/auction/service/AuctionBidService.java
@@ -287,7 +287,6 @@ public class AuctionBidService {
 				state.currentPrice(),
 				AuctionStatus.SUCCESSFUL_BID
 			);
-			auctionNotificationService.notifyReviewRequest(auction, state.highestBidderId());
 			auctionEventPublisher.publishAuctionEnded(
 				state.highestBidderId(),
 				auctionId,

--- a/src/main/java/com/dealit/dealit/domain/auction/service/AuctionNotificationService.java
+++ b/src/main/java/com/dealit/dealit/domain/auction/service/AuctionNotificationService.java
@@ -66,7 +66,7 @@ public class AuctionNotificationService {
 		}
 
 		if (status == AuctionStatus.NO_BID) {
-			String title = "유찰 알림";
+			String title = "경매가 유찰 되었어요";
 			String content = "'" + auction.getProduct().getName() + "' 경매가 입찰 없이 종료되었어요. 재등록 해볼까요?";
 			createAuctionNotification(receiverId, title, content, auction.getAuctionId());
 			sendAuctionPush(receiverId, title, content, "AUCTION_NO_BID", auction.getAuctionId(), null);
@@ -88,14 +88,35 @@ public class AuctionNotificationService {
 		sendAuctionPush(bidderId, title, content, "AUCTION_BID_FAILED", auction.getAuctionId(), winnerId);
 	}
 
+	public void notifyAuctionShipped(Auction auction, Long winnerId, Long roomId) {
+		String title = "상품이 발송되었습니다.";
+		String content = "'" + auction.getProduct().getName() + "' 상품이 발송되었어요. 물건을 받으면 수령확정을 눌러주세요.";
+		String targetUrl = chatTargetUrl(roomId, auction.getAuctionId());
+		createChatNotification(winnerId, title, content, auction.getAuctionId(), roomId, targetUrl);
+		sendAuctionPush(winnerId, title, content, "AUCTION_SHIPPED", auction.getAuctionId(), null, targetUrl, roomId);
+	}
+
+	public void notifyAuctionReceived(Auction auction, Long sellerId, Long roomId) {
+		String title = "수령확정이 완료되었습니다.";
+		String content = "'" + auction.getProduct().getName() + "' 상품 구매자가 수령확정을 완료했어요.";
+		String targetUrl = chatTargetUrl(roomId, auction.getAuctionId());
+		createChatNotification(sellerId, title, content, auction.getAuctionId(), roomId, targetUrl);
+		sendAuctionPush(sellerId, title, content, "AUCTION_RECEIVED", auction.getAuctionId(), null, targetUrl, roomId);
+	}
+
 	public void notifyReviewRequest(Auction auction, Long winnerId) {
 		String title = "후기 작성 알림";
 		String content = "'" + auction.getProduct().getName() + "' 거래 후기를 작성해 주세요.";
-		createAuctionNotification(winnerId, title, content, auction.getAuctionId());
-		sendAuctionPush(winnerId, title, content, "REVIEW_REQUESTED", auction.getAuctionId(), null);
+		String targetUrl = reviewTargetUrl(auction);
+		createAuctionNotification(winnerId, title, content, auction.getAuctionId(), targetUrl);
+		sendAuctionPush(winnerId, title, content, "REVIEW_REQUESTED", auction.getAuctionId(), null, targetUrl);
 	}
 
 	private void createAuctionNotification(Long receiverId, String title, String content, Long auctionId) {
+		createAuctionNotification(receiverId, title, content, auctionId, "/auctions/" + auctionId);
+	}
+
+	private void createAuctionNotification(Long receiverId, String title, String content, Long auctionId, String targetUrl) {
 		notificationCenterService.create(
 			receiverId,
 			new NotificationCreateRequest(
@@ -104,7 +125,28 @@ public class AuctionNotificationService {
 				content,
 				TARGET_TYPE,
 				auctionId,
-				"/auctions/" + auctionId
+				targetUrl
+			)
+		);
+	}
+
+	private void createChatNotification(
+		Long receiverId,
+		String title,
+		String content,
+		Long auctionId,
+		Long roomId,
+		String targetUrl
+	) {
+		notificationCenterService.create(
+			receiverId,
+			new NotificationCreateRequest(
+				InAppNotificationType.AUCTION,
+				title,
+				content,
+				roomId == null ? TARGET_TYPE : "CHAT",
+				roomId == null ? auctionId : roomId,
+				targetUrl
 			)
 		);
 	}
@@ -117,19 +159,35 @@ public class AuctionNotificationService {
 		Long auctionId,
 		Long actorId
 	) {
+		sendAuctionPush(receiverId, title, content, type, auctionId, actorId, "/auctions/" + auctionId);
+	}
+
+	private void sendAuctionPush(
+		Long receiverId,
+		String title,
+		String content,
+		String type,
+		Long auctionId,
+		Long actorId,
+		String targetUrl
+	) {
+		sendAuctionPush(receiverId, title, content, type, auctionId, actorId, targetUrl, null);
+	}
+
+	private void sendAuctionPush(
+		Long receiverId,
+		String title,
+		String content,
+		String type,
+		Long auctionId,
+		Long actorId,
+		String targetUrl,
+		Long roomId
+	) {
 		try {
 			Map<String, String> data = actorId == null
-				? Map.of(
-					"type", type,
-					"auctionId", String.valueOf(auctionId),
-					"targetUrl", "/auctions/" + auctionId
-				)
-				: Map.of(
-					"type", type,
-					"auctionId", String.valueOf(auctionId),
-					"actorId", String.valueOf(actorId),
-					"targetUrl", "/auctions/" + auctionId
-				);
+				? auctionPushData(type, auctionId, null, targetUrl, roomId)
+				: auctionPushData(type, auctionId, actorId, targetUrl, roomId);
 			int sentCount = fcmNotificationService.sendToMember(receiverId, title, content, data);
 			log.debug("Sent auction push notification. type={}, auctionId={}, receiverId={}, sentCount={}",
 				type, auctionId, receiverId, sentCount);
@@ -144,5 +202,53 @@ public class AuctionNotificationService {
 			return "";
 		}
 		return NumberFormat.getNumberInstance(Locale.KOREA).format(price.stripTrailingZeros());
+	}
+
+	private String reviewTargetUrl(Auction auction) {
+		return "/mypage/review/write?auctionId=" + auction.getAuctionId()
+			+ "&displayProductId=" + auction.getProduct().getProductId();
+	}
+
+	private String chatTargetUrl(Long roomId, Long auctionId) {
+		return roomId == null ? "/auctions/" + auctionId : "/chats/" + roomId;
+	}
+
+	private Map<String, String> auctionPushData(
+		String type,
+		Long auctionId,
+		Long actorId,
+		String targetUrl,
+		Long roomId
+	) {
+		if (actorId != null && roomId != null) {
+			return Map.of(
+				"type", type,
+				"auctionId", String.valueOf(auctionId),
+				"actorId", String.valueOf(actorId),
+				"targetUrl", targetUrl,
+				"roomId", String.valueOf(roomId)
+			);
+		}
+		if (actorId != null) {
+			return Map.of(
+				"type", type,
+				"auctionId", String.valueOf(auctionId),
+				"actorId", String.valueOf(actorId),
+				"targetUrl", targetUrl
+			);
+		}
+		if (roomId != null) {
+			return Map.of(
+				"type", type,
+				"auctionId", String.valueOf(auctionId),
+				"targetUrl", targetUrl,
+				"roomId", String.valueOf(roomId)
+			);
+		}
+		return Map.of(
+			"type", type,
+			"auctionId", String.valueOf(auctionId),
+			"targetUrl", targetUrl
+		);
 	}
 }

--- a/src/main/java/com/dealit/dealit/domain/auction/service/AuctionRefundService.java
+++ b/src/main/java/com/dealit/dealit/domain/auction/service/AuctionRefundService.java
@@ -3,6 +3,7 @@ package com.dealit.dealit.domain.auction.service;
 import com.dealit.dealit.domain.auction.AuctionPaymentStatus;
 import com.dealit.dealit.domain.auction.entity.AuctionPayment;
 import com.dealit.dealit.domain.auction.repository.AuctionPaymentRepository;
+import com.dealit.dealit.domain.chat.repository.ChatRoomRepository;
 import com.dealit.dealit.domain.wallet.service.WalletService;
 import java.time.Clock;
 import java.time.OffsetDateTime;
@@ -22,6 +23,8 @@ public class AuctionRefundService {
 
 	private final AuctionPaymentRepository auctionPaymentRepository;
 	private final WalletService walletService;
+	private final AuctionNotificationService auctionNotificationService;
+	private final ChatRoomRepository chatRoomRepository;
 	private final Clock clock;
 
 	@Transactional
@@ -98,6 +101,22 @@ public class AuctionRefundService {
 				payment.getAmount(),
 				payment.getAuction().getAuctionId()
 			);
+			auctionNotificationService.notifyAuctionReceived(
+				payment.getAuction(),
+				payment.getSellerId(),
+				findRoomId(payment)
+			);
+			auctionNotificationService.notifyReviewRequest(payment.getAuction(), payment.getBidderId());
 		}
+	}
+
+	private Long findRoomId(AuctionPayment payment) {
+		return chatRoomRepository.findBySellerIdAndBuyerIdAndProductIdAndDeletedAtIsNull(
+				payment.getSellerId(),
+				payment.getBidderId(),
+				payment.getAuction().getProduct().getProductId()
+			)
+			.map(room -> room.getRoomId())
+			.orElse(null);
 	}
 }

--- a/src/main/java/com/dealit/dealit/domain/chat/service/ChatService.java
+++ b/src/main/java/com/dealit/dealit/domain/chat/service/ChatService.java
@@ -4,6 +4,7 @@ import com.dealit.dealit.domain.auction.AuctionPaymentStatus;
 import com.dealit.dealit.domain.auction.AuctionStatus;
 import com.dealit.dealit.domain.auction.entity.AuctionPayment;
 import com.dealit.dealit.domain.auction.repository.AuctionPaymentRepository;
+import com.dealit.dealit.domain.auction.service.AuctionNotificationService;
 import com.dealit.dealit.domain.chat.dto.ChatMessageListResponse;
 import com.dealit.dealit.domain.chat.dto.ChatMessageResponse;
 import com.dealit.dealit.domain.chat.dto.ChatRoomDetailResponse;
@@ -71,6 +72,7 @@ public class ChatService {
     private final PurchaseRepository purchaseRepository;
     private final EventStreamService eventStreamService;
     private final FcmNotificationService fcmNotificationService;
+    private final AuctionNotificationService auctionNotificationService;
     private final Clock clock;
 
     public CreateChatRoomResponse createChatRoom(CreateChatRoomRequest request, Long currentUserId) {
@@ -176,6 +178,7 @@ public class ChatService {
         if (!payment.markShipped(now)) {
             throw new IllegalArgumentException("현재 상태에서는 발송 처리를 할 수 없습니다.");
         }
+        auctionNotificationService.notifyAuctionShipped(payment.getAuction(), payment.getBidderId(), room.getRoomId());
 
         publishRoomAndUnreadUpdates(room, room.getSellerId(), room.getBuyerId(), LocalDateTime.now(clock));
         return buildCreateRoomResponse(room, currentUserId, room.getSellerId(), room.getBuyerId(), room.getCreatedAt());
@@ -209,6 +212,8 @@ public class ChatService {
                 payment.getAmount(),
                 payment.getAuction().getAuctionId()
         );
+        auctionNotificationService.notifyAuctionReceived(payment.getAuction(), payment.getSellerId(), room.getRoomId());
+        auctionNotificationService.notifyReviewRequest(payment.getAuction(), currentUserId);
 
         publishRoomAndUnreadUpdates(room, room.getSellerId(), room.getBuyerId(), LocalDateTime.now(clock));
         return buildCreateRoomResponse(room, currentUserId, room.getSellerId(), room.getBuyerId(), room.getCreatedAt());

--- a/src/test/java/com/dealit/dealit/domain/auction/AuctionNotificationServiceTest.java
+++ b/src/test/java/com/dealit/dealit/domain/auction/AuctionNotificationServiceTest.java
@@ -18,6 +18,7 @@ import com.dealit.dealit.domain.product.ProductStatus;
 import com.dealit.dealit.domain.product.entity.Product;
 import java.math.BigDecimal;
 import java.time.OffsetDateTime;
+import java.util.Map;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -59,8 +60,54 @@ class AuctionNotificationServiceTest {
 		ArgumentCaptor<NotificationCreateRequest> captor = ArgumentCaptor.forClass(NotificationCreateRequest.class);
 		verify(notificationCenterService).create(eq(10L), captor.capture());
 		assertThat(captor.getValue().type()).isEqualTo(InAppNotificationType.AUCTION);
-		assertThat(captor.getValue().title()).isEqualTo("유찰 알림");
+		assertThat(captor.getValue().title()).isEqualTo("경매가 유찰 되었어요");
 		assertThat(captor.getValue().targetType()).isEqualTo("AUCTION");
+	}
+
+	@Test
+	@DisplayName("후기 작성 알림은 후기 작성 화면으로 이동하는 대상 URL을 포함한다")
+	void notifyReviewRequestCreatesReviewWriteTarget() {
+		Auction auction = auction(10L);
+		when(fcmNotificationService.sendToMember(eq(20L), any(), any(), any())).thenReturn(0);
+
+		auctionNotificationService.notifyReviewRequest(auction, 20L);
+
+		ArgumentCaptor<NotificationCreateRequest> notificationCaptor =
+			ArgumentCaptor.forClass(NotificationCreateRequest.class);
+		verify(notificationCenterService).create(eq(20L), notificationCaptor.capture());
+		assertThat(notificationCaptor.getValue().title()).isEqualTo("후기 작성 알림");
+		assertThat(notificationCaptor.getValue().targetUrl())
+			.isEqualTo("/mypage/review/write?auctionId=1&displayProductId=21");
+
+		@SuppressWarnings("unchecked")
+		ArgumentCaptor<Map<String, String>> dataCaptor = ArgumentCaptor.forClass(Map.class);
+		verify(fcmNotificationService).sendToMember(eq(20L), eq("후기 작성 알림"), any(), dataCaptor.capture());
+		assertThat(dataCaptor.getValue()).containsEntry("type", "REVIEW_REQUESTED");
+		assertThat(dataCaptor.getValue())
+			.containsEntry("targetUrl", "/mypage/review/write?auctionId=1&displayProductId=21");
+	}
+
+	@Test
+	@DisplayName("경매 발송 알림은 채팅방으로 이동하는 대상 URL을 포함한다")
+	void notifyAuctionShippedCreatesChatTarget() {
+		Auction auction = auction(10L);
+		when(fcmNotificationService.sendToMember(eq(20L), any(), any(), any())).thenReturn(0);
+
+		auctionNotificationService.notifyAuctionShipped(auction, 20L, 30L);
+
+		ArgumentCaptor<NotificationCreateRequest> notificationCaptor =
+			ArgumentCaptor.forClass(NotificationCreateRequest.class);
+		verify(notificationCenterService).create(eq(20L), notificationCaptor.capture());
+		assertThat(notificationCaptor.getValue().targetType()).isEqualTo("CHAT");
+		assertThat(notificationCaptor.getValue().targetId()).isEqualTo(30L);
+		assertThat(notificationCaptor.getValue().targetUrl()).isEqualTo("/chats/30");
+
+		@SuppressWarnings("unchecked")
+		ArgumentCaptor<Map<String, String>> dataCaptor = ArgumentCaptor.forClass(Map.class);
+		verify(fcmNotificationService).sendToMember(eq(20L), eq("상품이 발송되었습니다."), any(), dataCaptor.capture());
+		assertThat(dataCaptor.getValue()).containsEntry("type", "AUCTION_SHIPPED");
+		assertThat(dataCaptor.getValue()).containsEntry("targetUrl", "/chats/30");
+		assertThat(dataCaptor.getValue()).containsEntry("roomId", "30");
 	}
 
 	private Auction auction(Long sellerId) {
@@ -76,6 +123,7 @@ class AuctionNotificationServiceTest {
 			null,
 			ProductStatus.ON_SALE
 		);
+		ReflectionTestUtils.setField(product, "productId", 21L);
 		Auction auction = Auction.create(
 			product,
 			new BigDecimal("100000"),

--- a/src/test/java/com/dealit/dealit/domain/auction/AuctionRefundServiceTest.java
+++ b/src/test/java/com/dealit/dealit/domain/auction/AuctionRefundServiceTest.java
@@ -11,6 +11,10 @@ import com.dealit.dealit.domain.auction.entity.Auction;
 import com.dealit.dealit.domain.auction.entity.AuctionPayment;
 import com.dealit.dealit.domain.auction.repository.AuctionPaymentRepository;
 import com.dealit.dealit.domain.auction.service.AuctionRefundService;
+import com.dealit.dealit.domain.auction.service.AuctionNotificationService;
+import com.dealit.dealit.domain.chat.entity.ChatRoom;
+import com.dealit.dealit.domain.chat.entity.ChatType;
+import com.dealit.dealit.domain.chat.repository.ChatRoomRepository;
 import com.dealit.dealit.domain.product.ProductSaleType;
 import com.dealit.dealit.domain.product.ProductStatus;
 import com.dealit.dealit.domain.product.entity.Product;
@@ -23,6 +27,7 @@ import java.time.ZoneOffset;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
 
 class AuctionRefundServiceTest {
 
@@ -30,9 +35,13 @@ class AuctionRefundServiceTest {
 
 	private final AuctionPaymentRepository auctionPaymentRepository = mock(AuctionPaymentRepository.class);
 	private final WalletService walletService = mock(WalletService.class);
+	private final AuctionNotificationService auctionNotificationService = mock(AuctionNotificationService.class);
+	private final ChatRoomRepository chatRoomRepository = mock(ChatRoomRepository.class);
 	private final AuctionRefundService auctionRefundService = new AuctionRefundService(
 		auctionPaymentRepository,
 		walletService,
+		auctionNotificationService,
+		chatRoomRepository,
 		FIXED_CLOCK
 	);
 
@@ -114,8 +123,15 @@ class AuctionRefundServiceTest {
 			OffsetDateTime.now(FIXED_CLOCK).minusDays(8)
 		);
 		payment.markShipped(OffsetDateTime.now(FIXED_CLOCK).minusDays(7).minusSeconds(1));
+		ChatRoom room = ChatRoom.create(sellerId, 20L, payment.getAuction().getProduct().getProductId(), ChatType.AUCTION);
+		ReflectionTestUtils.setField(room, "roomId", 30L);
 		when(auctionPaymentRepository.findByAuctionPaymentIdAndDeletedAtIsNull(paymentId))
 			.thenReturn(Optional.of(payment));
+		when(chatRoomRepository.findBySellerIdAndBuyerIdAndProductIdAndDeletedAtIsNull(
+			sellerId,
+			20L,
+			payment.getAuction().getProduct().getProductId()
+		)).thenReturn(Optional.of(room));
 
 		auctionRefundService.autoConfirmReceived(paymentId);
 
@@ -123,6 +139,8 @@ class AuctionRefundServiceTest {
 		assertThat(payment.getReceivedConfirmedAt()).isEqualTo(OffsetDateTime.now(FIXED_CLOCK));
 		assertThat(payment.getSettledAt()).isEqualTo(OffsetDateTime.now(FIXED_CLOCK));
 		verify(walletService).settleAuctionPayment(sellerId, 101000L, payment.getAuction().getAuctionId());
+		verify(auctionNotificationService).notifyAuctionReceived(payment.getAuction(), payment.getSellerId(), 30L);
+		verify(auctionNotificationService).notifyReviewRequest(payment.getAuction(), payment.getBidderId());
 	}
 
 	private Auction auction(Long sellerId) {
@@ -138,6 +156,7 @@ class AuctionRefundServiceTest {
 			null,
 			ProductStatus.ON_SALE
 		);
+		ReflectionTestUtils.setField(product, "productId", 21L);
 		return Auction.create(
 			product,
 			new BigDecimal("100000"),

--- a/src/test/java/com/dealit/dealit/domain/chat/ChatServiceCreateRoomTest.java
+++ b/src/test/java/com/dealit/dealit/domain/chat/ChatServiceCreateRoomTest.java
@@ -14,6 +14,7 @@ import com.dealit.dealit.domain.auction.AuctionStatus;
 import com.dealit.dealit.domain.auction.entity.Auction;
 import com.dealit.dealit.domain.auction.entity.AuctionPayment;
 import com.dealit.dealit.domain.auction.repository.AuctionPaymentRepository;
+import com.dealit.dealit.domain.auction.service.AuctionNotificationService;
 import com.dealit.dealit.domain.chat.dto.CreateChatRoomRequest;
 import com.dealit.dealit.domain.chat.dto.CreateChatRoomResponse;
 import com.dealit.dealit.domain.chat.entity.ChatRoom;
@@ -54,6 +55,7 @@ class ChatServiceCreateRoomTest {
         PurchaseRepository purchaseRepository = mock(PurchaseRepository.class);
         EventStreamService eventStreamService = mock(EventStreamService.class);
         FcmNotificationService fcmNotificationService = mock(FcmNotificationService.class);
+        AuctionNotificationService auctionNotificationService = mock(AuctionNotificationService.class);
 
         when(chatRoomRepository.findBySellerIdAndBuyerIdAndProductIdAndDeletedAtIsNull(anyLong(), anyLong(), anyLong()))
                 .thenReturn(Optional.empty());
@@ -71,6 +73,7 @@ class ChatServiceCreateRoomTest {
                 purchaseRepository,
                 eventStreamService,
                 fcmNotificationService,
+                auctionNotificationService,
                 Clock.systemUTC()
         );
 
@@ -95,6 +98,7 @@ class ChatServiceCreateRoomTest {
         PurchaseRepository purchaseRepository = mock(PurchaseRepository.class);
         EventStreamService eventStreamService = mock(EventStreamService.class);
         FcmNotificationService fcmNotificationService = mock(FcmNotificationService.class);
+        AuctionNotificationService auctionNotificationService = mock(AuctionNotificationService.class);
 
         ChatRoom existingRoom = ChatRoom.create(10L, 20L, 100L, ChatType.GENERAL);
         when(productOwnershipPort.getOwnerIdByProductId(100L)).thenReturn(10L);
@@ -115,6 +119,7 @@ class ChatServiceCreateRoomTest {
                 purchaseRepository,
                 eventStreamService,
                 fcmNotificationService,
+                auctionNotificationService,
                 Clock.systemUTC()
         );
 
@@ -141,6 +146,7 @@ class ChatServiceCreateRoomTest {
         PurchaseRepository purchaseRepository = mock(PurchaseRepository.class);
         EventStreamService eventStreamService = mock(EventStreamService.class);
         FcmNotificationService fcmNotificationService = mock(FcmNotificationService.class);
+        AuctionNotificationService auctionNotificationService = mock(AuctionNotificationService.class);
 
         ChatRoom room = ChatRoom.create(10L, 20L, 100L, ChatType.AUCTION);
         ProductSummaryPort.ProductSummary product =
@@ -183,6 +189,7 @@ class ChatServiceCreateRoomTest {
                 purchaseRepository,
                 eventStreamService,
                 fcmNotificationService,
+                auctionNotificationService,
                 Clock.fixed(OffsetDateTime.parse("2026-05-10T13:00:00Z").toInstant(), java.time.ZoneOffset.UTC)
         );
 
@@ -208,6 +215,7 @@ class ChatServiceCreateRoomTest {
         PurchaseRepository purchaseRepository = mock(PurchaseRepository.class);
         EventStreamService eventStreamService = mock(EventStreamService.class);
         FcmNotificationService fcmNotificationService = mock(FcmNotificationService.class);
+        AuctionNotificationService auctionNotificationService = mock(AuctionNotificationService.class);
 
         ChatRoom room = ChatRoom.create(10L, 20L, 100L, ChatType.AUCTION);
         ProductSummaryPort.ProductSummary product =
@@ -247,6 +255,7 @@ class ChatServiceCreateRoomTest {
                 purchaseRepository,
                 eventStreamService,
                 fcmNotificationService,
+                auctionNotificationService,
                 Clock.fixed(OffsetDateTime.parse("2026-05-10T13:00:00Z").toInstant(), java.time.ZoneOffset.UTC)
         );
 
@@ -272,6 +281,7 @@ class ChatServiceCreateRoomTest {
         PurchaseRepository purchaseRepository = mock(PurchaseRepository.class);
         EventStreamService eventStreamService = mock(EventStreamService.class);
         FcmNotificationService fcmNotificationService = mock(FcmNotificationService.class);
+        AuctionNotificationService auctionNotificationService = mock(AuctionNotificationService.class);
 
         ChatRoom room = ChatRoom.create(10L, 20L, 100L, ChatType.GENERAL);
         ProductSummaryPort.ProductSummary product =
@@ -311,6 +321,7 @@ class ChatServiceCreateRoomTest {
                 purchaseRepository,
                 eventStreamService,
                 fcmNotificationService,
+                auctionNotificationService,
                 Clock.fixed(OffsetDateTime.parse("2026-05-10T13:00:00Z").toInstant(), java.time.ZoneOffset.UTC)
         );
 
@@ -335,6 +346,7 @@ class ChatServiceCreateRoomTest {
         PurchaseRepository purchaseRepository = mock(PurchaseRepository.class);
         EventStreamService eventStreamService = mock(EventStreamService.class);
         FcmNotificationService fcmNotificationService = mock(FcmNotificationService.class);
+        AuctionNotificationService auctionNotificationService = mock(AuctionNotificationService.class);
 
         ChatRoom room = ChatRoom.create(10L, 20L, 100L, ChatType.AUCTION);
         ProductSummaryPort.ProductSummary product =
@@ -374,6 +386,7 @@ class ChatServiceCreateRoomTest {
                 purchaseRepository,
                 eventStreamService,
                 fcmNotificationService,
+                auctionNotificationService,
                 Clock.fixed(OffsetDateTime.parse("2026-05-10T13:00:00Z").toInstant(), java.time.ZoneOffset.UTC)
         );
 
@@ -400,6 +413,7 @@ class ChatServiceCreateRoomTest {
         PurchaseRepository purchaseRepository = mock(PurchaseRepository.class);
         EventStreamService eventStreamService = mock(EventStreamService.class);
         FcmNotificationService fcmNotificationService = mock(FcmNotificationService.class);
+        AuctionNotificationService auctionNotificationService = mock(AuctionNotificationService.class);
 
         when(productOwnershipPort.getOwnerIdByProductId(404L))
                 .thenThrow(new ProductNotFoundException("유효한 상품을 찾을 수 없습니다. productId=404"));
@@ -416,6 +430,7 @@ class ChatServiceCreateRoomTest {
                 purchaseRepository,
                 eventStreamService,
                 fcmNotificationService,
+                auctionNotificationService,
                 Clock.systemUTC()
         );
 


### PR DESCRIPTION
### 🚀 Summary

<!-- 작업 내용에 대한 간략한 설명을 써주세요. -->
경매 거래 진행 알림을 추가하고, 후기 작성 알림 일부 수정 했습니다.
---

### ✨ Description

<!-- 상세한 설명, 기능의 사용법, 주의 사항 실행 결과(이미지 첨부 가능) 등을 보여주세요. -->
 - 경매 후기 작성 알림 발송 시점 변경 수정
      - 기존 낙찰 성공 직후 발송에서 수령확정 이후 발송으로 변경
      - 자동 수령확정 시에도 후기 작성 알림 발송
      - 알림 클릭 시 후기 작성 페이지로 이동
      
  - 경매 발송 후 수령확정 요청 알림 추가
      - 판매자가 보냈어요 처리 시 낙찰자에게 알림 발송
      - 알림 클릭 시 해당 채팅방으로 이동
     
  - 경매 수령확정 완료 알림 추가
      - 낙찰자가 수령확정 시 판매자에게 알림 발송
      - 자동 수령확정 시에도 판매자에게 알림 발송
      - 알림 클릭 시 해당 채팅방으로 이동
   
  - 테스트
      - 경매 알림, 자동 수령확정, 채팅 서비스 관련 테스트 통과
---

### 🎲 Issue Number

<!-- Please enter {Issue Number} below to automatically close the connected issue. -->

close #82 
