### PR TITLE
[refactor] API Body 추가 alias 생성

### DIFF
--- a/src/main/java/com/dealit/dealit/domain/purchase/controller/MyPagePurchaseController.java
+++ b/src/main/java/com/dealit/dealit/domain/purchase/controller/MyPagePurchaseController.java
@@ -2,6 +2,7 @@ package com.dealit.dealit.domain.purchase.controller;
 
 import com.dealit.dealit.domain.purchase.dto.MyPurchaseListResponse;
 import com.dealit.dealit.domain.purchase.dto.MySaleListResponse;
+import com.dealit.dealit.domain.purchase.dto.PurchaseReceiptResponse;
 import com.dealit.dealit.domain.purchase.entity.PurchaseStatus;
 import com.dealit.dealit.domain.purchase.service.PurchaseService;
 import com.dealit.dealit.global.security.AuthenticatedMember;
@@ -12,11 +13,12 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-@Tag(name = "MyPage Purchase", description = "마이페이지 구매내역 API")
+@Tag(name = "MyPage Purchase", description = "마이페이지 구매/판매내역 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/mypage")
@@ -34,6 +36,16 @@ public class MyPagePurchaseController {
 		@RequestParam(required = false) List<PurchaseStatus> status
 	) {
 		return purchaseService.getMyPurchases(member.memberId(), page, size, status);
+	}
+
+	@Operation(summary = "마이페이지 일반 상품 거래 영수증 조회", description = "구매자 또는 판매자가 purchaseId 기준으로 일반 상품 거래 영수증을 조회합니다.")
+	@ApiResponse(responseCode = "200", description = "영수증 조회 성공")
+	@GetMapping("/purchases/{purchaseId}/receipt")
+	public PurchaseReceiptResponse getPurchaseReceipt(
+		@AuthenticationPrincipal AuthenticatedMember member,
+		@PathVariable Long purchaseId
+	) {
+		return purchaseService.getReceipt(purchaseId, member.memberId());
 	}
 
 	@Operation(summary = "내 판매내역 조회", description = "현재 로그인한 사용자의 판매내역을 페이지 단위로 조회합니다.")

--- a/src/main/java/com/dealit/dealit/domain/purchase/dto/PurchaseReceiptResponse.java
+++ b/src/main/java/com/dealit/dealit/domain/purchase/dto/PurchaseReceiptResponse.java
@@ -1,5 +1,6 @@
 package com.dealit.dealit.domain.purchase.dto;
 
+import com.dealit.dealit.domain.product.ProductSaleType;
 import com.dealit.dealit.domain.purchase.entity.PurchaseStatus;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.OffsetDateTime;
@@ -27,13 +28,37 @@ public record PurchaseReceiptResponse(
 	@Schema(description = "결제 금액", example = "30000")
 	long amount,
 
-	@Schema(description = "구매 상태", example = "PAID", allowableValues = {"PAID", "COMPLETED"})
+	@Schema(description = "구매 상태", example = "PAID", allowableValues = {"PAID", "SHIPPED", "COMPLETED", "CANCELED"})
 	PurchaseStatus status,
 
 	@Schema(description = "구매 일시", example = "2026-05-06T21:30:00+09:00")
 	OffsetDateTime purchasedAt,
 
 	@Schema(description = "연결된 채팅방 ID. 현재는 null일 수 있습니다.", example = "15", nullable = true)
-	Long chatRoomId
+	Long chatRoomId,
+
+	@Schema(description = "상품 거래 유형", example = "REGULAR", allowableValues = {"REGULAR"})
+	ProductSaleType productType,
+
+	@Schema(description = "결제 완료 일시. 별도 값이 없으면 구매 일시와 같습니다.", example = "2026-05-06T21:30:00+09:00", nullable = true)
+	OffsetDateTime paidAt,
+
+	@Schema(description = "판매자 발송 완료 일시", example = "2026-05-06T22:05:00+09:00", nullable = true)
+	OffsetDateTime shippedAt,
+
+	@Schema(description = "거래 완료 일시", example = "2026-05-06T22:10:00+09:00", nullable = true)
+	OffsetDateTime completedAt,
+
+	@Schema(description = "거래 취소 일시", example = "2026-05-09T22:05:00+09:00", nullable = true)
+	OffsetDateTime canceledAt,
+
+	@Schema(description = "판매자 발송 완료 여부", example = "true")
+	boolean sellerShipped,
+
+	@Schema(description = "구매자 수령 확인 여부", example = "false")
+	boolean buyerConfirmed,
+
+	@Schema(description = "거래 상대 닉네임. 구매자에게는 판매자, 판매자에게는 구매자 닉네임을 반환합니다.", example = "Dealit#3", nullable = true)
+	String counterpartNickname
 ) {
 }

