### PR TITLE
[chore] RDS 연동

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -81,12 +81,14 @@ jobs:
         uses: appleboy/ssh-action@v1.0.3
         env:
           BACKEND_IMAGE: ${{ env.BACKEND_IMAGE }}
+          RDS_DB_HOST: ${{ secrets.RDS_DB_HOST }}
+          RDS_DB_PASSWORD: ${{ secrets.RDS_DB_PASSWORD }}
         with:
           host: ${{ secrets.DEPLOY_HOST }}
           username: ${{ secrets.DEPLOY_USER }}
           key: ${{ secrets.DEPLOY_SSH_KEY }}
           port: ${{ secrets.DEPLOY_PORT || 22 }}
-          envs: BACKEND_IMAGE
+          envs: BACKEND_IMAGE,RDS_DB_HOST,RDS_DB_PASSWORD
           script: |
             set -e
             cd "${{ secrets.DEPLOY_PATH }}"
@@ -104,6 +106,16 @@ jobs:
               sed -i "s|^BACKEND_IMAGE=.*|BACKEND_IMAGE=${BACKEND_IMAGE}|" .env
             else
               printf '\nBACKEND_IMAGE=%s\n' "${BACKEND_IMAGE}" >> .env
+            fi
+            if grep -q '^DB_HOST=' .env; then
+              sed -i "s|^DB_HOST=.*|DB_HOST=${RDS_DB_HOST}|" .env
+            else
+              printf '\nDB_HOST=%s\n' "${RDS_DB_HOST}" >> .env
+            fi
+            if grep -q '^DB_PASSWORD=' .env; then
+              sed -i "s|^DB_PASSWORD=.*|DB_PASSWORD=${RDS_DB_PASSWORD}|" .env
+            else
+              printf '\nDB_PASSWORD=%s\n' "${RDS_DB_PASSWORD}" >> .env
             fi
             $COMPOSE -f docker-compose.prod.yml pull backend
             $COMPOSE -f docker-compose.prod.yml up -d --build --remove-orphans

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,22 +1,4 @@
 services:
-  postgres:
-    image: postgres:16
-    container_name: dealit-postgres
-    environment:
-      POSTGRES_DB: ${DB_NAME}
-      POSTGRES_USER: ${DB_USERNAME}
-      POSTGRES_PASSWORD: ${DB_PASSWORD}
-    ports:
-      - "${DB_BIND_HOST:-127.0.0.1}:${DB_PORT:-5432}:5432"
-    volumes:
-      - postgres-data:/var/lib/postgresql/data
-    healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${DB_USERNAME} -d ${DB_NAME}"]
-      interval: 10s
-      timeout: 5s
-      retries: 10
-    restart: unless-stopped
-
   redis:
     image: redis:7.4-alpine
     container_name: dealit-redis
@@ -69,16 +51,14 @@ services:
     image: ${BACKEND_IMAGE}
     container_name: dealit-backend
     depends_on:
-      postgres:
-        condition: service_healthy
       redis:
         condition: service_healthy
       ai:
         condition: service_healthy
     environment:
       SPRING_PROFILES_ACTIVE: docker
-      DB_HOST: postgres
-      DB_PORT: 5432
+      DB_HOST: ${DB_HOST}
+      DB_PORT: ${DB_PORT:-5432}
       DB_NAME: ${DB_NAME}
       DB_USERNAME: ${DB_USERNAME}
       DB_PASSWORD: ${DB_PASSWORD}
@@ -135,6 +115,5 @@ services:
     restart: unless-stopped
 
 volumes:
-  postgres-data:
   redis-data:
   opensearch-data:


### PR DESCRIPTION
### 🚀 Summary

AWS RDS PostgreSQL 연동을 위한 운영 배포 설정을 변경했습니다.

---

### ✨ Description
- 운영 배포용 `docker-compose.prod.yml`에서 기존 PostgreSQL 컨테이너 구성을 제거했습니다.
- 백엔드 컨테이너가 `DB_HOST`, `DB_PORT` 값을 `.env`에서 읽도록 변경했습니다.
- GitHub Actions CD 과정에서 RDS 관련 Secrets 값을 EC2의 `.env`에 반영하도록 설정했습니다.
- RDS는 별도로 생성했으며, EC2에서 RDS PostgreSQL에 접근할 수 있도록 보안 그룹 인바운드 규칙을 추가했습니다.

주의 사항:
- `RDS_DB_HOST`, `RDS_DB_PASSWORD` Repository Secrets가 설정되어 있어야 정상 배포됩니다.
- merge 후 develop 배포가 실행되면 EC2의 DB 연결 대상이 RDS로 변경됩니다.

---

### 🎲 Issue Number

close #109