### PR TITLE
[feat] AI가격추천 백엔드 연동

### DIFF
--- a/src/main/java/com/dealit/dealit/domain/auction/service/AuctionService.java
+++ b/src/main/java/com/dealit/dealit/domain/auction/service/AuctionService.java
@@ -47,6 +47,9 @@ import com.dealit.dealit.domain.category.dto.CategoryRecommendationResult;
 import com.dealit.dealit.domain.category.service.CategoryRecommendationService;
 import com.dealit.dealit.domain.member.exception.EmailNotVerifiedException;
 import com.dealit.dealit.domain.member.repository.MemberRepository;
+import com.dealit.dealit.domain.price.client.AiPriceRecommendationClient;
+import com.dealit.dealit.domain.price.dto.AiPriceRecommendationRequest;
+import com.dealit.dealit.domain.price.dto.AiPriceRecommendationResponse;
 import com.dealit.dealit.domain.product.ProductStatus;
 import com.dealit.dealit.domain.product.entity.Product;
 import com.dealit.dealit.domain.product.entity.ProductImage;
@@ -100,6 +103,7 @@ public class AuctionService {
 	private final AuctionImageStorage auctionImageStorage;
 	private final ImageUrlService imageUrlService;
 	private final CategoryRecommendationService categoryRecommendationService;
+	private final AiPriceRecommendationClient aiPriceRecommendationClient;
 	private final ObjectMapper objectMapper;
 	private final AuctionRedisService auctionRedisService;
 	private final Clock clock;
@@ -800,10 +804,16 @@ public class AuctionService {
 	}
 
 	public RecommendPriceResponse recommendPrice(RecommendPriceRequest request) {
-		int textWeight = request.name().trim().length() * 10 + request.description().trim().length() * 2;
-		BigDecimal recommendedPrice = BigDecimal.valueOf(Math.max(10000, textWeight * 100L));
+		AiPriceRecommendationResponse response = aiPriceRecommendationClient.recommend(
+			AiPriceRecommendationRequest.of(
+				request.name().trim(),
+				request.description().trim(),
+				request.saleType().name()
+			)
+		);
+		BigDecimal recommendedPrice = BigDecimal.valueOf(response.suggestedPrice());
 		if (request.saleType() == ProductSaleType.AUCTION) {
-			BigDecimal startPrice = recommendedPrice.multiply(BigDecimal.valueOf(0.7)).setScale(0, RoundingMode.DOWN);
+			BigDecimal startPrice = BigDecimal.valueOf(response.suggestedPriceMin());
 			return new RecommendPriceResponse(recommendedPrice, startPrice);
 		}
 		return new RecommendPriceResponse(recommendedPrice, null);

--- a/src/main/java/com/dealit/dealit/domain/price/client/AiPriceRecommendationClient.java
+++ b/src/main/java/com/dealit/dealit/domain/price/client/AiPriceRecommendationClient.java
@@ -1,0 +1,63 @@
+package com.dealit.dealit.domain.price.client;
+
+import com.dealit.dealit.domain.category.client.AiCategoryRecommendationProperties;
+import com.dealit.dealit.domain.price.dto.AiPriceRecommendationRequest;
+import com.dealit.dealit.domain.price.dto.AiPriceRecommendationResponse;
+import com.dealit.dealit.domain.price.exception.PriceRecommendationException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestClientResponseException;
+
+@Component
+public class AiPriceRecommendationClient {
+
+	private final RestClient restClient;
+
+	public AiPriceRecommendationClient(
+		AiCategoryRecommendationProperties properties,
+		RestClient.Builder restClientBuilder
+	) {
+		this.restClient = restClientBuilder
+			.baseUrl(properties.normalizedBaseUrl())
+			.build();
+	}
+
+	public AiPriceRecommendationResponse recommend(AiPriceRecommendationRequest request) {
+		try {
+			AiPriceRecommendationResponse response = restClient
+				.post()
+				.uri("/api/v1/recommendations/prices")
+				.contentType(MediaType.APPLICATION_JSON)
+				.accept(MediaType.APPLICATION_JSON)
+				.body(request)
+				.retrieve()
+				.body(AiPriceRecommendationResponse.class);
+
+			if (response == null) {
+				throw new PriceRecommendationException(
+					"PRICE_RECOMMENDATION_EMPTY_RESPONSE",
+					"AI 가격 추천 응답이 비어 있습니다.",
+					HttpStatus.BAD_GATEWAY
+				);
+			}
+
+			return response;
+		} catch (RestClientResponseException exception) {
+			throw new PriceRecommendationException(
+				"PRICE_RECOMMENDATION_FAILED",
+				"AI 가격 추천 호출에 실패했습니다. status=%d, body=%s"
+					.formatted(exception.getStatusCode().value(), exception.getResponseBodyAsString()),
+				HttpStatus.BAD_GATEWAY
+			);
+		} catch (RestClientException exception) {
+			throw new PriceRecommendationException(
+				"PRICE_RECOMMENDATION_FAILED",
+				"AI 가격 추천 호출에 실패했습니다.",
+				HttpStatus.BAD_GATEWAY
+			);
+		}
+	}
+}

--- a/src/main/java/com/dealit/dealit/domain/price/dto/AiPriceRecommendationRequest.java
+++ b/src/main/java/com/dealit/dealit/domain/price/dto/AiPriceRecommendationRequest.java
@@ -1,0 +1,25 @@
+package com.dealit.dealit.domain.price.dto;
+
+import java.util.List;
+
+public record AiPriceRecommendationRequest(
+	String title,
+	String description,
+	Long categoryId,
+	String categoryName,
+	String saleType,
+	List<String> imageUrls,
+	List<AiRecentPriceRequest> recentPrices
+) {
+	public static AiPriceRecommendationRequest of(String title, String description, String saleType) {
+		return new AiPriceRecommendationRequest(
+			title,
+			description,
+			null,
+			null,
+			saleType,
+			List.of(),
+			List.of()
+		);
+	}
+}

--- a/src/main/java/com/dealit/dealit/domain/price/dto/AiPriceRecommendationResponse.java
+++ b/src/main/java/com/dealit/dealit/domain/price/dto/AiPriceRecommendationResponse.java
@@ -1,0 +1,12 @@
+package com.dealit.dealit.domain.price.dto;
+
+public record AiPriceRecommendationResponse(
+	Long suggestedPriceMin,
+	Long suggestedPrice,
+	Long suggestedPriceMax,
+	Double confidence,
+	String reason,
+	java.util.List<String> factors,
+	String modelVersion
+) {
+}

--- a/src/main/java/com/dealit/dealit/domain/price/dto/AiRecentPriceRequest.java
+++ b/src/main/java/com/dealit/dealit/domain/price/dto/AiRecentPriceRequest.java
@@ -1,0 +1,8 @@
+package com.dealit.dealit.domain.price.dto;
+
+public record AiRecentPriceRequest(
+	Long price,
+	String title,
+	String soldAt
+) {
+}

--- a/src/main/java/com/dealit/dealit/domain/price/exception/PriceRecommendationException.java
+++ b/src/main/java/com/dealit/dealit/domain/price/exception/PriceRecommendationException.java
@@ -1,0 +1,17 @@
+package com.dealit.dealit.domain.price.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class PriceRecommendationException extends RuntimeException {
+
+	private final String code;
+	private final HttpStatus status;
+
+	public PriceRecommendationException(String code, String message, HttpStatus status) {
+		super(message);
+		this.code = code;
+		this.status = status;
+	}
+}

--- a/src/main/java/com/dealit/dealit/domain/product/service/ProductService.java
+++ b/src/main/java/com/dealit/dealit/domain/product/service/ProductService.java
@@ -10,6 +10,9 @@ import com.dealit.dealit.domain.member.entity.Member;
 import com.dealit.dealit.domain.member.exception.EmailNotVerifiedException;
 import com.dealit.dealit.domain.member.repository.MemberInterestCategoryRepository;
 import com.dealit.dealit.domain.member.repository.MemberRepository;
+import com.dealit.dealit.domain.price.client.AiPriceRecommendationClient;
+import com.dealit.dealit.domain.price.dto.AiPriceRecommendationRequest;
+import com.dealit.dealit.domain.price.dto.AiPriceRecommendationResponse;
 import com.dealit.dealit.domain.product.ProductSaleType;
 import com.dealit.dealit.domain.product.ProductStatus;
 import com.dealit.dealit.domain.product.dto.CategoryOptionResponse;
@@ -93,6 +96,7 @@ public class ProductService {
 	private final ProductImageStorage productImageStorage;
 	private final ImageUrlService imageUrlService;
 	private final CategoryRecommendationService categoryRecommendationService;
+	private final AiPriceRecommendationClient aiPriceRecommendationClient;
 	private final ObjectMapper objectMapper;
 	private final ApplicationEventPublisher applicationEventPublisher;
 
@@ -434,9 +438,14 @@ public class ProductService {
 			throw new InvalidProductRequestException("일반 상품 가격 추천에서는 saleType이 REGULAR여야 합니다.");
 		}
 
-		int textWeight = request.name().trim().length() * 10 + request.description().trim().length() * 2;
-		BigDecimal recommendedPrice = BigDecimal.valueOf(Math.max(10000, textWeight * 100L));
-		return new RecommendPriceResponse(recommendedPrice);
+		AiPriceRecommendationResponse response = aiPriceRecommendationClient.recommend(
+			AiPriceRecommendationRequest.of(
+				request.name().trim(),
+				request.description().trim(),
+				request.saleType().name()
+			)
+		);
+		return new RecommendPriceResponse(BigDecimal.valueOf(response.suggestedPrice()));
 	}
 
 	@Transactional

--- a/src/main/java/com/dealit/dealit/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/dealit/dealit/global/error/GlobalExceptionHandler.java
@@ -14,6 +14,7 @@ import com.dealit.dealit.domain.member.exception.DuplicateMemberException;
 import com.dealit.dealit.domain.member.exception.DuplicateNicknameException;
 import com.dealit.dealit.domain.member.exception.MemberException;
 import com.dealit.dealit.domain.notification.exception.NotificationException;
+import com.dealit.dealit.domain.price.exception.PriceRecommendationException;
 import com.dealit.dealit.domain.product.exception.ProductException;
 import com.dealit.dealit.domain.purchase.exception.PurchaseException;
 import com.dealit.dealit.domain.wallet.exception.WalletException;
@@ -130,6 +131,12 @@ public class GlobalExceptionHandler {
 
 	@ExceptionHandler(CategoryRecommendationException.class)
 	public ResponseEntity<ErrorResponse> handleCategoryRecommendationException(CategoryRecommendationException exception) {
+		return ResponseEntity.status(exception.getStatus())
+			.body(ErrorResponse.of(exception.getStatus().value(), exception.getCode(), exception.getMessage(), List.of()));
+	}
+
+	@ExceptionHandler(PriceRecommendationException.class)
+	public ResponseEntity<ErrorResponse> handlePriceRecommendationException(PriceRecommendationException exception) {
 		return ResponseEntity.status(exception.getStatus())
 			.body(ErrorResponse.of(exception.getStatus().value(), exception.getCode(), exception.getMessage(), List.of()));
 	}


### PR DESCRIPTION
## 요약
  - 가격 추천 API가 기존 더미 계산 대신 AI 서버 `/api/v1/recommendations/prices`를 호출하도록 연동
  - 기존 `AI_CATEGORY_RECOMMENDATION_BASE_URL` 설정을 재사용해 별도 env 추가 없이 동작하도록 구현
  - 일반 상품/경매 상품의 기존 프론트 응답 형식은 유지

  ## 변경 사항
  - `AiPriceRecommendationClient` 추가
  - AI 가격 추천 요청/응답 DTO 추가
  - 가격 추천 실패 예외 및 글로벌 예외 처리 추가
  - 일반 상품 가격 추천은 `suggestedPrice`를 `recommendedPrice`로 반환
  - 경매 가격 추천은 `suggestedPrice`를 `recommendedPrice`, `suggestedPriceMin`을 `startPrice`로 반환

### 🎲 Issue Number

<!-- Please enter {Issue Number} below to automatically close the connected issue. -->

close #110 