--- a/src/main/java/com/dealit/dealit/domain/purchase/service/PurchaseService.java
+++ b/src/main/java/com/dealit/dealit/domain/purchase/service/PurchaseService.java
@@ -165,7 +165,15 @@ public class PurchaseService {
 			toWalletAmount(purchase.getPriceSnapshot()),
 			purchase.getStatus(),
 			toSeoulOffsetDateTime(purchase.getPurchasedAt()),
-			purchase.getChatRoomId()
+			purchase.getChatRoomId(),
+			product.getSaleType(),
+			toSeoulOffsetDateTime(purchase.getPurchasedAt()),
+			toSeoulOffsetDateTime(purchase.getShippedAt()),
+			toSeoulOffsetDateTime(purchase.getCompletedAt()),
+			toSeoulOffsetDateTime(purchase.getCanceledAt()),
+			purchase.getShippedAt() != null,
+			purchase.getBuyerCompletedAt() != null,
+			resolveCounterpartNickname(purchase, memberId)
 		);
 	}
 
@@ -516,6 +524,16 @@ public class PurchaseService {
 		return productRepository.findByProductIdAndDeletedAtIsNull(purchase.getProductId())
 			.map(Product::getName)
 			.orElse("구매한");
+	}
+
+	private String resolveCounterpartNickname(Purchase purchase, Long memberId) {
+		Long counterpartId = purchase.getBuyerId().equals(memberId)
+			? purchase.getSellerId()
+			: purchase.getBuyerId();
+
+		return memberRepository.findByMemberIdAndDeletedAtIsNull(counterpartId)
+			.map(Member::getNickname)
+			.orElse(null);
 	}
 
 	private PurchaseCompletionResponse toCompletionResponse(Purchase purchase) {

--- a/src/test/java/com/dealit/dealit/domain/purchase/PurchaseIntegrationTest.java
+++ b/src/test/java/com/dealit/dealit/domain/purchase/PurchaseIntegrationTest.java
@@ -336,7 +336,15 @@ class PurchaseIntegrationTest {
 			.andExpect(jsonPath("$.amount").value(30000))
 			.andExpect(jsonPath("$.status").value("PAID"))
 			.andExpect(jsonPath("$.purchasedAt").exists())
-			.andExpect(jsonPath("$.chatRoomId").isNumber());
+			.andExpect(jsonPath("$.chatRoomId").isNumber())
+			.andExpect(jsonPath("$.productType").value("REGULAR"))
+			.andExpect(jsonPath("$.paidAt").exists())
+			.andExpect(jsonPath("$.shippedAt").doesNotExist())
+			.andExpect(jsonPath("$.completedAt").doesNotExist())
+			.andExpect(jsonPath("$.canceledAt").doesNotExist())
+			.andExpect(jsonPath("$.sellerShipped").value(false))
+			.andExpect(jsonPath("$.buyerConfirmed").value(false))
+			.andExpect(jsonPath("$.counterpartNickname").value(seller.getNickname()));
 	}
 
 	@Test
@@ -349,7 +357,23 @@ class PurchaseIntegrationTest {
 		mockMvc.perform(get("/api/v1/purchases/{purchaseId}", purchaseId)
 				.with(authentication(authenticatedMember(seller))))
 			.andExpect(status().isOk())
-			.andExpect(jsonPath("$.purchaseId").value(purchaseId));
+			.andExpect(jsonPath("$.purchaseId").value(purchaseId))
+			.andExpect(jsonPath("$.counterpartNickname").value(buyer.getNickname()));
+	}
+
+	@Test
+	@DisplayName("留덉씠?섏씠吏 alias濡??곸닔利앹쓣 議고쉶?????덈떎")
+	void buyerCanGetReceiptThroughMyPageAlias() throws Exception {
+		Product product = saveProduct(seller, ProductStatus.ON_SALE, BigDecimal.valueOf(30000));
+		walletService.charge(buyer.getMemberId(), 50000);
+		Long purchaseId = purchaseProduct(product, buyer);
+
+		mockMvc.perform(get("/api/v1/mypage/purchases/{purchaseId}/receipt", purchaseId)
+				.with(authentication(authenticatedMember(buyer))))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.purchaseId").value(purchaseId))
+			.andExpect(jsonPath("$.productType").value("REGULAR"))
+			.andExpect(jsonPath("$.counterpartNickname").value(seller.getNickname()));
 	}
 
 	@Test
@@ -415,6 +439,15 @@ class PurchaseIntegrationTest {
 
 		assertThat(notificationRepository.countByMemberMemberIdAndReadAtIsNullAndDeletedAtIsNull(buyer.getMemberId()))
 			.isEqualTo(4);
+
+		mockMvc.perform(get("/api/v1/purchases/{purchaseId}", purchaseId)
+				.with(authentication(authenticatedMember(buyer))))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.status").value("SHIPPED"))
+			.andExpect(jsonPath("$.shippedAt").exists())
+			.andExpect(jsonPath("$.completedAt").doesNotExist())
+			.andExpect(jsonPath("$.sellerShipped").value(true))
+			.andExpect(jsonPath("$.buyerConfirmed").value(false));
 	}
 
 	@Test
@@ -451,6 +484,15 @@ class PurchaseIntegrationTest {
 			.isEqualTo(3);
 		assertThat(notificationRepository.countByMemberMemberIdAndReadAtIsNullAndDeletedAtIsNull(buyer.getMemberId()))
 			.isEqualTo(4);
+
+		mockMvc.perform(get("/api/v1/purchases/{purchaseId}", purchaseId)
+				.with(authentication(authenticatedMember(seller))))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.status").value("COMPLETED"))
+			.andExpect(jsonPath("$.shippedAt").exists())
+			.andExpect(jsonPath("$.completedAt").exists())
+			.andExpect(jsonPath("$.sellerShipped").value(true))
+			.andExpect(jsonPath("$.buyerConfirmed").value(true));
 	}
 
 	@Test


### PR DESCRIPTION
### 🚀 Summary

일반 상품 구매/판매 내역의 자세히 보기 페이지에서 사용할 거래 영수증 API 응답을 확장했습니다.

---

### ✨ Description

- 기존 `GET /api/v1/purchases/{purchaseId}` 영수증 응답에 화면 구성용 필드를 추가했습니다.
  - `productType`
  - `paidAt`
  - `shippedAt`
  - `completedAt`
  - `canceledAt`
  - `sellerShipped`
  - `buyerConfirmed`
  - `counterpartNickname`

- 마이페이지 전용 alias API를 추가했습니다.
  - `GET /api/v1/mypage/purchases/{purchaseId}/receipt`

- 내부 로직은 기존 `purchaseService.getReceipt()`를 재사용합니다.
- 기존 필드명, 타입, 권한 정책은 변경하지 않았습니다.
- 구매자/판매자만 조회 가능하며, 제3자는 기존처럼 `403`을 반환합니다.
- 일반 상품 거래만 1차 범위로 처리했으며, 경매 거래는 추후 `AuctionPayment` 기반 별도 API로 확장 예정입니다.

검증:
- `PurchaseIntegrationTest` 통과
- 구매자 조회, 판매자 조회, 제3자 접근 차단, `PAID/SHIPPED/COMPLETED` 상태별 영수증 필드 검증 추가

---

### 🎲 Issue Number

close #{Issue Number}