### PR TITLE
[feat] 최근 본 상품 기능 구현

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -25,6 +25,8 @@ tags:
   description: 위치 보조 API
 - name: Wallet
   description: 딜릿머니 API
+- name: MyPage Purchase
+  description: 마이페이지 구매/판매내역 API
 - name: Auction
   description: 경매 상품 관리 API
 - name: Profile
@@ -43,12 +45,12 @@ tags:
   description: 이메일 인증 API
 - name: Auction
   description: 경매 상품 등록 API
-- name: MyPage Purchase
-  description: 마이페이지 구매내역 API
 - name: Member
   description: 회원 API
 - name: Chats
   description: 채팅 API
+- name: Recent Products
+  description: 최근 본 상품 API
 - name: Notification
   description: 알림 API
 - name: Purchase
@@ -1548,6 +1550,57 @@ paths:
             '*/*':
               schema:
                 $ref: "#/components/schemas/LoginResponse"
+  /api/v1/auctions/{auctionId}/reauction:
+    post:
+      tags:
+      - Auction
+      summary: 재경매 등록
+      description: 유찰된 본인 경매를 바탕으로 새 경매를 등록한다.
+      operationId: reauction
+      parameters:
+      - name: auctionId
+        in: path
+        required: true
+        schema:
+          type: integer
+          format: int64
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateAuctionRequest"
+        required: true
+      responses:
+        "400":
+          description: Bad Request
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: Not Found
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "409":
+          description: Conflict
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "201":
+          description: Created
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ReauctionResponse"
   /api/v1/auctions/{auctionId}/bids:
     get:
       tags:
@@ -2476,6 +2529,51 @@ paths:
             '*/*':
               schema:
                 $ref: "#/components/schemas/AuctionEditDetailResponse"
+  /api/v1/auctions/{auctionId}/reauction/decline:
+    patch:
+      tags:
+      - Auction
+      summary: 재경매 거절
+      description: 유찰된 경매의 재등록 대기를 종료한다.
+      operationId: declineReauction
+      parameters:
+      - name: auctionId
+        in: path
+        required: true
+        schema:
+          type: integer
+          format: int64
+      responses:
+        "400":
+          description: Bad Request
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: Not Found
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "409":
+          description: Conflict
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "200":
+          description: OK
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/DeclineReauctionResponse"
   /api/v1/wallet:
     get:
       tags:
@@ -2730,6 +2828,52 @@ paths:
             '*/*':
               schema:
                 $ref: "#/components/schemas/ReviewListResponse"
+  /api/v1/users/me/recent-products:
+    get:
+      tags:
+      - Recent Products
+      summary: Recent Products
+      description: 로그인 사용자의 최근 본 일반상품과 경매상품을 최신 조회순으로 함께 조회합니다.
+      operationId: getRecentProducts
+      parameters:
+      - name: size
+        in: query
+        required: false
+        schema:
+          type: integer
+          format: int32
+          default: 20
+      responses:
+        "400":
+          description: Bad Request
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: Not Found
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "409":
+          description: Conflict
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "200":
+          description: 최근 본 상품 조회 성공
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/RecentProductListResponse"
   /api/v1/users/me/mypage:
     get:
       tags:
@@ -2773,8 +2917,8 @@ paths:
       tags:
       - Search
       summary: Text Search
-      description: "keyword, categoryId 조건으로 판매 중인 일반 상품과 진행 중인 경매를 OpenSearch에서 조\
-        회합니다."
+      description: "keyword, type, categoryId 조건으로 판매 중인 일반 상품과 진행 중인 경매를 OpenSearch에\
+        서 조회합니다. type이 없으면 전체 검색입니다."
       operationId: search
       parameters:
       - name: keyword
@@ -2782,6 +2926,15 @@ paths:
         required: false
         schema:
           type: string
+      - name: type
+        in: query
+        required: false
+        schema:
+          type: string
+          description: 통합 검색 결과 유형
+          enum:
+          - REGULAR
+          - AUCTION
       - name: categoryId
         in: query
         required: false
@@ -2838,9 +2991,18 @@ paths:
       tags:
       - Search
       summary: Popular Search Keywords
-      description: 사용자가 검색한 keyword 횟수를 기준으로 인기 검색어를 조회합니다.
+      description: 사용자가 검색한 keyword 횟수를 기준으로 인기 검색어를 조회합니다. type이 없으면 전체 인기검색어입니다.
       operationId: popularKeywords
       parameters:
+      - name: type
+        in: query
+        required: false
+        schema:
+          type: string
+          description: 통합 검색 결과 유형
+          enum:
+          - REGULAR
+          - AUCTION
       - name: size
         in: query
         required: false
@@ -3557,6 +3719,51 @@ paths:
             '*/*':
               schema:
                 $ref: "#/components/schemas/MyPurchaseListResponse"
+  /api/v1/mypage/purchases/{purchaseId}/receipt:
+    get:
+      tags:
+      - MyPage Purchase
+      summary: 마이페이지 일반 상품 거래 영수증 조회
+      description: 구매자 또는 판매자가 purchaseId 기준으로 일반 상품 거래 영수증을 조회합니다.
+      operationId: getPurchaseReceipt
+      parameters:
+      - name: purchaseId
+        in: path
+        required: true
+        schema:
+          type: integer
+          format: int64
+      responses:
+        "400":
+          description: Bad Request
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: Not Found
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "409":
+          description: Conflict
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "200":
+          description: 영수증 조회 성공
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/PurchaseReceiptResponse"
   /api/v1/mypage/products/selling:
     get:
       tags:
@@ -4131,6 +4338,51 @@ paths:
             '*/*':
               schema:
                 $ref: "#/components/schemas/CurrentMemberResponse"
