### PR TITLE
[refactor] 경매 낙찰 시 purchase 연동 및 리팩토링

### DIFF
--- a/src/main/java/com/dealit/dealit/domain/auction/entity/AuctionPayment.java
+++ b/src/main/java/com/dealit/dealit/domain/auction/entity/AuctionPayment.java
@@ -35,6 +35,9 @@ public class AuctionPayment extends BaseEntity {
 	@Column(name = "auction_payment_id")
 	private Long auctionPaymentId;
 
+	@Column(name = "purchase_id")
+	private Long purchaseId;
+
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "auction_id", nullable = false)
 	private Auction auction;
@@ -84,6 +87,12 @@ public class AuctionPayment extends BaseEntity {
 
 	public static AuctionPayment reserve(Auction auction, Long bidderId, Long sellerId, Long amount, OffsetDateTime reservedAt) {
 		return new AuctionPayment(auction, bidderId, sellerId, amount, reservedAt);
+	}
+
+	public void linkPurchase(Long purchaseId) {
+		if (this.purchaseId == null) {
+			this.purchaseId = purchaseId;
+		}
 	}
 
 	public boolean requestRefund(OffsetDateTime refundRequestedAt) {

--- a/src/main/java/com/dealit/dealit/domain/auction/repository/AuctionPaymentRepository.java
+++ b/src/main/java/com/dealit/dealit/domain/auction/repository/AuctionPaymentRepository.java
@@ -26,6 +26,9 @@ public interface AuctionPaymentRepository extends JpaRepository<AuctionPayment, 
 	Optional<AuctionPayment> findByAuctionPaymentIdAndDeletedAtIsNull(Long auctionPaymentId);
 
 	@Lock(LockModeType.PESSIMISTIC_WRITE)
+	Optional<AuctionPayment> findByPurchaseIdAndDeletedAtIsNull(Long purchaseId);
+
+	@Lock(LockModeType.PESSIMISTIC_WRITE)
 	Optional<AuctionPayment> findFirstByAuctionAuctionIdAndBidderIdAndSellerIdAndStatusInAndDeletedAtIsNullOrderByReservedAtDescAuctionPaymentIdDesc(
 		Long auctionId,
 		Long bidderId,

--- a/src/main/java/com/dealit/dealit/domain/auction/service/AuctionBidService.java
+++ b/src/main/java/com/dealit/dealit/domain/auction/service/AuctionBidService.java
@@ -33,6 +33,7 @@ import com.dealit.dealit.domain.member.exception.EmailNotVerifiedException;
 import com.dealit.dealit.domain.member.repository.MemberRepository;
 import com.dealit.dealit.domain.product.entity.Product;
 import com.dealit.dealit.domain.product.entity.ProductImage;
+import com.dealit.dealit.domain.purchase.service.PurchaseService;
 import com.dealit.dealit.domain.search.event.AuctionSearchDeleteRequestedEvent;
 import com.dealit.dealit.domain.search.event.AuctionSearchIndexRequestedEvent;
 import com.dealit.dealit.domain.wallet.service.WalletService;
@@ -70,6 +71,7 @@ public class AuctionBidService {
 	private final AuctionNotificationService auctionNotificationService;
 	private final ApplicationEventPublisher applicationEventPublisher;
 	private final ChatRoomRepository chatRoomRepository;
+	private final PurchaseService purchaseService;
 	private final WishlistService wishlistService;
 	private final ImageUrlService imageUrlService;
 	private final Clock clock;
@@ -260,7 +262,13 @@ public class AuctionBidService {
 
 		auction.completeWithWinner(state.highestBidderId(), state.currentPrice());
 		auction.getProduct().markSold();
-		ensureAuctionChatRoom(auction, state.highestBidderId());
+		Long chatRoomId = ensureAuctionChatRoom(auction, state.highestBidderId());
+		AuctionPayment winningPayment = loadWinningPayment(
+			auctionId,
+			state.highestBidderId(),
+			auction.getProduct().getMemberId()
+		);
+		purchaseService.createAuctionPurchase(auction, winningPayment, chatRoomId);
 		auctionRedisService.removeEnding(auctionId);
 		auctionRedisService.deleteState(auctionId);
 		auctionRedisService.removeClosingSoonNotified(auctionId);
@@ -348,14 +356,27 @@ public class AuctionBidService {
 		}
 	}
 
-	private void ensureAuctionChatRoom(Auction auction, Long buyerId) {
+	private AuctionPayment loadWinningPayment(Long auctionId, Long winnerId, Long sellerId) {
+		return auctionPaymentRepository
+			.findFirstByAuctionAuctionIdAndBidderIdAndSellerIdAndStatusInAndDeletedAtIsNullOrderByReservedAtDescAuctionPaymentIdDesc(
+				auctionId,
+				winnerId,
+				sellerId,
+				List.of(AuctionPaymentStatus.RESERVED)
+			)
+			.orElseThrow(() -> new InvalidAuctionRequestException("낙찰자의 예치금을 찾을 수 없습니다."));
+	}
+
+	private Long ensureAuctionChatRoom(Auction auction, Long buyerId) {
 		Long sellerId = auction.getProduct().getMemberId();
 		Long productId = auction.getProduct().getProductId();
-		chatRoomRepository.findBySellerIdAndBuyerIdAndProductIdAndDeletedAtIsNull(sellerId, buyerId, productId)
-			.ifPresentOrElse(
-				ChatRoom::markAuction,
-				() -> chatRoomRepository.save(ChatRoom.create(sellerId, buyerId, productId, ChatType.AUCTION))
-			);
+		return chatRoomRepository.findBySellerIdAndBuyerIdAndProductIdAndDeletedAtIsNull(sellerId, buyerId, productId)
+			.map(chatRoom -> {
+				chatRoom.markAuction();
+				return chatRoom.getRoomId();
+			})
+			.orElseGet(() -> chatRoomRepository.save(ChatRoom.create(sellerId, buyerId, productId, ChatType.AUCTION))
+				.getRoomId());
 	}
 
 	private List<ImageResponse> toImageResponses(Product product) {

--- a/src/main/java/com/dealit/dealit/domain/auction/service/AuctionRefundService.java
+++ b/src/main/java/com/dealit/dealit/domain/auction/service/AuctionRefundService.java
@@ -3,6 +3,7 @@ package com.dealit.dealit.domain.auction.service;
 import com.dealit.dealit.domain.auction.AuctionPaymentStatus;
 import com.dealit.dealit.domain.auction.entity.AuctionPayment;
 import com.dealit.dealit.domain.auction.repository.AuctionPaymentRepository;
+import com.dealit.dealit.domain.purchase.service.PurchaseService;
 import com.dealit.dealit.domain.wallet.service.WalletService;
 import java.time.Clock;
 import java.time.OffsetDateTime;
@@ -22,6 +23,7 @@ public class AuctionRefundService {
 
 	private final AuctionPaymentRepository auctionPaymentRepository;
 	private final WalletService walletService;
+	private final PurchaseService purchaseService;
 	private final Clock clock;
 
 	@Transactional
@@ -82,7 +84,9 @@ public class AuctionRefundService {
 		if (payment == null || payment.getStatus() != AuctionPaymentStatus.RESERVED) {
 			return;
 		}
-		payment.requestRefund(OffsetDateTime.now(clock));
+		if (payment.requestRefund(OffsetDateTime.now(clock))) {
+			purchaseService.syncAuctionPurchaseCanceled(payment.getPurchaseId());
+		}
 	}
 
 	@Transactional
@@ -98,6 +102,7 @@ public class AuctionRefundService {
 				payment.getAmount(),
 				payment.getAuction().getAuctionId()
 			);
+			purchaseService.syncAuctionPurchaseCompleted(payment.getPurchaseId());
 		}
 	}
 }

--- a/src/main/java/com/dealit/dealit/domain/chat/service/ChatService.java
+++ b/src/main/java/com/dealit/dealit/domain/chat/service/ChatService.java
@@ -176,6 +176,7 @@ public class ChatService {
         if (!payment.markShipped(now)) {
             throw new IllegalArgumentException("현재 상태에서는 발송 처리를 할 수 없습니다.");
         }
+        syncAuctionPurchaseShipped(payment.getPurchaseId());
 
         publishRoomAndUnreadUpdates(room, room.getSellerId(), room.getBuyerId(), LocalDateTime.now(clock));
         return buildCreateRoomResponse(room, currentUserId, room.getSellerId(), room.getBuyerId(), room.getCreatedAt());
@@ -209,6 +210,7 @@ public class ChatService {
                 payment.getAmount(),
                 payment.getAuction().getAuctionId()
         );
+        syncAuctionPurchaseCompleted(payment.getPurchaseId());
 
         publishRoomAndUnreadUpdates(room, room.getSellerId(), room.getBuyerId(), LocalDateTime.now(clock));
         return buildCreateRoomResponse(room, currentUserId, room.getSellerId(), room.getBuyerId(), room.getCreatedAt());
@@ -724,6 +726,39 @@ public class ChatService {
     private boolean isAuctionTradeReady(AuctionPayment payment) {
         return payment.getAuction().getStatus() == AuctionStatus.SUCCESSFUL_BID
                 && payment.getBidderId().equals(payment.getAuction().getWinnerId());
+    }
+
+    private void syncAuctionPurchaseShipped(Long purchaseId) {
+        if (purchaseId == null) {
+            return;
+        }
+        Purchase purchase = purchaseRepository.findById(purchaseId).orElse(null);
+        if (purchase == null || purchase.getStatus() != PurchaseStatus.PAID) {
+            return;
+        }
+        try {
+            purchase.markShipped();
+        } catch (IllegalStateException ignored) {
+        }
+    }
+
+    private void syncAuctionPurchaseCompleted(Long purchaseId) {
+        if (purchaseId == null) {
+            return;
+        }
+        Purchase purchase = purchaseRepository.findById(purchaseId).orElse(null);
+        if (purchase == null || purchase.getStatus() == PurchaseStatus.CANCELED) {
+            return;
+        }
+        try {
+            if (purchase.getStatus() == PurchaseStatus.PAID) {
+                purchase.markShipped();
+            }
+            purchase.markBuyerCompleted();
+            purchase.complete();
+            purchase.settle();
+        } catch (IllegalStateException ignored) {
+        }
     }
 
     private CreateChatRoomResponse.ActionButtons inactiveActionButtons(

--- a/src/main/java/com/dealit/dealit/domain/purchase/service/PurchaseService.java
+++ b/src/main/java/com/dealit/dealit/domain/purchase/service/PurchaseService.java
@@ -1,6 +1,10 @@
 package com.dealit.dealit.domain.purchase.service;
 
 import com.dealit.dealit.domain.auth.exception.InvalidCredentialsException;
+import com.dealit.dealit.domain.auction.AuctionPaymentStatus;
+import com.dealit.dealit.domain.auction.entity.Auction;
+import com.dealit.dealit.domain.auction.entity.AuctionPayment;
+import com.dealit.dealit.domain.auction.repository.AuctionPaymentRepository;
 import com.dealit.dealit.domain.chat.entity.ChatRoom;
 import com.dealit.dealit.domain.chat.entity.ChatType;
 import com.dealit.dealit.domain.chat.repository.ChatRoomRepository;
@@ -43,6 +47,7 @@ import java.time.ZoneId;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -62,6 +67,7 @@ public class PurchaseService {
 	private static final ZoneId SEOUL_ZONE = ZoneId.of("Asia/Seoul");
 
 	private final PurchaseRepository purchaseRepository;
+	private final AuctionPaymentRepository auctionPaymentRepository;
 	private final ProductRepository productRepository;
 	private final MemberRepository memberRepository;
 	private final WalletService walletService;
@@ -122,6 +128,35 @@ public class PurchaseService {
 			notifyPurchasePaid(purchase, product);
 			return toPurchaseResponse(purchase);
 		}
+
+	@Transactional
+	public Purchase createAuctionPurchase(Auction auction, AuctionPayment winningPayment, Long chatRoomId) {
+		if (auction == null || winningPayment == null) {
+			throw new IllegalArgumentException("낙찰 경매와 결제 정보는 필수입니다.");
+		}
+
+		Product product = auction.getProduct();
+		String idempotencyKey = "auction-" + auction.getAuctionId();
+		Purchase purchase = purchaseRepository.findByBuyerIdAndIdempotencyKey(
+				winningPayment.getBidderId(),
+				idempotencyKey
+			)
+			.orElseGet(() -> purchaseRepository.save(Purchase.paid(
+				product.getProductId(),
+				winningPayment.getBidderId(),
+				winningPayment.getSellerId(),
+				BigDecimal.valueOf(winningPayment.getAmount()),
+				idempotencyKey
+			)));
+
+		if (chatRoomId != null) {
+			purchase.linkChatRoom(chatRoomId);
+		} else {
+			linkPurchaseChatRoomIfNeeded(purchase);
+		}
+		winningPayment.linkPurchase(purchase.getPurchaseId());
+		return purchase;
+	}
 
 	private void linkPurchaseChatRoomIfNeeded(Purchase purchase) {
 		if (purchase.getChatRoomId() != null) {
@@ -261,6 +296,7 @@ public class PurchaseService {
 		} catch (IllegalStateException exception) {
 			throw new PurchaseNotCompletableException(exception.getMessage());
 		}
+		markLinkedAuctionPaymentShipped(purchase);
 		notifyPurchaseShipped(purchase);
 		return toCompletionResponse(purchase);
 	}
@@ -401,6 +437,14 @@ public class PurchaseService {
 		} catch (IllegalStateException exception) {
 			return 0;
 		}
+		Optional<AuctionPayment> linkedAuctionPayment = findLinkedAuctionPayment(purchase);
+		if (linkedAuctionPayment.isPresent()) {
+			AuctionPayment payment = linkedAuctionPayment.get();
+			if (payment.getStatus() == AuctionPaymentStatus.RESERVED) {
+				payment.requestRefund(toSeoulOffsetDateTime(LocalDateTime.now()));
+			}
+			return 1;
+		}
 		productPaymentService.findByPurchaseId(purchase.getPurchaseId())
 			.ifPresentOrElse(
 				payment -> productPaymentService.refund(payment, "판매자 3일 내 미발송 자동 취소"),
@@ -413,6 +457,23 @@ public class PurchaseService {
 		if (purchase.isSettled()) {
 			return;
 		}
+		Optional<AuctionPayment> linkedAuctionPayment = findLinkedAuctionPayment(purchase);
+		if (linkedAuctionPayment.isPresent()) {
+			AuctionPayment payment = linkedAuctionPayment.get();
+			if (payment.getStatus() == AuctionPaymentStatus.SETTLED) {
+				purchase.settle();
+				return;
+			}
+			if (payment.confirmReceived(toSeoulOffsetDateTime(LocalDateTime.now()))) {
+				walletService.settleAuctionPayment(
+					payment.getSellerId(),
+					payment.getAmount(),
+					payment.getAuction().getAuctionId()
+				);
+				purchase.settle();
+			}
+			return;
+		}
 		productPaymentService.findByPurchaseId(purchase.getPurchaseId())
 			.ifPresentOrElse(
 				payment -> productPaymentService.settle(payment, settlementReason),
@@ -423,6 +484,66 @@ public class PurchaseService {
 				)
 			);
 		purchase.settle();
+	}
+
+	@Transactional
+	public void syncAuctionPurchaseShipped(Long purchaseId) {
+		if (purchaseId == null) {
+			return;
+		}
+		Purchase purchase = purchaseRepository.findById(purchaseId).orElse(null);
+		if (purchase == null || purchase.getStatus() != PurchaseStatus.PAID) {
+			return;
+		}
+		try {
+			purchase.markShipped();
+		} catch (IllegalStateException ignored) {
+		}
+	}
+
+	@Transactional
+	public void syncAuctionPurchaseCompleted(Long purchaseId) {
+		if (purchaseId == null) {
+			return;
+		}
+		Purchase purchase = purchaseRepository.findById(purchaseId).orElse(null);
+		if (purchase == null || purchase.getStatus() == PurchaseStatus.CANCELED) {
+			return;
+		}
+		try {
+			if (purchase.getStatus() == PurchaseStatus.PAID) {
+				purchase.markShipped();
+			}
+			purchase.markBuyerCompleted();
+			purchase.complete();
+			purchase.settle();
+		} catch (IllegalStateException ignored) {
+		}
+	}
+
+	@Transactional
+	public void syncAuctionPurchaseCanceled(Long purchaseId) {
+		if (purchaseId == null) {
+			return;
+		}
+		Purchase purchase = purchaseRepository.findById(purchaseId).orElse(null);
+		if (purchase == null || purchase.getStatus() != PurchaseStatus.PAID) {
+			return;
+		}
+		try {
+			purchase.cancel();
+		} catch (IllegalStateException ignored) {
+		}
+	}
+
+	private void markLinkedAuctionPaymentShipped(Purchase purchase) {
+		findLinkedAuctionPayment(purchase)
+			.filter(payment -> payment.getStatus() == AuctionPaymentStatus.RESERVED)
+			.ifPresent(payment -> payment.markShipped(toSeoulOffsetDateTime(LocalDateTime.now())));
+	}
+
+	private Optional<AuctionPayment> findLinkedAuctionPayment(Purchase purchase) {
+		return auctionPaymentRepository.findByPurchaseIdAndDeletedAtIsNull(purchase.getPurchaseId());
 	}
 
 	private void markProductEnded(Purchase purchase) {

--- a/src/test/java/com/dealit/dealit/domain/auction/AuctionBidServiceTest.java
+++ b/src/test/java/com/dealit/dealit/domain/auction/AuctionBidServiceTest.java
@@ -6,6 +6,7 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -35,6 +36,7 @@ import com.dealit.dealit.domain.member.repository.MemberRepository;
 import com.dealit.dealit.domain.product.ProductSaleType;
 import com.dealit.dealit.domain.product.ProductStatus;
 import com.dealit.dealit.domain.product.entity.Product;
+import com.dealit.dealit.domain.purchase.service.PurchaseService;
 import com.dealit.dealit.domain.wallet.service.WalletService;
 import com.dealit.dealit.domain.wishlist.service.WishlistService;
 import com.dealit.dealit.global.service.ImageUrlService;
@@ -74,6 +76,7 @@ class AuctionBidServiceTest {
 	private final AuctionNotificationService auctionNotificationService = mock(AuctionNotificationService.class);
 	private final ApplicationEventPublisher applicationEventPublisher = mock(ApplicationEventPublisher.class);
 	private final ChatRoomRepository chatRoomRepository = mock(ChatRoomRepository.class);
+	private final PurchaseService purchaseService = mock(PurchaseService.class);
 	private final WishlistService wishlistService = mock(WishlistService.class);
 	private final ImageUrlService imageUrlService = mock(ImageUrlService.class);
 
@@ -89,6 +92,7 @@ class AuctionBidServiceTest {
 		auctionNotificationService,
 		applicationEventPublisher,
 		chatRoomRepository,
+		purchaseService,
 		wishlistService,
 		imageUrlService,
 		FIXED_CLOCK
@@ -142,10 +146,30 @@ class AuctionBidServiceTest {
 		Long winnerId = 20L;
 		BigDecimal finalPrice = new BigDecimal("150000");
 		Auction auction = auction(sellerId);
+		AuctionPayment winningPayment = AuctionPayment.reserve(
+			auction,
+			winnerId,
+			sellerId,
+			150000L,
+			OffsetDateTime.now(FIXED_CLOCK)
+		);
 		when(auctionRepository.findByAuctionIdAndDeletedAtIsNullAndProductDeletedAtIsNull(auctionId))
 			.thenReturn(Optional.of(auction));
 		when(auctionRedisService.getState(auctionId))
 			.thenReturn(new AuctionState(finalPrice, new BigDecimal("1000"), winnerId));
+		when(chatRoomRepository.findBySellerIdAndBuyerIdAndProductIdAndDeletedAtIsNull(
+			eq(sellerId),
+			eq(winnerId),
+			any()
+		)).thenReturn(Optional.empty());
+		when(chatRoomRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+		when(auctionPaymentRepository
+			.findFirstByAuctionAuctionIdAndBidderIdAndSellerIdAndStatusInAndDeletedAtIsNullOrderByReservedAtDescAuctionPaymentIdDesc(
+				auctionId,
+				winnerId,
+				sellerId,
+				List.of(AuctionPaymentStatus.RESERVED)
+			)).thenReturn(Optional.of(winningPayment));
 		when(bidRepository.findDistinctBidderIdsByAuctionIdAndBidderIdNot(auctionId, winnerId))
 			.thenReturn(Collections.emptyList());
 
@@ -156,6 +180,7 @@ class AuctionBidServiceTest {
 		assertThat(auction.getWinnerId()).isEqualTo(winnerId);
 		assertThat(auction.getFinalPrice()).isEqualByComparingTo(finalPrice);
 		assertThat(auction.getCurrentPrice()).isEqualByComparingTo(finalPrice);
+		verify(purchaseService).createAuctionPurchase(auction, winningPayment, null);
 		verify(auctionRedisService).removeEnding(auctionId);
 		verify(auctionRedisService).deleteState(auctionId);
 		verify(auctionNotificationService).notifyAuctionEnded(
@@ -336,9 +361,9 @@ class AuctionBidServiceTest {
 		assertThat(previousPayment.getRefundRequestedAt()).isEqualTo(OffsetDateTime.now(FIXED_CLOCK));
 		verify(walletService, never()).refundAuctionPayment(anyLong(), anyLong(), anyLong());
 		ArgumentCaptor<Object> eventCaptor = ArgumentCaptor.forClass(Object.class);
-		verify(applicationEventPublisher).publishEvent(eventCaptor.capture());
-		assertThat(eventCaptor.getValue())
-			.isInstanceOf(com.dealit.dealit.domain.auction.event.AuctionRefundRequestedEvent.class);
+		verify(applicationEventPublisher, atLeastOnce()).publishEvent(eventCaptor.capture());
+		assertThat(eventCaptor.getAllValues())
+			.anyMatch(com.dealit.dealit.domain.auction.event.AuctionRefundRequestedEvent.class::isInstance);
 	}
 
 	@Test

--- a/src/test/java/com/dealit/dealit/domain/auction/AuctionRefundServiceTest.java
+++ b/src/test/java/com/dealit/dealit/domain/auction/AuctionRefundServiceTest.java
@@ -14,6 +14,7 @@ import com.dealit.dealit.domain.auction.service.AuctionRefundService;
 import com.dealit.dealit.domain.product.ProductSaleType;
 import com.dealit.dealit.domain.product.ProductStatus;
 import com.dealit.dealit.domain.product.entity.Product;
+import com.dealit.dealit.domain.purchase.service.PurchaseService;
 import com.dealit.dealit.domain.wallet.service.WalletService;
 import java.math.BigDecimal;
 import java.time.Clock;
@@ -30,9 +31,11 @@ class AuctionRefundServiceTest {
 
 	private final AuctionPaymentRepository auctionPaymentRepository = mock(AuctionPaymentRepository.class);
 	private final WalletService walletService = mock(WalletService.class);
+	private final PurchaseService purchaseService = mock(PurchaseService.class);
 	private final AuctionRefundService auctionRefundService = new AuctionRefundService(
 		auctionPaymentRepository,
 		walletService,
+		purchaseService,
 		FIXED_CLOCK
 	);
 


### PR DESCRIPTION
### 🚀 Summary

<!-- 작업 내용에 대한 간략한 설명을 써주세요. -->
- 낙찰후 purchase연동, 기존 경매로직은 그대로 유지
---

### ✨ Description

<!-- 상세한 설명, 기능의 사용법, 주의 사항 실행 결과(이미지 첨부 가능) 등을 보여주세요. -->
## 작업 내용

- 경매 낙찰 성공 시 낙찰자 기준으로 `Purchase`를 생성하도록 연동했습니다.
- 최종 낙찰자의 `AuctionPayment`에 생성된 `purchaseId`를 연결했습니다.
- 기존 경매 입찰/예치/이전 입찰자 환불 로직은 유지했습니다.
- 경매 채팅방의 “보냈어요”, “받았어요” 처리 시 기존 `AuctionPayment` 상태와 함께 연결된 `Purchase` 상태도 동기화되도록 했습니다.
- 경매 자동 미발송 환불, 자동 수령확정 시에도 연결된 `Purchase` 상태가 함께 갱신되도록 했습니다.

## 변경 방향

기존에는 경매 낙찰 이후 거래 상태를 `AuctionPayment`에서 별도로 관리했습니다.  
이번 변경에서는 입찰/예치/환불 등 경매 고유 로직은 유지하되, 낙찰 이후 거래를 `Purchase`와 연결해 구매내역/판매내역에서 활용할 수 있는 기반을 추가했습니다.

---

### 🎲 Issue Number

<!-- Please enter {Issue Number} below to automatically close the connected issue. -->

close #94 
