### PR TITLE
[chore] 백엔드 CD 파이프라인 구축

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,7 @@ name: Deploy backend
 on:
   push:
     branches:
-      - dev
+      - develop
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,103 @@
+name: Deploy backend
+
+on:
+  push:
+    branches:
+      - dev
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: backend-production
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "21"
+          cache: gradle
+
+      - name: Run tests
+        run: ./gradlew test --no-daemon
+
+  build-and-deploy:
+    name: Build and deploy
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set image name
+        run: |
+          echo "BACKEND_IMAGE_REPOSITORY=ghcr.io/${GITHUB_REPOSITORY,,}" >> "$GITHUB_ENV"
+          echo "BACKEND_IMAGE=ghcr.io/${GITHUB_REPOSITORY,,}:latest" >> "$GITHUB_ENV"
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push backend image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: |
+            ${{ env.BACKEND_IMAGE }}
+            ${{ env.BACKEND_IMAGE_REPOSITORY }}:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Copy production compose file
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.DEPLOY_HOST }}
+          username: ${{ secrets.DEPLOY_USER }}
+          key: ${{ secrets.DEPLOY_SSH_KEY }}
+          port: ${{ secrets.DEPLOY_PORT || 22 }}
+          source: docker-compose.prod.yml
+          target: ${{ secrets.DEPLOY_PATH }}
+
+      - name: Deploy on server
+        uses: appleboy/ssh-action@v1.0.3
+        env:
+          BACKEND_IMAGE: ${{ env.BACKEND_IMAGE }}
+        with:
+          host: ${{ secrets.DEPLOY_HOST }}
+          username: ${{ secrets.DEPLOY_USER }}
+          key: ${{ secrets.DEPLOY_SSH_KEY }}
+          port: ${{ secrets.DEPLOY_PORT || 22 }}
+          envs: BACKEND_IMAGE
+          script: |
+            set -e
+            cd "${{ secrets.DEPLOY_PATH }}"
+            touch .env
+            docker login ghcr.io -u "${{ github.actor }}" -p "${{ secrets.GITHUB_TOKEN }}"
+            if grep -q '^BACKEND_IMAGE=' .env; then
+              sed -i "s|^BACKEND_IMAGE=.*|BACKEND_IMAGE=${BACKEND_IMAGE}|" .env
+            else
+              printf '\nBACKEND_IMAGE=%s\n' "${BACKEND_IMAGE}" >> .env
+            fi
+            docker compose -f docker-compose.prod.yml pull backend
+            docker compose -f docker-compose.prod.yml up -d --build
+            docker image prune -f
+            curl --fail --silent --show-error http://localhost:${SERVER_PORT:-8080}/actuator/health

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -7,7 +7,7 @@ services:
       POSTGRES_USER: ${DB_USERNAME}
       POSTGRES_PASSWORD: ${DB_PASSWORD}
     ports:
-      - "${DB_PORT:-5432}:5432"
+      - "${DB_BIND_HOST:-127.0.0.1}:${DB_PORT:-5432}:5432"
     volumes:
       - postgres-data:/var/lib/postgresql/data
     healthcheck:
@@ -21,7 +21,7 @@ services:
     image: redis:7.4-alpine
     container_name: dealit-redis
     ports:
-      - "${REDIS_PORT:-6379}:6379"
+      - "${REDIS_BIND_HOST:-127.0.0.1}:${REDIS_PORT:-6379}:6379"
     volumes:
       - redis-data:/data
     healthcheck:
@@ -39,7 +39,7 @@ services:
       DISABLE_SECURITY_PLUGIN: "true"
       OPENSEARCH_JAVA_OPTS: "-Xms512m -Xmx512m"
     ports:
-      - "${OPENSEARCH_PORT:-9200}:9200"
+      - "${OPENSEARCH_BIND_HOST:-127.0.0.1}:${OPENSEARCH_PORT:-9200}:9200"
     volumes:
       - opensearch-data:/usr/share/opensearch/data
     healthcheck:
@@ -123,7 +123,7 @@ services:
       OPENSEARCH_INDEX_NAME: ${OPENSEARCH_INDEX_NAME:-dealit-search}
       AI_CATEGORY_RECOMMENDATION_BASE_URL: ${AI_CATEGORY_RECOMMENDATION_BASE_URL:-http://ai:8000}
     ports:
-      - "${SERVER_PORT:-8080}:8080"
+      - "${BACKEND_BIND_HOST:-127.0.0.1}:${SERVER_PORT:-8080}:8080"
     volumes:
       - ./secrets:/app/secrets:ro
       - ./uploads:/app/uploads

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,153 @@
+services:
+  postgres:
+    image: postgres:16
+    container_name: dealit-postgres
+    environment:
+      POSTGRES_DB: ${DB_NAME}
+      POSTGRES_USER: ${DB_USERNAME}
+      POSTGRES_PASSWORD: ${DB_PASSWORD}
+    ports:
+      - "${DB_PORT:-5432}:5432"
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${DB_USERNAME} -d ${DB_NAME}"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+    restart: unless-stopped
+
+  redis:
+    image: redis:7.4-alpine
+    container_name: dealit-redis
+    ports:
+      - "${REDIS_PORT:-6379}:6379"
+    volumes:
+      - redis-data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+    restart: unless-stopped
+
+  opensearch:
+    image: opensearchproject/opensearch:2.18.0
+    container_name: dealit-opensearch
+    environment:
+      discovery.type: single-node
+      DISABLE_SECURITY_PLUGIN: "true"
+      OPENSEARCH_JAVA_OPTS: "-Xms512m -Xmx512m"
+    ports:
+      - "${OPENSEARCH_PORT:-9200}:9200"
+    volumes:
+      - opensearch-data:/usr/share/opensearch/data
+    healthcheck:
+      test: ["CMD-SHELL", "curl --fail --silent http://localhost:9200/_cluster/health || exit 1"]
+      interval: 15s
+      timeout: 5s
+      retries: 20
+    restart: unless-stopped
+
+  ai:
+    build:
+      context: ../AI
+      dockerfile: Dockerfile
+    container_name: dealit-ai
+    env_file:
+      - ../AI/.env
+    expose:
+      - "8000"
+    healthcheck:
+      test: ["CMD-SHELL", "python -c \"import urllib.request; urllib.request.urlopen('http://localhost:8000/api/v1/health', timeout=5)\""]
+      interval: 15s
+      timeout: 5s
+      retries: 10
+    restart: unless-stopped
+
+  backend:
+    image: ${BACKEND_IMAGE}
+    container_name: dealit-backend
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      ai:
+        condition: service_healthy
+    environment:
+      SPRING_PROFILES_ACTIVE: docker
+      DB_HOST: postgres
+      DB_PORT: 5432
+      DB_NAME: ${DB_NAME}
+      DB_USERNAME: ${DB_USERNAME}
+      DB_PASSWORD: ${DB_PASSWORD}
+      REDIS_HOST: redis
+      REDIS_PORT: 6379
+      SERVER_PORT: ${SERVER_PORT:-8080}
+      JPA_DDL_AUTO: ${JPA_DDL_AUTO:-validate}
+      JPA_SHOW_SQL: ${JPA_SHOW_SQL:-false}
+      JPA_FORMAT_SQL: ${JPA_FORMAT_SQL:-false}
+      HIBERNATE_SQL_LOG_LEVEL: ${HIBERNATE_SQL_LOG_LEVEL:-info}
+      JWT_SECRET: ${JWT_SECRET}
+      JWT_ACCESS_TOKEN_EXPIRATION_MS: ${JWT_ACCESS_TOKEN_EXPIRATION_MS:-3600000}
+      JWT_ISSUER: ${JWT_ISSUER:-dealit}
+      KAKAO_REST_API_KEY: ${KAKAO_REST_API_KEY}
+      KAKAO_LOCAL_BASE_URL: ${KAKAO_LOCAL_BASE_URL:-https://dapi.kakao.com}
+      APP_MAIL_HOST: ${APP_MAIL_HOST:-}
+      APP_MAIL_PORT: ${APP_MAIL_PORT:-587}
+      APP_MAIL_USERNAME: ${APP_MAIL_USERNAME:-}
+      APP_MAIL_PASSWORD: ${APP_MAIL_PASSWORD:-}
+      APP_MAIL_PROTOCOL: ${APP_MAIL_PROTOCOL:-smtp}
+      APP_MAIL_AUTH: ${APP_MAIL_AUTH:-true}
+      APP_MAIL_STARTTLS_ENABLE: ${APP_MAIL_STARTTLS_ENABLE:-true}
+      APP_EMAIL_VERIFICATION_SENDER_ADDRESS: ${APP_EMAIL_VERIFICATION_SENDER_ADDRESS:-}
+      APP_CORS_ALLOWED_ORIGINS: ${APP_CORS_ALLOWED_ORIGINS}
+      APP_EVENTS_SSE_REDIS_ENABLED: ${APP_EVENTS_SSE_REDIS_ENABLED:-true}
+      APP_EVENTS_SSE_REDIS_CHANNEL: ${APP_EVENTS_SSE_REDIS_CHANNEL:-dealit:events:sse-events}
+      APP_IMAGES_PUBLIC_BASE_URL: ${APP_IMAGES_PUBLIC_BASE_URL}
+      APP_IMAGES_STORAGE_ROOT: ${APP_IMAGES_STORAGE_ROOT:-/app/uploads}
+      APP_IMAGES_STORAGE_TYPE: ${APP_IMAGES_STORAGE_TYPE:-local}
+      AWS_REGION: ${AWS_REGION:-ap-northeast-2}
+      AWS_S3_BUCKET: ${AWS_S3_BUCKET:-}
+      AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID:-}
+      AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY:-}
+      FIREBASE_ENABLED: ${FIREBASE_ENABLED:-false}
+      FIREBASE_PROJECT_ID: ${FIREBASE_PROJECT_ID:-dealit-f6b55}
+      FIREBASE_SERVICE_ACCOUNT_PATH: ${FIREBASE_SERVICE_ACCOUNT_PATH:-}
+      FIREBASE_SERVICE_ACCOUNT_JSON: ${FIREBASE_SERVICE_ACCOUNT_JSON:-}
+      FIREBASE_SERVICE_ACCOUNT_BASE64: ${FIREBASE_SERVICE_ACCOUNT_BASE64:-}
+      OPENSEARCH_ENABLED: ${OPENSEARCH_ENABLED:-true}
+      OPENSEARCH_AUTO_REINDEX_ON_STARTUP: ${OPENSEARCH_AUTO_REINDEX_ON_STARTUP:-true}
+      OPENSEARCH_URI: ${OPENSEARCH_URI:-http://opensearch:9200}
+      OPENSEARCH_INDEX_NAME: ${OPENSEARCH_INDEX_NAME:-dealit-search}
+      AI_CATEGORY_RECOMMENDATION_BASE_URL: ${AI_CATEGORY_RECOMMENDATION_BASE_URL:-http://ai:8000}
+    ports:
+      - "${SERVER_PORT:-8080}:8080"
+    volumes:
+      - ./secrets:/app/secrets:ro
+      - ./uploads:/app/uploads
+    healthcheck:
+      test: ["CMD-SHELL", "curl --fail --silent http://localhost:8080/actuator/health || exit 1"]
+      interval: 15s
+      timeout: 5s
+      retries: 10
+    restart: unless-stopped
+
+  nginx:
+    image: nginx:1.29-alpine
+    container_name: dealit-nginx
+    depends_on:
+      backend:
+        condition: service_healthy
+    ports:
+      - "${NGINX_PORT:-80}:80"
+    volumes:
+      - ./nginx/nginx.conf:/etc/nginx/conf.d/default.conf:ro
+      - ./nginx/logs:/var/log/nginx
+    restart: unless-stopped
+
+volumes:
+  postgres-data:
+  redis-data:
+  opensearch-data:

--- a/docs/cd-guide.md
+++ b/docs/cd-guide.md
@@ -1,6 +1,6 @@
 # CD Guide
 
-이 문서는 `dev` 브랜치에 merge되면 GitHub Actions가 backend Docker 이미지를 빌드하고 AWS 서버에서 자동 배포하도록 구성하는 절차입니다.
+이 문서는 `develop` 브랜치에 merge되면 GitHub Actions가 backend Docker 이미지를 빌드하고 AWS 서버에서 자동 배포하도록 구성하는 절차입니다.
 
 ## 1. AWS 서버 준비
 
@@ -70,12 +70,12 @@ mkdir -p nginx/logs secrets uploads
 
 `nginx/nginx.conf`는 현재 repo의 파일을 서버에 복사해 둡니다.
 
-그 다음 GitHub Actions의 `Deploy backend` workflow를 수동 실행하거나, `dev` 브랜치에 merge하면 자동 배포됩니다.
+그 다음 GitHub Actions의 `Deploy backend` workflow를 수동 실행하거나, `develop` 브랜치에 merge하면 자동 배포됩니다.
 
 ## 5. 배포 흐름
 
 ```text
-dev push/merge
+develop push/merge
 -> ./gradlew test
 -> Docker image build
 -> ghcr.io/...:latest push

--- a/docs/cd-guide.md
+++ b/docs/cd-guide.md
@@ -41,9 +41,15 @@ APP_IMAGES_PUBLIC_BASE_URL=https://api.dealit.site
 JPA_DDL_AUTO=validate
 NGINX_PORT=80
 SERVER_PORT=8080
+DB_BIND_HOST=127.0.0.1
+REDIS_BIND_HOST=127.0.0.1
+OPENSEARCH_BIND_HOST=127.0.0.1
+BACKEND_BIND_HOST=127.0.0.1
 ```
 
 AI는 현재 서버 구성과 동일하게 `../AI` 디렉터리의 Dockerfile로 빌드합니다. 따라서 `DEPLOY_PATH`의 부모 디렉터리에 `AI` 디렉터리가 있어야 합니다.
+
+PostgreSQL, Redis, OpenSearch, backend는 컨테이너 간 Docker 내부 네트워크 또는 서버 로컬 health check로 접근하므로 운영 compose에서는 기본적으로 호스트의 `127.0.0.1`에만 바인딩합니다. 외부 접속이 필요하면 AWS Security Group과 서비스 인증 설정을 먼저 점검한 뒤 별도 값으로 열어야 합니다.
 
 ## 3. GitHub Secrets
 

--- a/docs/cd-guide.md
+++ b/docs/cd-guide.md
@@ -1,0 +1,96 @@
+# CD Guide
+
+이 문서는 `dev` 브랜치에 merge되면 GitHub Actions가 backend Docker 이미지를 빌드하고 AWS 서버에서 자동 배포하도록 구성하는 절차입니다.
+
+## 1. AWS 서버 준비
+
+서버에는 Docker와 Docker Compose plugin이 설치되어 있어야 합니다.
+
+배포 디렉터리를 만들고 repo에서 필요한 운영 파일을 둡니다. 현재 서버에서 `docker-compose up -d --build`를 실행한 backend 디렉터리가 `DEPLOY_PATH`입니다.
+
+현재 서버 구조가 `~/AI`, `~/Backend`라면 `DEPLOY_PATH`는 `/home/ec2-user/Backend`입니다.
+
+서버의 `~/dealit/backend`에는 최소한 아래 파일/디렉터리가 필요합니다.
+
+```text
+.env
+docker-compose.prod.yml
+nginx/nginx.conf
+nginx/logs/
+secrets/
+uploads/
+```
+
+`docker-compose.prod.yml`은 GitHub Actions가 배포 때마다 복사합니다.
+
+## 2. 서버 .env 예시
+
+서버의 `.env`에는 운영 secret을 직접 둡니다. 이 파일은 GitHub에 올리지 않습니다.
+
+```dotenv
+BACKEND_IMAGE=ghcr.io/OWNER/REPOSITORY:latest
+
+DB_NAME=dealit
+DB_USERNAME=dealit
+DB_PASSWORD=change-me
+JWT_SECRET=change-me-to-long-random-secret
+
+APP_CORS_ALLOWED_ORIGINS=https://your-frontend-domain.com
+APP_IMAGES_PUBLIC_BASE_URL=https://api.dealit.site
+
+JPA_DDL_AUTO=validate
+NGINX_PORT=80
+SERVER_PORT=8080
+```
+
+AI는 현재 서버 구성과 동일하게 `../AI` 디렉터리의 Dockerfile로 빌드합니다. 따라서 `DEPLOY_PATH`의 부모 디렉터리에 `AI` 디렉터리가 있어야 합니다.
+
+## 3. GitHub Secrets
+
+GitHub repository settings > Secrets and variables > Actions에 아래 secret을 등록합니다.
+
+```text
+DEPLOY_HOST       # 15.134.165.112 또는 api.dealit.site
+DEPLOY_USER       # ec2-user
+DEPLOY_SSH_KEY    # private key 내용 전체
+DEPLOY_PORT       # 보통 22
+DEPLOY_PATH       # /home/ec2-user/Backend
+```
+
+GHCR push는 기본 `GITHUB_TOKEN`을 사용하므로 별도 token이 필요 없습니다.
+
+## 4. 최초 1회 실행
+
+서버에서 최초 1회만 필요한 디렉터리를 만듭니다.
+
+```bash
+cd /home/ec2-user/Backend
+mkdir -p nginx/logs secrets uploads
+```
+
+`nginx/nginx.conf`는 현재 repo의 파일을 서버에 복사해 둡니다.
+
+그 다음 GitHub Actions의 `Deploy backend` workflow를 수동 실행하거나, `dev` 브랜치에 merge하면 자동 배포됩니다.
+
+## 5. 배포 흐름
+
+```text
+dev push/merge
+-> ./gradlew test
+-> Docker image build
+-> ghcr.io/...:latest push
+-> AWS 서버에 docker-compose.prod.yml 복사
+-> 서버 .env의 BACKEND_IMAGE 갱신
+-> docker compose pull backend
+-> docker compose up -d --build
+-> /actuator/health 확인
+```
+
+## 6. 서버에서 상태 확인
+
+```bash
+cd /home/ec2-user/Backend
+docker compose -f docker-compose.prod.yml ps
+docker compose -f docker-compose.prod.yml logs -f backend
+curl http://localhost:8080/actuator/health
+```

--- a/src/main/java/com/dealit/dealit/domain/auction/service/AuctionService.java
+++ b/src/main/java/com/dealit/dealit/domain/auction/service/AuctionService.java
@@ -313,7 +313,7 @@ public class AuctionService {
 	public ReauctionResponse reauction(Long memberId, Long auctionId, CreateAuctionRequest request) {
 		validateReauctionRequestBySaleType(request);
 		validateCategorySelection(request.categoryId());
-		Member member = loadActiveMember(memberId);
+		Member member = loadVerifiedMember(memberId);
 		Auction sourceAuction = loadReauctionCandidate(memberId, auctionId);
 		Product sourceProduct = sourceAuction.getProduct();
 		OffsetDateTime now = OffsetDateTime.now(clock);
@@ -813,7 +813,7 @@ public class AuctionService {
 	public CreateAuctionResponse createAuction(Long memberId, CreateAuctionRequest request) {
 		validateRequestBySaleType(request);
 		validateCategorySelection(request.categoryId());
-		Member member = loadActiveMember(memberId);
+		Member member = loadVerifiedMember(memberId);
 		OffsetDateTime now = OffsetDateTime.now(clock);
 		AuctionPeriod auctionPeriod = resolveAuctionPeriod(request, now);
 		BigDecimal minimumBidAmount = resolveMinimumBidAmount(request.startPrice(), request.minimumBidAmount());

--- a/src/main/resources/application-docker.yml
+++ b/src/main/resources/application-docker.yml
@@ -1,4 +1,6 @@
 spring:
+  config:
+    import: optional:file:.env[.properties]
   datasource:
     url: jdbc:postgresql://${DB_HOST:postgres}:${DB_PORT:5432}/${DB_NAME:dealit}
     username: ${DB_USERNAME:dealit}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,4 +1,6 @@
 spring:
+  config:
+    import: optional:file:.env.local[.properties]
   datasource:
     url: jdbc:postgresql://${DB_HOST:localhost}:${DB_PORT:5432}/${DB_NAME:dealit}
     username: ${DB_USERNAME:dealit}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,8 +1,6 @@
 spring:
   application:
     name: dealit
-  config:
-    import: optional:file:.env[.properties]
   profiles:
     default: local
   servlet:

--- a/src/test/java/com/dealit/dealit/domain/auction/AuctionIntegrationTest.java
+++ b/src/test/java/com/dealit/dealit/domain/auction/AuctionIntegrationTest.java
@@ -144,7 +144,7 @@ class AuctionIntegrationTest {
 			.andExpect(jsonPath("$.content[0].description").value("Includes dock and controller."))
 			.andExpect(jsonPath("$.content[0].categoryName").value("사무용노트북"))
 			.andExpect(jsonPath("$.content[0].thumbnailUrl").value("http://localhost:8080/uploads/auction/images/test-image.jpg"))
-			.andExpect(jsonPath("$.content[0].auctionStatus").value("AUCTION_LIVE"))
+			.andExpect(jsonPath("$.content[0].auctionStatus").value("ONGOING"))
 			.andExpect(jsonPath("$.content[0].startPrice").value(180000))
 			.andExpect(jsonPath("$.content[0].minimumBidAmount").value(1800))
 			.andExpect(jsonPath("$.content[0].currentPrice").value(180000))
@@ -366,8 +366,8 @@ class AuctionIntegrationTest {
 			.andExpect(status().isCreated())
 			.andExpect(jsonPath("$.productId").isNumber())
 			.andExpect(jsonPath("$.saleType").value("AUCTION"))
-			.andExpect(jsonPath("$.status").value("AUCTION_LIVE"))
-			.andExpect(jsonPath("$.auction.status").value("AUCTION_LIVE"))
+			.andExpect(jsonPath("$.status").value("ONGOING"))
+			.andExpect(jsonPath("$.auction.status").value("ONGOING"))
 			.andExpect(jsonPath("$.auction.startAt").value(notNullValue()))
 			.andExpect(jsonPath("$.auction.endAt").value(notNullValue()));
 	}
@@ -643,7 +643,7 @@ class AuctionIntegrationTest {
 			.andExpect(jsonPath("$.startAt").value(notNullValue()))
 			.andExpect(jsonPath("$.endsAt").value(notNullValue()))
 			.andExpect(jsonPath("$.serverTime").value(notNullValue()))
-			.andExpect(jsonPath("$.status").value("AUCTION_LIVE"));
+			.andExpect(jsonPath("$.status").value("ONGOING"));
 	}
 
 	@Test
@@ -696,7 +696,7 @@ class AuctionIntegrationTest {
 					}
 					"""))
 			.andExpect(status().isBadRequest())
-			.andExpect(jsonPath("$.code").value("INVALID_AUCTION_REQUEST"))
+			.andExpect(jsonPath("$.code").value("BID_PRICE_BELOW_MINIMUM"))
 			.andExpect(jsonPath("$.message").value("최소 입찰 금액을 충족해야 합니다."));
 	}
 
@@ -728,7 +728,7 @@ class AuctionIntegrationTest {
 					""".formatted(uploadedImage.getImageId())))
 			.andExpect(status().isBadRequest())
 			.andExpect(jsonPath("$.code").value("INVALID_AUCTION_REQUEST"))
-			.andExpect(jsonPath("$.message").value("경매 판매에서는 진행 기간이 필수입니다."));
+			.andExpect(jsonPath("$.message").value("경매 판매에서는 진행 기간 또는 종료 시각이 필수입니다."));
 	}
 
 	private void deleteStoredImages() throws IOException {

--- a/src/test/java/com/dealit/dealit/domain/member/ProfileIntegrationTest.java
+++ b/src/test/java/com/dealit/dealit/domain/member/ProfileIntegrationTest.java
@@ -407,7 +407,7 @@ class ProfileIntegrationTest {
 			.andExpect(jsonPath("$.profileImageUrl").value(startsWith("http://localhost:8080/uploads/profile/images/")));
 
 		Member updatedMember = memberRepository.findById(savedMember.getMemberId()).orElseThrow();
-		assertThat(updatedMember.getProfileImage()).endsWith(".jpg");
+		assertThat(updatedMember.getProfileImage()).endsWith(".png");
 	}
 
 	@Test

--- a/src/test/java/com/dealit/dealit/domain/product/PopularProductIntegrationTest.java
+++ b/src/test/java/com/dealit/dealit/domain/product/PopularProductIntegrationTest.java
@@ -71,7 +71,7 @@ class PopularProductIntegrationTest {
 		));
 		ReflectionTestUtils.setField(lowScoreProduct, "createdAt", LocalDateTime.now().minusHours(10));
 		ReflectionTestUtils.setField(lowScoreProduct, "updatedAt", LocalDateTime.now().minusHours(10));
-		for (int count = 0; count < 20; count++) {
+		for (int count = 0; count < 10; count++) {
 			lowScoreProduct.increaseViewCount();
 		}
 		productRepository.save(lowScoreProduct);
@@ -115,7 +115,7 @@ class PopularProductIntegrationTest {
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.content", hasSize(2)))
 			.andExpect(jsonPath("$.content[0].name").value("최근 인기 상품"))
-			.andExpect(jsonPath("$.content[0].popularScore").value(6.0))
+			.andExpect(jsonPath("$.content[0].popularScore").value(12.0))
 			.andExpect(jsonPath("$.content[1].name").value("오래된 인기 상품"));
 	}
 }

--- a/src/test/java/com/dealit/dealit/domain/product/ProductIntegrationTest.java
+++ b/src/test/java/com/dealit/dealit/domain/product/ProductIntegrationTest.java
@@ -210,9 +210,9 @@ class ProductIntegrationTest {
 			.getResponse()
 			.getContentAsString();
 
-		long productId = com.jayway.jsonpath.JsonPath.read(response, "$.productId");
+		Number productId = com.jayway.jsonpath.JsonPath.read(response, "$.productId");
 
-		mockMvc.perform(patch("/api/v1/products/{productId}", productId)
+		mockMvc.perform(patch("/api/v1/products/{productId}", productId.longValue())
 				.with(authentication(authenticatedMember()))
 				.contentType(MediaType.APPLICATION_JSON)
 				.content("""

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -39,5 +39,6 @@ app:
   images:
     public-base-url: http://localhost:8080
     storage-root: ${java.io.tmpdir}/dealit-test-uploads
+    storage-type: local
   firebase:
     enabled: false


### PR DESCRIPTION
### 🚀 Summary

<!-- 작업 내용에 대한 간략한 설명을 써주세요. -->
-CD 구축
---

### ✨ Description

<!-- 상세한 설명, 기능의 사용법, 주의 사항 실행 결과(이미지 첨부 가능) 등을 보여주세요. -->
## 작업 내용

- GitHub Actions 기반 백엔드 CD workflow 추가
- develop 브랜치 push/merge 시 테스트, Docker 이미지 빌드, GHCR push, AWS EC2 배포 수행
- 운영 서버용 `docker-compose.prod.yml` 추가
- 로컬/test/docker profile 별 env 로딩 방식 분리
- 테스트가 로컬/운영 환경변수에 흔들리지 않도록 test 설정 보강
- 경매 등록 시 이메일 미인증 회원이 등록 가능한 문제 수정
- 변경된 도메인 응답에 맞춰 테스트 기대값 수정

## 배포 흐름

```text
develop merge
-> ./gradlew test
-> backend Docker image build
-> GHCR push
-> EC2 SSH 접속
-> docker-compose.prod.yml 복사
-> docker compose pull backend
-> docker compose up -d --build
-> /actuator/health 확인
---

### 🎲 Issue Number

<!-- Please enter {Issue Number} below to automatically close the connected issue. -->

close #104 