+  /api/v1/auctions/{auctionId}/reauction-preview:
+    get:
+      tags:
+      - Auction
+      summary: 재경매 미리보기
+      description: 유찰된 본인 경매를 재등록하기 위한 기존 상품 정보를 조회한다.
+      operationId: getReauctionPreview
+      parameters:
+      - name: auctionId
+        in: path
+        required: true
+        schema:
+          type: integer
+          format: int64
+      responses:
+        "400":
+          description: Bad Request
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: Not Found
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "409":
+          description: Conflict
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "200":
+          description: OK
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ReauctionPreviewResponse"
   /api/v1/auctions/{auctionId}/edit:
     get:
       tags:
@@ -5536,39 +5788,6 @@ components:
           format: int64
           description: 만료 시간(ms)
           example: 3600000
-    BidRequest:
-      type: object
-      description: 경매 입찰 요청
-      properties:
-        bidPrice:
-          type: number
-          description: 입찰가
-          example: 12000
-      required:
-      - bidPrice
-    BidMessages:
-      type: object
-      properties:
-        reserveNotice:
-          type: string
-        refundNotice:
-          type: string
-    BidResponse:
-      type: object
-      properties:
-        auctionId:
-          type: integer
-          format: int64
-        currentPrice:
-          type: number
-        bidderId:
-          type: integer
-          format: int64
-        serverTime:
-          type: string
-          format: date-time
-        messages:
-          $ref: "#/components/schemas/BidMessages"
     CreateAuctionRequest:
       type: object
       description: 경매 상품 등록 요청
@@ -5647,6 +5866,52 @@ components:
       - location
       - name
       - saleType
+    ReauctionResponse:
+      type: object
+      description: 재경매 등록 응답
+      properties:
+        sourceAuctionId:
+          type: integer
+          format: int64
+        productId:
+          type: integer
+          format: int64
+        auctionId:
+          type: integer
+          format: int64
+    BidRequest:
+      type: object
+      description: 경매 입찰 요청
+      properties:
+        bidPrice:
+          type: number
+          description: 입찰가
+          example: 12000
+      required:
+      - bidPrice
+    BidMessages:
+      type: object
+      properties:
+        reserveNotice:
+          type: string
+        refundNotice:
+          type: string
+    BidResponse:
+      type: object
+      properties:
+        auctionId:
+          type: integer
+          format: int64
+        currentPrice:
+          type: number
+        bidderId:
+          type: integer
+          format: int64
+        serverTime:
+          type: string
+          format: date-time
+        messages:
+          $ref: "#/components/schemas/BidMessages"
     AuctionScheduleResponse:
       type: object
       description: 경매 일정 및 상태 정보
@@ -6219,6 +6484,21 @@ components:
           format: int32
           description: 정렬 순서
           example: 1
+    DeclineReauctionResponse:
+      type: object
+      description: 재경매 거절 응답
+      properties:
+        auctionId:
+          type: integer
+          format: int64
+        status:
+          type: string
+          enum:
+          - DRAFT
+          - ONGOING
+          - ENDED
+          - NO_BID
+          - SUCCESSFUL_BID
     WalletLedgerListResponse:
       type: object
       properties:
@@ -6297,6 +6577,70 @@ components:
         reviewCount:
           type: integer
           format: int64
+    RecentProductItemResponse:
+      type: object
+      description: 최근 본 상품 항목
+      properties:
+        type:
+          type: string
+          description: 최근 본 상품 유형
+          enum:
+          - REGULAR
+          - AUCTION
+          example: REGULAR
+        productId:
+          type: integer
+          format: int64
+          description: 상품 ID
+          example: 1
+        auctionId:
+          type: integer
+          format: int64
+          description: 경매 ID
+          example: 10
+        name:
+          type: string
+          description: 상품명
+          example: 맥북 에어
+        thumbnailUrl:
+          type: string
+          description: 대표 이미지 URL
+          example: http://localhost:8080/uploads/product/images/example.jpg
+        price:
+          type: number
+          description: 일반 상품 가격
+          example: 30000
+        currentPrice:
+          type: number
+          description: 경매 현재가
+          example: 50000
+        location:
+          type: string
+          description: 거래 위치
+          example: 서울 강남구
+        categoryName:
+          type: string
+          description: 카테고리명
+          example: 노트북
+        viewedAt:
+          type: string
+          format: date-time
+          description: 조회 시각
+          example: 2026-05-21T12:00:00+09:00
+    RecentProductListResponse:
+      type: object
+      description: 최근 본 상품 목록 응답
+      properties:
+        content:
+          type: array
+          description: 최근 본 상품 목록
+          items:
+            $ref: "#/components/schemas/RecentProductItemResponse"
+        size:
+          type: integer
+          format: int32
+          description: 조회 개수
+          example: 20
     MyLocationResponse:
       type: object
       properties:
@@ -6440,6 +6784,13 @@ components:
           type: string
           description: 검색어
           example: 맥북
+        type:
+          type: string
+          description: 검색 결과 유형 필터
+          enum:
+          - REGULAR
+          - AUCTION
+          example: REGULAR
         categoryId:
           type: integer
           format: int64
@@ -6538,7 +6889,9 @@ components:
           description: 구매 상태
           enum:
           - PAID
+          - SHIPPED
           - COMPLETED
+          - CANCELED
           example: PAID
         purchasedAt:
           type: string
@@ -6550,6 +6903,44 @@ components:
           format: int64
           description: 연결된 채팅방 ID. 현재는 null일 수 있습니다.
           example: 15
