### PR TITLE
[refactor] API와 DTO 추가

### DIFF
--- a/src/main/java/com/dealit/dealit/domain/auction/repository/AuctionPaymentRepository.java
+++ b/src/main/java/com/dealit/dealit/domain/auction/repository/AuctionPaymentRepository.java
@@ -28,6 +28,8 @@ public interface AuctionPaymentRepository extends JpaRepository<AuctionPayment, 
 	@Lock(LockModeType.PESSIMISTIC_WRITE)
 	Optional<AuctionPayment> findByPurchaseIdAndDeletedAtIsNull(Long purchaseId);
 
+	List<AuctionPayment> findAllByPurchaseIdInAndDeletedAtIsNull(Collection<Long> purchaseIds);
+
 	@Lock(LockModeType.PESSIMISTIC_WRITE)
 	Optional<AuctionPayment> findFirstByAuctionAuctionIdAndBidderIdAndSellerIdAndStatusInAndDeletedAtIsNullOrderByReservedAtDescAuctionPaymentIdDesc(
 		Long auctionId,

--- a/src/main/java/com/dealit/dealit/domain/purchase/dto/MyPurchaseItemResponse.java
+++ b/src/main/java/com/dealit/dealit/domain/purchase/dto/MyPurchaseItemResponse.java
@@ -1,5 +1,6 @@
 package com.dealit.dealit.domain.purchase.dto;
 
+import com.dealit.dealit.domain.product.ProductSaleType;
 import com.dealit.dealit.domain.purchase.entity.PurchaseStatus;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.OffsetDateTime;
@@ -31,6 +32,24 @@ public record MyPurchaseItemResponse(
 	OffsetDateTime purchasedAt,
 
 	@Schema(description = "연결된 채팅방 ID. 없으면 null입니다.", example = "15", nullable = true)
-	Long chatRoomId
+	Long chatRoomId,
+
+	ProductSaleType productType,
+
+	Long auctionId,
+
+	boolean sellerShipped,
+
+	boolean buyerConfirmed,
+
+	boolean completed,
+
+	OffsetDateTime shippedAt,
+
+	OffsetDateTime completedAt,
+
+	boolean reviewWritten,
+
+	boolean reviewAvailable
 ) {
 }

--- a/src/main/java/com/dealit/dealit/domain/purchase/dto/MySaleItemResponse.java
+++ b/src/main/java/com/dealit/dealit/domain/purchase/dto/MySaleItemResponse.java
@@ -1,5 +1,6 @@
 package com.dealit.dealit.domain.purchase.dto;
 
+import com.dealit.dealit.domain.product.ProductSaleType;
 import com.dealit.dealit.domain.purchase.entity.PurchaseStatus;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.OffsetDateTime;
@@ -31,6 +32,22 @@ public record MySaleItemResponse(
 	OffsetDateTime purchasedAt,
 
 	@Schema(description = "연결된 채팅방 ID. 없으면 null입니다.", example = "15", nullable = true)
-	Long chatRoomId
+	Long chatRoomId,
+
+	ProductSaleType productType,
+
+	Long auctionId,
+
+	boolean sellerShipped,
+
+	boolean buyerConfirmed,
+
+	boolean completed,
+
+	OffsetDateTime shippedAt,
+
+	OffsetDateTime completedAt,
+
+	boolean reviewReceived
 ) {
 }

--- a/src/main/java/com/dealit/dealit/domain/purchase/service/PurchaseService.java
+++ b/src/main/java/com/dealit/dealit/domain/purchase/service/PurchaseService.java
@@ -37,6 +37,7 @@ import com.dealit.dealit.domain.purchase.exception.PurchaseForbiddenException;
 import com.dealit.dealit.domain.purchase.exception.PurchaseNotFoundException;
 import com.dealit.dealit.domain.purchase.exception.PurchaseNotCompletableException;
 import com.dealit.dealit.domain.purchase.repository.PurchaseRepository;
+import com.dealit.dealit.domain.review.repository.ReviewRepository;
 import com.dealit.dealit.domain.wallet.exception.InvalidWalletRequestException;
 import com.dealit.dealit.domain.wallet.service.WalletService;
 import com.dealit.dealit.global.service.ImageUrlService;
@@ -45,9 +46,11 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.util.Comparator;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -68,6 +71,7 @@ public class PurchaseService {
 
 	private final PurchaseRepository purchaseRepository;
 	private final AuctionPaymentRepository auctionPaymentRepository;
+	private final ReviewRepository reviewRepository;
 	private final ProductRepository productRepository;
 	private final MemberRepository memberRepository;
 	private final WalletService walletService;
@@ -226,9 +230,23 @@ public class PurchaseService {
 			? purchaseRepository.findByBuyerIdOrderByPurchaseIdDesc(memberId, pageRequest)
 			: purchaseRepository.findByBuyerIdAndStatusInOrderByPurchaseIdDesc(memberId, statuses, pageRequest);
 
-		Map<Long, Product> productsById = loadProductsById(purchasePage.getContent());
-		List<MyPurchaseItemResponse> content = purchasePage.getContent().stream()
-			.map(purchase -> toMyPurchaseItemResponse(purchase, productsById.get(purchase.getProductId())))
+		List<Purchase> purchases = purchasePage.getContent();
+		Map<Long, Product> productsById = loadProductsById(purchases);
+		Map<Long, AuctionPayment> auctionPaymentsByPurchaseId = loadAuctionPaymentsByPurchaseId(purchases);
+		Set<Long> reviewedRegularProductIds = loadReviewedRegularProductIds(
+			memberId,
+			purchases,
+			auctionPaymentsByPurchaseId
+		);
+		Set<Long> reviewedAuctionIds = loadReviewedAuctionIds(memberId, auctionPaymentsByPurchaseId);
+		List<MyPurchaseItemResponse> content = purchases.stream()
+			.map(purchase -> toMyPurchaseItemResponse(
+				purchase,
+				productsById.get(purchase.getProductId()),
+				auctionPaymentsByPurchaseId.get(purchase.getPurchaseId()),
+				reviewedRegularProductIds,
+				reviewedAuctionIds
+			))
 			.toList();
 
 		return new MyPurchaseListResponse(
@@ -254,9 +272,19 @@ public class PurchaseService {
 			? purchaseRepository.findBySellerIdOrderByPurchaseIdDesc(memberId, pageRequest)
 			: purchaseRepository.findBySellerIdAndStatusInOrderByPurchaseIdDesc(memberId, statuses, pageRequest);
 
-		Map<Long, Product> productsById = loadProductsById(purchasePage.getContent());
-		List<MySaleItemResponse> content = purchasePage.getContent().stream()
-			.map(purchase -> toMySaleItemResponse(purchase, productsById.get(purchase.getProductId())))
+		List<Purchase> purchases = purchasePage.getContent();
+		Map<Long, Product> productsById = loadProductsById(purchases);
+		Map<Long, AuctionPayment> auctionPaymentsByPurchaseId = loadAuctionPaymentsByPurchaseId(purchases);
+		Set<ReviewProductKey> regularReviewKeys = loadRegularReviewKeys(purchases, auctionPaymentsByPurchaseId);
+		Set<ReviewAuctionKey> auctionReviewKeys = loadAuctionReviewKeys(purchases, auctionPaymentsByPurchaseId);
+		List<MySaleItemResponse> content = purchases.stream()
+			.map(purchase -> toMySaleItemResponse(
+				purchase,
+				productsById.get(purchase.getProductId()),
+				auctionPaymentsByPurchaseId.get(purchase.getPurchaseId()),
+				regularReviewKeys,
+				auctionReviewKeys
+			))
 			.toList();
 
 		return new MySaleListResponse(
@@ -376,11 +404,108 @@ public class PurchaseService {
 			.distinct()
 			.toList();
 
+		if (productIds.isEmpty()) {
+			return Map.of();
+		}
 		return productRepository.findAllByProductIdInAndDeletedAtIsNull(productIds).stream()
 			.collect(Collectors.toMap(Product::getProductId, Function.identity()));
 	}
 
-	private MyPurchaseItemResponse toMyPurchaseItemResponse(Purchase purchase, Product product) {
+	private Map<Long, AuctionPayment> loadAuctionPaymentsByPurchaseId(List<Purchase> purchases) {
+		List<Long> purchaseIds = purchases.stream()
+			.map(Purchase::getPurchaseId)
+			.distinct()
+			.toList();
+
+		if (purchaseIds.isEmpty()) {
+			return Map.of();
+		}
+		return auctionPaymentRepository.findAllByPurchaseIdInAndDeletedAtIsNull(purchaseIds).stream()
+			.collect(Collectors.toMap(AuctionPayment::getPurchaseId, Function.identity()));
+	}
+
+	private Set<Long> loadReviewedRegularProductIds(
+		Long reviewerId,
+		List<Purchase> purchases,
+		Map<Long, AuctionPayment> auctionPaymentsByPurchaseId
+	) {
+		Set<Long> productIds = purchases.stream()
+			.filter(purchase -> !auctionPaymentsByPurchaseId.containsKey(purchase.getPurchaseId()))
+			.map(Purchase::getProductId)
+			.collect(Collectors.toSet());
+
+		if (productIds.isEmpty()) {
+			return Set.of();
+		}
+		return new HashSet<>(reviewRepository.findReviewedRegularProductIds(reviewerId, productIds));
+	}
+
+	private Set<Long> loadReviewedAuctionIds(
+		Long reviewerId,
+		Map<Long, AuctionPayment> auctionPaymentsByPurchaseId
+	) {
+		Set<Long> auctionIds = auctionPaymentsByPurchaseId.values().stream()
+			.map(payment -> payment.getAuction().getAuctionId())
+			.collect(Collectors.toSet());
+
+		if (auctionIds.isEmpty()) {
+			return Set.of();
+		}
+		return new HashSet<>(reviewRepository.findReviewedAuctionIds(reviewerId, auctionIds));
+	}
+
+	private Set<ReviewProductKey> loadRegularReviewKeys(
+		List<Purchase> purchases,
+		Map<Long, AuctionPayment> auctionPaymentsByPurchaseId
+	) {
+		Set<Long> buyerIds = purchases.stream()
+			.map(Purchase::getBuyerId)
+			.collect(Collectors.toSet());
+		Set<Long> productIds = purchases.stream()
+			.filter(purchase -> !auctionPaymentsByPurchaseId.containsKey(purchase.getPurchaseId()))
+			.map(Purchase::getProductId)
+			.collect(Collectors.toSet());
+
+		if (buyerIds.isEmpty() || productIds.isEmpty()) {
+			return Set.of();
+		}
+		return reviewRepository.findRegularReviewsByReviewersAndProducts(buyerIds, productIds).stream()
+			.map(review -> new ReviewProductKey(review.getReviewerId(), review.getProductId()))
+			.collect(Collectors.toSet());
+	}
+
+	private Set<ReviewAuctionKey> loadAuctionReviewKeys(
+		List<Purchase> purchases,
+		Map<Long, AuctionPayment> auctionPaymentsByPurchaseId
+	) {
+		Set<Long> buyerIds = purchases.stream()
+			.map(Purchase::getBuyerId)
+			.collect(Collectors.toSet());
+		Set<Long> auctionIds = auctionPaymentsByPurchaseId.values().stream()
+			.map(payment -> payment.getAuction().getAuctionId())
+			.collect(Collectors.toSet());
+
+		if (buyerIds.isEmpty() || auctionIds.isEmpty()) {
+			return Set.of();
+		}
+		return reviewRepository.findAuctionReviewsByReviewersAndAuctions(buyerIds, auctionIds).stream()
+			.map(review -> new ReviewAuctionKey(review.getReviewerId(), review.getAuctionId()))
+			.collect(Collectors.toSet());
+	}
+
+	private MyPurchaseItemResponse toMyPurchaseItemResponse(
+		Purchase purchase,
+		Product product,
+		AuctionPayment auctionPayment,
+		Set<Long> reviewedRegularProductIds,
+		Set<Long> reviewedAuctionIds
+	) {
+		Long auctionId = auctionPayment == null ? null : auctionPayment.getAuction().getAuctionId();
+		ProductSaleType productType = product == null ? null : product.getSaleType();
+		boolean reviewWritten = auctionId == null
+			? reviewedRegularProductIds.contains(purchase.getProductId())
+			: reviewedAuctionIds.contains(auctionId);
+		boolean completed = purchase.getStatus() == PurchaseStatus.COMPLETED;
 		return new MyPurchaseItemResponse(
 			purchase.getPurchaseId(),
 			purchase.getProductId(),
@@ -390,11 +515,32 @@ public class PurchaseService {
 			toWalletAmount(purchase.getPriceSnapshot()),
 			purchase.getStatus(),
 			toSeoulOffsetDateTime(purchase.getPurchasedAt()),
-			purchase.getChatRoomId()
+			purchase.getChatRoomId(),
+			productType,
+			auctionId,
+			purchase.getShippedAt() != null,
+			purchase.getBuyerCompletedAt() != null,
+			completed,
+			toSeoulOffsetDateTime(purchase.getShippedAt()),
+			toSeoulOffsetDateTime(purchase.getCompletedAt()),
+			reviewWritten,
+			completed && !reviewWritten
 		);
 	}
 
-	private MySaleItemResponse toMySaleItemResponse(Purchase purchase, Product product) {
+	private MySaleItemResponse toMySaleItemResponse(
+		Purchase purchase,
+		Product product,
+		AuctionPayment auctionPayment,
+		Set<ReviewProductKey> regularReviewKeys,
+		Set<ReviewAuctionKey> auctionReviewKeys
+	) {
+		Long auctionId = auctionPayment == null ? null : auctionPayment.getAuction().getAuctionId();
+		ProductSaleType productType = product == null ? null : product.getSaleType();
+		boolean reviewReceived = auctionId == null
+			? regularReviewKeys.contains(new ReviewProductKey(purchase.getBuyerId(), purchase.getProductId()))
+			: auctionReviewKeys.contains(new ReviewAuctionKey(purchase.getBuyerId(), auctionId));
+		boolean completed = purchase.getStatus() == PurchaseStatus.COMPLETED;
 		return new MySaleItemResponse(
 			purchase.getPurchaseId(),
 			purchase.getProductId(),
@@ -404,7 +550,15 @@ public class PurchaseService {
 			toWalletAmount(purchase.getPriceSnapshot()),
 			purchase.getStatus(),
 			toSeoulOffsetDateTime(purchase.getPurchasedAt()),
-			purchase.getChatRoomId()
+			purchase.getChatRoomId(),
+			productType,
+			auctionId,
+			purchase.getShippedAt() != null,
+			purchase.getBuyerCompletedAt() != null,
+			completed,
+			toSeoulOffsetDateTime(purchase.getShippedAt()),
+			toSeoulOffsetDateTime(purchase.getCompletedAt()),
+			reviewReceived
 		);
 	}
 
@@ -691,5 +845,11 @@ public class PurchaseService {
 			return null;
 		}
 		return dateTime.atZone(SEOUL_ZONE).toOffsetDateTime();
+	}
+
+	private record ReviewProductKey(Long reviewerId, Long productId) {
+	}
+
+	private record ReviewAuctionKey(Long reviewerId, Long auctionId) {
 	}
 }

--- a/src/main/java/com/dealit/dealit/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/dealit/dealit/domain/review/repository/ReviewRepository.java
@@ -2,6 +2,8 @@ package com.dealit.dealit.domain.review.repository;
 
 import com.dealit.dealit.domain.review.dto.ReviewRatingSummaryResponse;
 import com.dealit.dealit.domain.review.entity.Review;
+import java.util.Collection;
+import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -17,6 +19,56 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
 	Page<Review> findAllByRevieweeIdAndDeletedAtIsNull(Long revieweeId, Pageable pageable);
 
 	Page<Review> findAllByReviewerIdAndDeletedAtIsNull(Long reviewerId, Pageable pageable);
+
+	@Query("""
+		select r.productId
+		from Review r
+		where r.reviewerId = :reviewerId
+		  and r.productId in :productIds
+		  and r.auctionId is null
+		  and r.deletedAt is null
+		""")
+	List<Long> findReviewedRegularProductIds(
+		@Param("reviewerId") Long reviewerId,
+		@Param("productIds") Collection<Long> productIds
+	);
+
+	@Query("""
+		select r.auctionId
+		from Review r
+		where r.reviewerId = :reviewerId
+		  and r.auctionId in :auctionIds
+		  and r.deletedAt is null
+		""")
+	List<Long> findReviewedAuctionIds(
+		@Param("reviewerId") Long reviewerId,
+		@Param("auctionIds") Collection<Long> auctionIds
+	);
+
+	@Query("""
+		select r
+		from Review r
+		where r.reviewerId in :reviewerIds
+		  and r.productId in :productIds
+		  and r.auctionId is null
+		  and r.deletedAt is null
+		""")
+	List<Review> findRegularReviewsByReviewersAndProducts(
+		@Param("reviewerIds") Collection<Long> reviewerIds,
+		@Param("productIds") Collection<Long> productIds
+	);
+
+	@Query("""
+		select r
+		from Review r
+		where r.reviewerId in :reviewerIds
+		  and r.auctionId in :auctionIds
+		  and r.deletedAt is null
+		""")
+	List<Review> findAuctionReviewsByReviewersAndAuctions(
+		@Param("reviewerIds") Collection<Long> reviewerIds,
+		@Param("auctionIds") Collection<Long> auctionIds
+	);
 
 	@Query("""
 		select new com.dealit.dealit.domain.review.dto.ReviewRatingSummaryResponse(

--- a/src/main/java/com/dealit/dealit/domain/review/service/ReviewService.java
+++ b/src/main/java/com/dealit/dealit/domain/review/service/ReviewService.java
@@ -121,6 +121,9 @@ public class ReviewService {
 		if (!reviewerId.equals(auction.getWinnerId())) {
 			throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Only the winning bidder can review this auction.");
 		}
+		if (!existsCompletedPurchase(product.getProductId(), product.getMemberId(), reviewerId)) {
+			throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Only the completed buyer can review this auction.");
+		}
 		return new ReviewTarget(product, auction.getAuctionId(), product.getMemberId());
 	}
 

--- a/src/test/java/com/dealit/dealit/domain/purchase/PurchaseIntegrationTest.java
+++ b/src/test/java/com/dealit/dealit/domain/purchase/PurchaseIntegrationTest.java
@@ -13,6 +13,7 @@ import com.dealit.dealit.domain.purchase.entity.Purchase;
 import com.dealit.dealit.domain.purchase.entity.PurchaseStatus;
 import com.dealit.dealit.domain.purchase.repository.PurchaseRepository;
 import com.dealit.dealit.domain.purchase.service.PurchaseService;
+import com.dealit.dealit.domain.review.repository.ReviewRepository;
 import com.dealit.dealit.domain.wallet.entity.WalletLedgerType;
 import com.dealit.dealit.domain.wallet.repository.WalletLedgerRepository;
 import com.dealit.dealit.domain.wallet.repository.WalletRepository;
@@ -62,6 +63,9 @@ class PurchaseIntegrationTest {
 	private PurchaseRepository purchaseRepository;
 
 	@Autowired
+	private ReviewRepository reviewRepository;
+
+	@Autowired
 	private ProductPaymentRepository productPaymentRepository;
 
 	@Autowired
@@ -85,6 +89,7 @@ class PurchaseIntegrationTest {
 
 	@BeforeEach
 	void setUp() {
+		reviewRepository.deleteAll();
 		notificationRepository.deleteAll();
 		productPaymentRepository.deleteAll();
 		purchaseRepository.deleteAll();
@@ -602,6 +607,15 @@ class PurchaseIntegrationTest {
 			.andExpect(jsonPath("$.content[0].status").value("PAID"))
 			.andExpect(jsonPath("$.content[0].purchasedAt").exists())
 			.andExpect(jsonPath("$.content[0].chatRoomId").isNumber())
+			.andExpect(jsonPath("$.content[0].productType").value("REGULAR"))
+			.andExpect(jsonPath("$.content[0].auctionId").doesNotExist())
+			.andExpect(jsonPath("$.content[0].sellerShipped").value(false))
+			.andExpect(jsonPath("$.content[0].buyerConfirmed").value(false))
+			.andExpect(jsonPath("$.content[0].completed").value(false))
+			.andExpect(jsonPath("$.content[0].shippedAt").doesNotExist())
+			.andExpect(jsonPath("$.content[0].completedAt").doesNotExist())
+			.andExpect(jsonPath("$.content[0].reviewWritten").value(false))
+			.andExpect(jsonPath("$.content[0].reviewAvailable").value(false))
 			.andExpect(jsonPath("$.page").value(0))
 			.andExpect(jsonPath("$.size").value(20))
 			.andExpect(jsonPath("$.totalElements").value(1))
@@ -668,10 +682,71 @@ class PurchaseIntegrationTest {
 			.andExpect(jsonPath("$.content[0].status").value("PAID"))
 			.andExpect(jsonPath("$.content[0].purchasedAt").exists())
 			.andExpect(jsonPath("$.content[0].chatRoomId").isNumber())
+			.andExpect(jsonPath("$.content[0].productType").value("REGULAR"))
+			.andExpect(jsonPath("$.content[0].auctionId").doesNotExist())
+			.andExpect(jsonPath("$.content[0].sellerShipped").value(false))
+			.andExpect(jsonPath("$.content[0].buyerConfirmed").value(false))
+			.andExpect(jsonPath("$.content[0].completed").value(false))
+			.andExpect(jsonPath("$.content[0].shippedAt").doesNotExist())
+			.andExpect(jsonPath("$.content[0].completedAt").doesNotExist())
+			.andExpect(jsonPath("$.content[0].reviewReceived").value(false))
 			.andExpect(jsonPath("$.page").value(0))
 			.andExpect(jsonPath("$.size").value(20))
 			.andExpect(jsonPath("$.totalElements").value(1))
 			.andExpect(jsonPath("$.hasNext").value(false));
+	}
+
+	@Test
+	@DisplayName("거래 완료 후 구매내역에는 리뷰 작성 가능 상태가 표시된다")
+	void completedPurchaseShowsReviewAvailable() throws Exception {
+		Product product = saveProduct(seller, ProductStatus.ON_SALE, BigDecimal.valueOf(30000));
+		walletService.charge(buyer.getMemberId(), 50000);
+		Long purchaseId = purchaseProduct(product, buyer);
+		completePurchase(purchaseId);
+
+		mockMvc.perform(get("/api/v1/mypage/purchases")
+				.with(authentication(authenticatedMember(buyer))))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.content[0].purchaseId").value(purchaseId))
+			.andExpect(jsonPath("$.content[0].status").value("COMPLETED"))
+			.andExpect(jsonPath("$.content[0].sellerShipped").value(true))
+			.andExpect(jsonPath("$.content[0].buyerConfirmed").value(true))
+			.andExpect(jsonPath("$.content[0].completed").value(true))
+			.andExpect(jsonPath("$.content[0].shippedAt").exists())
+			.andExpect(jsonPath("$.content[0].completedAt").exists())
+			.andExpect(jsonPath("$.content[0].reviewWritten").value(false))
+			.andExpect(jsonPath("$.content[0].reviewAvailable").value(true));
+	}
+
+	@Test
+	@DisplayName("리뷰 작성 후 구매/판매내역에는 리뷰 상태가 반영된다")
+	void reviewStateIsReflectedInMyPageLists() throws Exception {
+		Product product = saveProduct(seller, ProductStatus.ON_SALE, BigDecimal.valueOf(30000));
+		walletService.charge(buyer.getMemberId(), 50000);
+		Long purchaseId = purchaseProduct(product, buyer);
+		completePurchase(purchaseId);
+
+		mockMvc.perform(post("/api/v1/reviews")
+				.with(authentication(authenticatedMember(buyer)))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(reviewRequestJson(product.getProductId())))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.productId").value(product.getProductId()))
+			.andExpect(jsonPath("$.reviewerId").value(buyer.getMemberId()))
+			.andExpect(jsonPath("$.revieweeId").value(seller.getMemberId()));
+
+		mockMvc.perform(get("/api/v1/mypage/purchases")
+				.with(authentication(authenticatedMember(buyer))))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.content[0].purchaseId").value(purchaseId))
+			.andExpect(jsonPath("$.content[0].reviewWritten").value(true))
+			.andExpect(jsonPath("$.content[0].reviewAvailable").value(false));
+
+		mockMvc.perform(get("/api/v1/mypage/sales")
+				.with(authentication(authenticatedMember(seller))))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.content[0].purchaseId").value(purchaseId))
+			.andExpect(jsonPath("$.content[0].reviewReceived").value(true));
 	}
 
 	@Test
@@ -774,6 +849,17 @@ class PurchaseIntegrationTest {
 		return purchaseRepository.findAll().getFirst().getPurchaseId();
 	}
 
+	private void completePurchase(Long purchaseId) throws Exception {
+		mockMvc.perform(post("/api/v1/purchases/{purchaseId}/ship", purchaseId)
+				.with(authentication(authenticatedMember(seller))))
+			.andExpect(status().isOk());
+
+		mockMvc.perform(post("/api/v1/purchases/{purchaseId}/buyer-complete", purchaseId)
+				.with(authentication(authenticatedMember(buyer))))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.status").value("COMPLETED"));
+	}
+
 	private int performConcurrentPurchase(
 		Long productId,
 		Member buyer,
@@ -798,6 +884,16 @@ class PurchaseIntegrationTest {
 			  "idempotencyKey": "%s"
 			}
 			""".formatted(idempotencyKey);
+	}
+
+	private String reviewRequestJson(Long productId) {
+		return """
+			{
+			  "productId": %d,
+			  "rating": 5.0,
+			  "content": "Great transaction."
+			}
+			""".formatted(productId);
 	}
 
 	private UsernamePasswordAuthenticationToken authenticatedMember(Member member) {


### PR DESCRIPTION
🚀 Summary
기존 마이페이지 구매내역/판매내역 API 응답에 거래 카드 표시용 필드를 추가했습니다.

✨ Description
기존 API는 유지하고, 새 API를 만들지 않았습니다.

- `GET /api/v1/mypage/purchases`
- `GET /api/v1/mypage/sales`

구매내역 응답 아이템에 아래 필드를 추가했습니다.

- `productType`
- `auctionId`
- `sellerShipped`
- `buyerConfirmed`
- `completed`
- `shippedAt`
- `completedAt`
- `reviewWritten`
- `reviewAvailable`

판매내역 응답 아이템에 아래 필드를 추가했습니다.

- `productType`
- `auctionId`
- `sellerShipped`
- `buyerConfirmed`
- `completed`
- `shippedAt`
- `completedAt`
- `reviewReceived`

구현 내용은 다음과 같습니다.

- 구매/판매내역은 기존처럼 `Purchase`를 기준으로 조회합니다.
- 경매 거래 정보는 `purchaseId -> AuctionPayment -> Auction` 기준으로 보강합니다.
- 리뷰 상태는 `Review`를 배치 조회해 N+1 조회를 피하도록 처리했습니다.
- 판매내역의 `reviewReceived`는 판매자가 아니라 구매자 기준으로 계산합니다.
  - `reviewerId = purchase.getBuyerId()`
- 빈 목록 조회 시 `IN ()` 쿼리가 발생하지 않도록 빈 컬렉션은 `Map.of()` / `Set.of()`로 처리했습니다.
- 경매 리뷰 작성 조건을 보강했습니다.
  - 기존 낙찰 성공 여부뿐 아니라 연결된 `Purchase`가 `COMPLETED` 상태일 때만 리뷰 작성이 가능하도록 변경했습니다.

테스트도 함께 보강했습니다.

- 기존 구매내역 조회 테스트에 새 필드 검증 추가
- 기존 판매내역 조회 테스트에 새 필드 검증 추가
- 거래 완료 후 구매내역의 `reviewAvailable=true` 검증 추가
- 리뷰 작성 후 구매내역의 `reviewWritten=true`, `reviewAvailable=false` 검증 추가
- 리뷰 작성 후 판매내역의 `reviewReceived=true` 검증 추가

🎲 Issue Number close #{Issue Number}