+        productType:
+          type: string
+          description: 상품 거래 유형
+          enum:
+          - REGULAR
+          example: REGULAR
+        paidAt:
+          type: string
+          format: date-time
+          description: 결제 완료 일시. 별도 값이 없으면 구매 일시와 같습니다.
+          example: 2026-05-06T21:30:00+09:00
+        shippedAt:
+          type: string
+          format: date-time
+          description: 판매자 발송 완료 일시
+          example: 2026-05-06T22:05:00+09:00
+        completedAt:
+          type: string
+          format: date-time
+          description: 거래 완료 일시
+          example: 2026-05-06T22:10:00+09:00
+        canceledAt:
+          type: string
+          format: date-time
+          description: 거래 취소 일시
+          example: 2026-05-09T22:05:00+09:00
+        sellerShipped:
+          type: boolean
+          description: 판매자 발송 완료 여부
+          example: true
+        buyerConfirmed:
+          type: boolean
+          description: 구매자 수령 확인 여부
+          example: false
+        counterpartNickname:
+          type: string
+          description: "거래 상대 닉네임. 구매자에게는 판매자, 판매자에게는 구매자 닉네임을 반환합니다."
+          example: Dealit#3
     CategoryResponse:
       type: object
       properties:
@@ -7853,6 +8244,55 @@ components:
         sortOrder:
           type: integer
           format: int32
+    ReauctionPreviewResponse:
+      type: object
+      description: 재경매 미리보기 응답
+      properties:
+        productId:
+          type: integer
+          format: int64
+        auctionId:
+          type: integer
+          format: int64
+        name:
+          type: string
+        description:
+          type: string
+        categoryId:
+          type: integer
+          format: int64
+        categoryName:
+          type: string
+        location:
+          type: string
+        images:
+          type: array
+          items:
+            $ref: "#/components/schemas/AuctionEditImageResponse"
+        startPrice:
+          type: number
+        minimumBidAmount:
+          type: number
+        auctionDurationDays:
+          type: integer
+          format: int64
+        auctionStatus:
+          type: string
+          enum:
+          - DRAFT
+          - ONGOING
+          - ENDED
+          - NO_BID
+          - SUCCESSFUL_BID
+        noBidAt:
+          type: string
+          format: date-time
+        reauctionExpiresAt:
+          type: string
+          format: date-time
+        remainingSeconds:
+          type: integer
+          format: int64
     AuctionBidHistoryResponse:
       type: object
       properties:

--- a/src/main/java/com/dealit/dealit/domain/auction/entity/Auction.java
+++ b/src/main/java/com/dealit/dealit/domain/auction/entity/Auction.java
@@ -124,6 +124,13 @@ public class Auction extends BaseEntity {
 		return startPrice.multiply(BigDecimal.valueOf(0.01)).setScale(0, RoundingMode.CEILING);
 	}
 
+	public BigDecimal resolveDisplayCurrentPrice(BigDecimal currentPrice) {
+		if (currentPrice == null || currentPrice.signum() <= 0) {
+			return startPrice;
+		}
+		return currentPrice;
+	}
+
 	public void completeWithWinner(Long winnerId, BigDecimal finalPrice) {
 		this.winnerId = winnerId;
 		this.finalPrice = finalPrice;

--- a/src/main/java/com/dealit/dealit/domain/auction/service/AuctionBidService.java
+++ b/src/main/java/com/dealit/dealit/domain/auction/service/AuctionBidService.java
@@ -95,7 +95,7 @@ public class AuctionBidService {
 				currentPrice = auction.getCurrentPrice();
 			}
 		}
-		currentPrice = resolveDisplayCurrentPrice(auction, currentPrice);
+		currentPrice = auction.resolveDisplayCurrentPrice(currentPrice);
 		Category category = categoryRepository.findById(product.getCategoryId()).orElse(null);
 		Member seller = memberRepository.findByMemberIdAndDeletedAtIsNull(product.getMemberId()).orElse(null);
 		return new AuctionDetailResponse(
@@ -148,7 +148,7 @@ public class AuctionBidService {
 
 		return new AuctionBidHistoryResponse(
 			auctionId,
-			resolveDisplayCurrentPrice(auction, auction.getCurrentPrice()),
+			auction.resolveDisplayCurrentPrice(auction.getCurrentPrice()),
 			bidItems.size(),
 			bidItems
 		);
@@ -399,13 +399,6 @@ public class AuctionBidService {
 			return null;
 		}
 		return imageUrlService.toPublicUrl(bidder.getProfileImage());
-	}
-
-	private BigDecimal resolveDisplayCurrentPrice(Auction auction, BigDecimal currentPrice) {
-		if (currentPrice == null || currentPrice.signum() <= 0) {
-			return auction.getStartPrice();
-		}
-		return currentPrice;
 	}
 
 	private OffsetDateTime serverTime() {

--- a/src/main/java/com/dealit/dealit/domain/auction/service/AuctionBidService.java
+++ b/src/main/java/com/dealit/dealit/domain/auction/service/AuctionBidService.java
@@ -33,6 +33,7 @@ import com.dealit.dealit.domain.member.exception.EmailNotVerifiedException;
 import com.dealit.dealit.domain.member.repository.MemberRepository;
 import com.dealit.dealit.domain.product.entity.Product;
 import com.dealit.dealit.domain.product.entity.ProductImage;
+import com.dealit.dealit.domain.recentproduct.service.RecentProductService;
 import com.dealit.dealit.domain.search.event.AuctionSearchDeleteRequestedEvent;
 import com.dealit.dealit.domain.search.event.AuctionSearchIndexRequestedEvent;
 import com.dealit.dealit.domain.wallet.service.WalletService;
@@ -72,6 +73,7 @@ public class AuctionBidService {
 	private final ChatRoomRepository chatRoomRepository;
 	private final WishlistService wishlistService;
 	private final ImageUrlService imageUrlService;
+	private final RecentProductService recentProductService;
 	private final Clock clock;
 
 	public AuctionDetailResponse getAuction(Long auctionId) {
@@ -80,6 +82,7 @@ public class AuctionBidService {
 
 	public AuctionDetailResponse getAuction(Long auctionId, Long memberId) {
 		Auction auction = loadAuctionDetail(auctionId);
+		recentProductService.recordAuction(memberId, auction.getAuctionId());
 		Product product = auction.getProduct();
 		BigDecimal currentPrice = auction.getCurrentPrice();
 		if (auction.isOngoing()) {

--- a/src/main/java/com/dealit/dealit/domain/product/service/ProductDetailService.java
+++ b/src/main/java/com/dealit/dealit/domain/product/service/ProductDetailService.java
@@ -12,6 +12,7 @@ import com.dealit.dealit.domain.product.entity.Product;
 import com.dealit.dealit.domain.product.entity.ProductImage;
 import com.dealit.dealit.domain.product.exception.ProductNotFoundException;
 import com.dealit.dealit.domain.product.repository.ProductRepository;
+import com.dealit.dealit.domain.recentproduct.service.RecentProductService;
 import com.dealit.dealit.global.service.ImageUrlService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -34,6 +35,7 @@ public class ProductDetailService {
 	private final CategoryRepository categoryRepository;
 	private final MemberRepository memberRepository;
 	private final ImageUrlService imageUrlService;
+	private final RecentProductService recentProductService;
 
 	@Transactional
 	public ProductDetailResponse getProductDetail(Long memberId, Long productId) {
@@ -46,6 +48,7 @@ public class ProductDetailService {
 		}
 
 		product.increaseViewCount();
+		recentProductService.recordRegularProduct(viewer.getMemberId(), product.getProductId());
 
 		Category category = categoryRepository.findById(product.getCategoryId()).orElse(null);
 		Member seller = memberRepository.findByMemberIdAndDeletedAtIsNull(product.getMemberId())

--- a/src/main/java/com/dealit/dealit/domain/product/service/ProductThumbnailResolver.java
+++ b/src/main/java/com/dealit/dealit/domain/product/service/ProductThumbnailResolver.java
@@ -1,0 +1,26 @@
+package com.dealit.dealit.domain.product.service;
+
+import com.dealit.dealit.domain.product.entity.Product;
+import com.dealit.dealit.domain.product.entity.ProductImage;
+import com.dealit.dealit.global.service.ImageUrlService;
+import java.util.Comparator;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ProductThumbnailResolver {
+
+	private final ImageUrlService imageUrlService;
+
+	public String resolve(Product product) {
+		return product.getImages().stream()
+			.filter(image -> image.getDeletedAt() == null)
+			.filter(image -> image.getImageUrl() != null && !image.getImageUrl().isBlank())
+			.sorted(Comparator.comparing(ProductImage::getSortOrder, Comparator.nullsLast(Integer::compareTo))
+				.thenComparing(ProductImage::getCreatedAt))
+			.map(image -> imageUrlService.toPublicUrl(image.getImageUrl()))
+			.findFirst()
+			.orElse(null);
+	}
+}

--- a/src/main/java/com/dealit/dealit/domain/recentproduct/RecentProductType.java
+++ b/src/main/java/com/dealit/dealit/domain/recentproduct/RecentProductType.java
@@ -1,0 +1,9 @@
+package com.dealit.dealit.domain.recentproduct;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "최근 본 상품 유형")
+public enum RecentProductType {
+	REGULAR,
+	AUCTION
+}

--- a/src/main/java/com/dealit/dealit/domain/recentproduct/controller/RecentProductController.java
+++ b/src/main/java/com/dealit/dealit/domain/recentproduct/controller/RecentProductController.java
@@ -1,0 +1,36 @@
+package com.dealit.dealit.domain.recentproduct.controller;
+
+import com.dealit.dealit.domain.recentproduct.dto.RecentProductListResponse;
+import com.dealit.dealit.domain.recentproduct.service.RecentProductService;
+import com.dealit.dealit.global.security.AuthenticatedMember;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Recent Products", description = "최근 본 상품 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/users/me/recent-products")
+public class RecentProductController {
+
+	private final RecentProductService recentProductService;
+
+	@Operation(
+		summary = "Recent Products",
+		description = "로그인 사용자의 최근 본 일반상품과 경매상품을 최신 조회순으로 함께 조회합니다."
+	)
+	@ApiResponse(responseCode = "200", description = "최근 본 상품 조회 성공")
+	@GetMapping
+	public RecentProductListResponse getRecentProducts(
+		@AuthenticationPrincipal AuthenticatedMember member,
+		@RequestParam(defaultValue = "20") int size
+	) {
+		return recentProductService.findRecentProducts(member.memberId(), size);
+	}
+}

--- a/src/main/java/com/dealit/dealit/domain/recentproduct/dto/RecentProductItemResponse.java
+++ b/src/main/java/com/dealit/dealit/domain/recentproduct/dto/RecentProductItemResponse.java
@@ -1,0 +1,40 @@
+package com.dealit.dealit.domain.recentproduct.dto;
+
+import com.dealit.dealit.domain.recentproduct.RecentProductType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+
+@Schema(description = "최근 본 상품 항목")
+public record RecentProductItemResponse(
+	@Schema(description = "최근 본 상품 유형", example = "REGULAR")
+	RecentProductType type,
+
+	@Schema(description = "상품 ID", example = "1")
+	Long productId,
+
+	@Schema(description = "경매 ID", example = "10")
+	Long auctionId,
+
+	@Schema(description = "상품명", example = "맥북 에어")
+	String name,
+
+	@Schema(description = "대표 이미지 URL", example = "http://localhost:8080/uploads/product/images/example.jpg")
+	String thumbnailUrl,
+
+	@Schema(description = "일반 상품 가격", example = "30000")
+	BigDecimal price,
+
+	@Schema(description = "경매 현재가", example = "50000")
+	BigDecimal currentPrice,
+
+	@Schema(description = "거래 위치", example = "서울 강남구")
+	String location,
+
+	@Schema(description = "카테고리명", example = "노트북")
+	String categoryName,
+
+	@Schema(description = "조회 시각", example = "2026-05-21T12:00:00+09:00")
+	OffsetDateTime viewedAt
+) {
+}

--- a/src/main/java/com/dealit/dealit/domain/recentproduct/dto/RecentProductListResponse.java
+++ b/src/main/java/com/dealit/dealit/domain/recentproduct/dto/RecentProductListResponse.java
@@ -1,0 +1,14 @@
+package com.dealit.dealit.domain.recentproduct.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+@Schema(description = "최근 본 상품 목록 응답")
+public record RecentProductListResponse(
+	@Schema(description = "최근 본 상품 목록")
+	List<RecentProductItemResponse> content,
+
+	@Schema(description = "조회 개수", example = "20")
+	int size
+) {
+}

--- a/src/main/java/com/dealit/dealit/domain/recentproduct/service/RecentProductService.java
+++ b/src/main/java/com/dealit/dealit/domain/recentproduct/service/RecentProductService.java
@@ -37,6 +37,7 @@ public class RecentProductService {
 	private static final String KEY_PREFIX = "recent-products:";
 	private static final String ALL = "ALL";
 	private static final int MAX_RECENT_PRODUCTS = 100;
+	private static final long RECENT_PRODUCT_TTL_MILLIS = 24 * 60 * 60 * 1000L;
 
 	private static final ZoneId SEOUL_ZONE = ZoneId.of("Asia/Seoul");
 
@@ -58,8 +59,10 @@ public class RecentProductService {
 	public RecentProductListResponse findRecentProducts(Long memberId, int size) {
 		int normalizedSize = Math.min(Math.max(size, 1), 50);
 		try {
+			String key = key(memberId);
+			removeExpiredItems(key);
 			Set<TypedTuple<String>> tuples = stringRedisTemplate.opsForZSet()
-				.reverseRangeWithScores(key(memberId), 0, normalizedSize - 1);
+				.reverseRangeWithScores(key, 0, normalizedSize - 1);
 			if (tuples == null || tuples.isEmpty()) {
 				return new RecentProductListResponse(List.of(), normalizedSize);
 			}
@@ -83,8 +86,14 @@ public class RecentProductService {
 	}
 
 	private void recordToKey(String key, String value, double score) {
+		removeExpiredItems(key);
 		stringRedisTemplate.opsForZSet().add(key, value, score);
 		stringRedisTemplate.opsForZSet().removeRange(key, 0, -(MAX_RECENT_PRODUCTS + 1L));
+	}
+
+	private void removeExpiredItems(String key) {
+		long cutoffMillis = clock.millis() - RECENT_PRODUCT_TTL_MILLIS;
+		stringRedisTemplate.opsForZSet().removeRangeByScore(key, 0, cutoffMillis);
 	}
 
 	private List<RecentProductItemResponse> resolveItems(Collection<TypedTuple<String>> tuples) {

--- a/src/main/java/com/dealit/dealit/domain/recentproduct/service/RecentProductService.java
+++ b/src/main/java/com/dealit/dealit/domain/recentproduct/service/RecentProductService.java
@@ -5,20 +5,17 @@ import com.dealit.dealit.domain.auction.entity.Category;
 import com.dealit.dealit.domain.auction.repository.AuctionRepository;
 import com.dealit.dealit.domain.auction.repository.CategoryRepository;
 import com.dealit.dealit.domain.product.entity.Product;
-import com.dealit.dealit.domain.product.entity.ProductImage;
 import com.dealit.dealit.domain.product.repository.ProductRepository;
+import com.dealit.dealit.domain.product.service.ProductThumbnailResolver;
 import com.dealit.dealit.domain.recentproduct.RecentProductType;
 import com.dealit.dealit.domain.recentproduct.dto.RecentProductItemResponse;
 import com.dealit.dealit.domain.recentproduct.dto.RecentProductListResponse;
-import com.dealit.dealit.global.service.ImageUrlService;
-import java.math.BigDecimal;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -47,7 +44,7 @@ public class RecentProductService {
 	private final ProductRepository productRepository;
 	private final AuctionRepository auctionRepository;
 	private final CategoryRepository categoryRepository;
-	private final ImageUrlService imageUrlService;
+	private final ProductThumbnailResolver productThumbnailResolver;
 	private final Clock clock;
 
 	public void recordRegularProduct(Long memberId, Long productId) {
@@ -99,23 +96,17 @@ public class RecentProductService {
 			return List.of();
 		}
 
-		Map<Long, Product> productsById = productRepository.findAllByProductIdInAndDeletedAtIsNull(
-				refs.stream()
-					.filter(ref -> ref.type() == RecentProductType.REGULAR)
-					.map(RecentProductRef::id)
-					.collect(Collectors.toSet())
-			)
-			.stream()
-			.collect(Collectors.toMap(Product::getProductId, Function.identity()));
+		Set<Long> productIds = refs.stream()
+			.filter(ref -> ref.type() == RecentProductType.REGULAR)
+			.map(RecentProductRef::id)
+			.collect(Collectors.toSet());
+		Set<Long> auctionIds = refs.stream()
+			.filter(ref -> ref.type() == RecentProductType.AUCTION)
+			.map(RecentProductRef::id)
+			.collect(Collectors.toSet());
 
-		Map<Long, Auction> auctionsById = auctionRepository.findAllByAuctionIdInAndDeletedAtIsNullAndProductDeletedAtIsNull(
-				refs.stream()
-					.filter(ref -> ref.type() == RecentProductType.AUCTION)
-					.map(RecentProductRef::id)
-					.collect(Collectors.toSet())
-			)
-			.stream()
-			.collect(Collectors.toMap(Auction::getAuctionId, Function.identity()));
+		Map<Long, Product> productsById = loadProductsById(productIds);
+		Map<Long, Auction> auctionsById = loadAuctionsById(auctionIds);
 
 		Map<Long, String> categoryNamesById = loadCategoryNames(productsById.values(), auctionsById.values());
 		List<RecentProductItemResponse> responses = new ArrayList<>();
@@ -129,6 +120,24 @@ public class RecentProductService {
 			}
 		}
 		return responses;
+	}
+
+	private Map<Long, Product> loadProductsById(Set<Long> productIds) {
+		if (productIds.isEmpty()) {
+			return Map.of();
+		}
+		return productRepository.findAllByProductIdInAndDeletedAtIsNull(productIds)
+			.stream()
+			.collect(Collectors.toMap(Product::getProductId, Function.identity()));
+	}
+
+	private Map<Long, Auction> loadAuctionsById(Set<Long> auctionIds) {
+		if (auctionIds.isEmpty()) {
+			return Map.of();
+		}
+		return auctionRepository.findAllByAuctionIdInAndDeletedAtIsNullAndProductDeletedAtIsNull(auctionIds)
+			.stream()
+			.collect(Collectors.toMap(Auction::getAuctionId, Function.identity()));
 	}
 
 	private Map<Long, String> loadCategoryNames(Collection<Product> products, Collection<Auction> auctions) {
@@ -160,7 +169,7 @@ public class RecentProductService {
 			product.getProductId(),
 			null,
 			product.getName(),
-			thumbnailUrl(product),
+			productThumbnailResolver.resolve(product),
 			product.getPrice(),
 			null,
 			product.getLocation(),
@@ -179,31 +188,13 @@ public class RecentProductService {
 			product.getProductId(),
 			auction.getAuctionId(),
 			product.getName(),
-			thumbnailUrl(product),
+			productThumbnailResolver.resolve(product),
 			null,
-			resolveAuctionCurrentPrice(auction),
+			auction.resolveDisplayCurrentPrice(auction.getCurrentPrice()),
 			product.getLocation(),
 			categoryNamesById.getOrDefault(product.getCategoryId(), ""),
 			viewedAt
 		);
-	}
-
-	private String thumbnailUrl(Product product) {
-		return product.getImages().stream()
-			.filter(image -> image.getDeletedAt() == null)
-			.filter(image -> image.getImageUrl() != null && !image.getImageUrl().isBlank())
-			.sorted(Comparator.comparing(ProductImage::getSortOrder, Comparator.nullsLast(Integer::compareTo))
-				.thenComparing(ProductImage::getCreatedAt))
-			.map(image -> imageUrlService.toPublicUrl(image.getImageUrl()))
-			.findFirst()
-			.orElse(null);
-	}
-
-	private BigDecimal resolveAuctionCurrentPrice(Auction auction) {
-		if (auction.getCurrentPrice() == null || auction.getCurrentPrice().signum() <= 0) {
-			return auction.getStartPrice();
-		}
-		return auction.getCurrentPrice();
 	}
 
 	private String categoryName(Category category) {

--- a/src/main/java/com/dealit/dealit/domain/recentproduct/service/RecentProductService.java
+++ b/src/main/java/com/dealit/dealit/domain/recentproduct/service/RecentProductService.java
@@ -1,0 +1,247 @@
+package com.dealit.dealit.domain.recentproduct.service;
+
+import com.dealit.dealit.domain.auction.entity.Auction;
+import com.dealit.dealit.domain.auction.entity.Category;
+import com.dealit.dealit.domain.auction.repository.AuctionRepository;
+import com.dealit.dealit.domain.auction.repository.CategoryRepository;
+import com.dealit.dealit.domain.product.entity.Product;
+import com.dealit.dealit.domain.product.entity.ProductImage;
+import com.dealit.dealit.domain.product.repository.ProductRepository;
+import com.dealit.dealit.domain.recentproduct.RecentProductType;
+import com.dealit.dealit.domain.recentproduct.dto.RecentProductItemResponse;
+import com.dealit.dealit.domain.recentproduct.dto.RecentProductListResponse;
+import com.dealit.dealit.global.service.ImageUrlService;
+import java.math.BigDecimal;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations.TypedTuple;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class RecentProductService {
+
+	private static final String KEY_PREFIX = "recent-products:";
+	private static final String ALL = "ALL";
+	private static final int MAX_RECENT_PRODUCTS = 100;
+
+	private static final ZoneId SEOUL_ZONE = ZoneId.of("Asia/Seoul");
+
+	private final StringRedisTemplate stringRedisTemplate;
+	private final ProductRepository productRepository;
+	private final AuctionRepository auctionRepository;
+	private final CategoryRepository categoryRepository;
+	private final ImageUrlService imageUrlService;
+	private final Clock clock;
+
+	public void recordRegularProduct(Long memberId, Long productId) {
+		record(memberId, RecentProductType.REGULAR, productId);
+	}
+
+	public void recordAuction(Long memberId, Long auctionId) {
+		record(memberId, RecentProductType.AUCTION, auctionId);
+	}
+
+	public RecentProductListResponse findRecentProducts(Long memberId, int size) {
+		int normalizedSize = Math.min(Math.max(size, 1), 50);
+		try {
+			Set<TypedTuple<String>> tuples = stringRedisTemplate.opsForZSet()
+				.reverseRangeWithScores(key(memberId), 0, normalizedSize - 1);
+			if (tuples == null || tuples.isEmpty()) {
+				return new RecentProductListResponse(List.of(), normalizedSize);
+			}
+			return new RecentProductListResponse(resolveItems(tuples), normalizedSize);
+		} catch (RuntimeException exception) {
+			return new RecentProductListResponse(List.of(), normalizedSize);
+		}
+	}
+
+	private void record(Long memberId, RecentProductType type, Long id) {
+		if (memberId == null || type == null || id == null) {
+			return;
+		}
+		try {
+			String value = value(type, id);
+			double score = clock.millis();
+			recordToKey(key(memberId), value, score);
+		} catch (RuntimeException exception) {
+			// Product detail should still work even if Redis recent-view storage is temporarily unavailable.
+		}
+	}
+
+	private void recordToKey(String key, String value, double score) {
+		stringRedisTemplate.opsForZSet().add(key, value, score);
+		stringRedisTemplate.opsForZSet().removeRange(key, 0, -(MAX_RECENT_PRODUCTS + 1L));
+	}
+
+	private List<RecentProductItemResponse> resolveItems(Collection<TypedTuple<String>> tuples) {
+		List<RecentProductRef> refs = tuples.stream()
+			.map(this::toRef)
+			.filter(Objects::nonNull)
+			.toList();
+		if (refs.isEmpty()) {
+			return List.of();
+		}
+
+		Map<Long, Product> productsById = productRepository.findAllByProductIdInAndDeletedAtIsNull(
+				refs.stream()
+					.filter(ref -> ref.type() == RecentProductType.REGULAR)
+					.map(RecentProductRef::id)
+					.collect(Collectors.toSet())
+			)
+			.stream()
+			.collect(Collectors.toMap(Product::getProductId, Function.identity()));
+
+		Map<Long, Auction> auctionsById = auctionRepository.findAllByAuctionIdInAndDeletedAtIsNullAndProductDeletedAtIsNull(
+				refs.stream()
+					.filter(ref -> ref.type() == RecentProductType.AUCTION)
+					.map(RecentProductRef::id)
+					.collect(Collectors.toSet())
+			)
+			.stream()
+			.collect(Collectors.toMap(Auction::getAuctionId, Function.identity()));
+
+		Map<Long, String> categoryNamesById = loadCategoryNames(productsById.values(), auctionsById.values());
+		List<RecentProductItemResponse> responses = new ArrayList<>();
+		for (RecentProductRef ref : refs) {
+			RecentProductItemResponse response = switch (ref.type()) {
+				case REGULAR -> toRegularResponse(productsById.get(ref.id()), categoryNamesById, ref.viewedAt());
+				case AUCTION -> toAuctionResponse(auctionsById.get(ref.id()), categoryNamesById, ref.viewedAt());
+			};
+			if (response != null) {
+				responses.add(response);
+			}
+		}
+		return responses;
+	}
+
+	private Map<Long, String> loadCategoryNames(Collection<Product> products, Collection<Auction> auctions) {
+		Set<Long> categoryIds = new java.util.HashSet<>();
+		products.stream()
+			.map(Product::getCategoryId)
+			.filter(Objects::nonNull)
+			.forEach(categoryIds::add);
+		auctions.stream()
+			.map(Auction::getProduct)
+			.map(Product::getCategoryId)
+			.filter(Objects::nonNull)
+			.forEach(categoryIds::add);
+		if (categoryIds.isEmpty()) {
+			return Map.of();
+		}
+		Map<Long, String> categoryNamesById = new LinkedHashMap<>();
+		categoryRepository.findAllById(categoryIds)
+			.forEach(category -> categoryNamesById.put(category.getId(), categoryName(category)));
+		return categoryNamesById;
+	}
+
+	private RecentProductItemResponse toRegularResponse(Product product, Map<Long, String> categoryNamesById, OffsetDateTime viewedAt) {
+		if (product == null) {
+			return null;
+		}
+		return new RecentProductItemResponse(
+			RecentProductType.REGULAR,
+			product.getProductId(),
+			null,
+			product.getName(),
+			thumbnailUrl(product),
+			product.getPrice(),
+			null,
+			product.getLocation(),
+			categoryNamesById.getOrDefault(product.getCategoryId(), ""),
+			viewedAt
+		);
+	}
+
+	private RecentProductItemResponse toAuctionResponse(Auction auction, Map<Long, String> categoryNamesById, OffsetDateTime viewedAt) {
+		if (auction == null) {
+			return null;
+		}
+		Product product = auction.getProduct();
+		return new RecentProductItemResponse(
+			RecentProductType.AUCTION,
+			product.getProductId(),
+			auction.getAuctionId(),
+			product.getName(),
+			thumbnailUrl(product),
+			null,
+			resolveAuctionCurrentPrice(auction),
+			product.getLocation(),
+			categoryNamesById.getOrDefault(product.getCategoryId(), ""),
+			viewedAt
+		);
+	}
+
+	private String thumbnailUrl(Product product) {
+		return product.getImages().stream()
+			.filter(image -> image.getDeletedAt() == null)
+			.filter(image -> image.getImageUrl() != null && !image.getImageUrl().isBlank())
+			.sorted(Comparator.comparing(ProductImage::getSortOrder, Comparator.nullsLast(Integer::compareTo))
+				.thenComparing(ProductImage::getCreatedAt))
+			.map(image -> imageUrlService.toPublicUrl(image.getImageUrl()))
+			.findFirst()
+			.orElse(null);
+	}
+
+	private BigDecimal resolveAuctionCurrentPrice(Auction auction) {
+		if (auction.getCurrentPrice() == null || auction.getCurrentPrice().signum() <= 0) {
+			return auction.getStartPrice();
+		}
+		return auction.getCurrentPrice();
+	}
+
+	private String categoryName(Category category) {
+		return category == null ? "" : category.getNameKo();
+	}
+
+	private RecentProductRef toRef(TypedTuple<String> tuple) {
+		if (tuple == null || tuple.getValue() == null || tuple.getScore() == null) {
+			return null;
+		}
+		String[] parts = tuple.getValue().split(":", 2);
+		if (parts.length != 2) {
+			return null;
+		}
+		try {
+			RecentProductType type = RecentProductType.valueOf(parts[0]);
+			Long id = Long.valueOf(parts[1]);
+			OffsetDateTime viewedAt = Instant.ofEpochMilli(tuple.getScore().longValue())
+				.atZone(SEOUL_ZONE)
+				.toOffsetDateTime();
+			return new RecentProductRef(type, id, viewedAt);
+		} catch (IllegalArgumentException exception) {
+			return null;
+		}
+	}
+
+	private String key(Long memberId) {
+		return KEY_PREFIX + memberId + ":" + ALL;
+	}
+
+	private String value(RecentProductType type, Long id) {
+		return type.name() + ":" + id;
+	}
+
+	private record RecentProductRef(
+		RecentProductType type,
+		Long id,
+		OffsetDateTime viewedAt
+	) {
+	}
+}

--- a/src/main/java/com/dealit/dealit/domain/search/service/SearchDocumentFactory.java
+++ b/src/main/java/com/dealit/dealit/domain/search/service/SearchDocumentFactory.java
@@ -4,15 +4,13 @@ import com.dealit.dealit.domain.auction.entity.Auction;
 import com.dealit.dealit.domain.auction.entity.Category;
 import com.dealit.dealit.domain.auction.repository.CategoryRepository;
 import com.dealit.dealit.domain.product.entity.Product;
-import com.dealit.dealit.domain.product.entity.ProductImage;
+import com.dealit.dealit.domain.product.service.ProductThumbnailResolver;
 import com.dealit.dealit.domain.search.document.SearchDocument;
 import com.dealit.dealit.domain.search.dto.SearchResultType;
-import com.dealit.dealit.global.service.ImageUrlService;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -26,7 +24,7 @@ public class SearchDocumentFactory {
 	private static final ZoneId SEOUL_ZONE = ZoneId.of("Asia/Seoul");
 
 	private final CategoryRepository categoryRepository;
-	private final ImageUrlService imageUrlService;
+	private final ProductThumbnailResolver productThumbnailResolver;
 
 	public SearchDocument regularProduct(Product product) {
 		return regularProduct(product, loadCategoryNodes());
@@ -40,7 +38,7 @@ public class SearchDocumentFactory {
 			null,
 			product.getName(),
 			product.getDescription(),
-			resolveThumbnailUrl(product),
+			productThumbnailResolver.resolve(product),
 			product.getCategoryId(),
 			resolveCategoryPathIds(product.getCategoryId(), nodesById),
 			resolveCategoryNames(product.getCategoryId(), nodesById),
@@ -69,7 +67,7 @@ public class SearchDocumentFactory {
 			auction.getAuctionId(),
 			product.getName(),
 			product.getDescription(),
-			resolveThumbnailUrl(product),
+			productThumbnailResolver.resolve(product),
 			product.getCategoryId(),
 			resolveCategoryPathIds(product.getCategoryId(), nodesById),
 			resolveCategoryNames(product.getCategoryId(), nodesById),
@@ -102,17 +100,6 @@ public class SearchDocumentFactory {
 			}
 		}
 		return nodesById;
-	}
-
-	private String resolveThumbnailUrl(Product product) {
-		return product.getImages().stream()
-			.filter(image -> image.getDeletedAt() == null)
-			.filter(image -> image.getImageUrl() != null && !image.getImageUrl().isBlank())
-			.sorted(Comparator.comparing(ProductImage::getSortOrder, Comparator.nullsLast(Integer::compareTo))
-				.thenComparing(ProductImage::getCreatedAt))
-			.map(image -> imageUrlService.toPublicUrl(image.getImageUrl()))
-			.findFirst()
-			.orElse(null);
 	}
 
 	private List<Long> resolveCategoryPathIds(Long categoryId, Map<Long, CategoryNode> nodesById) {

--- a/src/test/java/com/dealit/dealit/domain/auction/AuctionBidServiceTest.java
+++ b/src/test/java/com/dealit/dealit/domain/auction/AuctionBidServiceTest.java
@@ -35,6 +35,7 @@ import com.dealit.dealit.domain.member.repository.MemberRepository;
 import com.dealit.dealit.domain.product.ProductSaleType;
 import com.dealit.dealit.domain.product.ProductStatus;
 import com.dealit.dealit.domain.product.entity.Product;
+import com.dealit.dealit.domain.recentproduct.service.RecentProductService;
 import com.dealit.dealit.domain.wallet.service.WalletService;
 import com.dealit.dealit.domain.wishlist.service.WishlistService;
 import com.dealit.dealit.global.service.ImageUrlService;
@@ -76,6 +77,7 @@ class AuctionBidServiceTest {
 	private final ChatRoomRepository chatRoomRepository = mock(ChatRoomRepository.class);
 	private final WishlistService wishlistService = mock(WishlistService.class);
 	private final ImageUrlService imageUrlService = mock(ImageUrlService.class);
+	private final RecentProductService recentProductService = mock(RecentProductService.class);
 
 	private final AuctionBidService auctionBidService = new AuctionBidService(
 		auctionRepository,
@@ -91,6 +93,7 @@ class AuctionBidServiceTest {
 		chatRoomRepository,
 		wishlistService,
 		imageUrlService,
+		recentProductService,
 		FIXED_CLOCK
 	);
 


### PR DESCRIPTION
### 🚀 Summary

상품 상세페이지 진입 기준으로 로그인 사용자의 최근 본 상품을 기록하고 조회하는 기능을 구현했습니다.

---

### ✨ Description

- 최근 본 상품 조회 API 추가
  - `GET /api/v1/users/me/recent-products`
  - 일반상품과 경매상품을 나누지 않고 최신 조회순으로 함께 반환

- 상품 상세 조회 시 최근 본 상품 자동 기록
  - 일반 상품 상세 조회 시 `REGULAR:{productId}` 기록
  - 경매 상품 상세 조회 시 `AUCTION:{auctionId}` 기록

- Redis 기반 최근 본 상품 저장
  - DB 테이블 추가 없이 Redis Sorted Set 사용
  - score는 조회 시각 기준 epoch millis
  - 같은 상품을 다시 보면 중복 저장 없이 최신 조회 시각으로 갱신
  - 사용자별 최대 100개 유지

---

### 🎲 Issue Number

<!-- Please enter {Issue Number} below to automatically close the connected issue. -->

close #96 
