### PR TITLE
[refactor] RDS연동으로 인한 CD수정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -82,17 +82,43 @@ jobs:
         env:
           BACKEND_IMAGE: ${{ env.BACKEND_IMAGE }}
           RDS_DB_HOST: ${{ secrets.RDS_DB_HOST }}
+          RDS_DB_PORT: ${{ secrets.RDS_DB_PORT }}
+          RDS_DB_NAME: ${{ secrets.RDS_DB_NAME }}
+          RDS_DB_USERNAME: ${{ secrets.RDS_DB_USERNAME }}
           RDS_DB_PASSWORD: ${{ secrets.RDS_DB_PASSWORD }}
         with:
           host: ${{ secrets.DEPLOY_HOST }}
           username: ${{ secrets.DEPLOY_USER }}
           key: ${{ secrets.DEPLOY_SSH_KEY }}
           port: ${{ secrets.DEPLOY_PORT || 22 }}
-          envs: BACKEND_IMAGE,RDS_DB_HOST,RDS_DB_PASSWORD
+          envs: BACKEND_IMAGE,RDS_DB_HOST,RDS_DB_PORT,RDS_DB_NAME,RDS_DB_USERNAME,RDS_DB_PASSWORD
           script: |
             set -e
             cd "${{ secrets.DEPLOY_PATH }}"
             touch .env
+            set_env_var() {
+              key="$1"
+              value="$2"
+              if [ -z "$value" ]; then
+                echo "Required value for ${key} is empty."
+                exit 1
+              fi
+              tmp="$(mktemp)"
+              if grep -q "^${key}=" .env; then
+                awk -v key="$key" -v value="$value" 'BEGIN { prefix = key "=" } index($0, prefix) == 1 { $0 = prefix value } { print }' .env > "$tmp"
+                cat "$tmp" > .env
+              else
+                printf '\n%s=%s\n' "$key" "$value" >> .env
+              fi
+              rm -f "$tmp"
+            }
+            set_env_var_if_present() {
+              key="$1"
+              value="$2"
+              if [ -n "$value" ]; then
+                set_env_var "$key" "$value"
+              fi
+            }
             if docker compose version >/dev/null 2>&1; then
               COMPOSE="docker compose"
             elif command -v docker-compose >/dev/null 2>&1; then
@@ -102,21 +128,12 @@ jobs:
               exit 1
             fi
             docker login ghcr.io -u "${{ github.actor }}" -p "${{ secrets.GITHUB_TOKEN }}"
-            if grep -q '^BACKEND_IMAGE=' .env; then
-              sed -i "s|^BACKEND_IMAGE=.*|BACKEND_IMAGE=${BACKEND_IMAGE}|" .env
-            else
-              printf '\nBACKEND_IMAGE=%s\n' "${BACKEND_IMAGE}" >> .env
-            fi
-            if grep -q '^DB_HOST=' .env; then
-              sed -i "s|^DB_HOST=.*|DB_HOST=${RDS_DB_HOST}|" .env
-            else
-              printf '\nDB_HOST=%s\n' "${RDS_DB_HOST}" >> .env
-            fi
-            if grep -q '^DB_PASSWORD=' .env; then
-              sed -i "s|^DB_PASSWORD=.*|DB_PASSWORD=${RDS_DB_PASSWORD}|" .env
-            else
-              printf '\nDB_PASSWORD=%s\n' "${RDS_DB_PASSWORD}" >> .env
-            fi
+            set_env_var BACKEND_IMAGE "$BACKEND_IMAGE"
+            set_env_var DB_HOST "$RDS_DB_HOST"
+            set_env_var DB_PASSWORD "$RDS_DB_PASSWORD"
+            set_env_var_if_present DB_PORT "$RDS_DB_PORT"
+            set_env_var_if_present DB_NAME "$RDS_DB_NAME"
+            set_env_var_if_present DB_USERNAME "$RDS_DB_USERNAME"
             $COMPOSE -f docker-compose.prod.yml pull backend
             $COMPOSE -f docker-compose.prod.yml up -d --build --remove-orphans
             docker image prune -f

--- a/docs/cd-guide.md
+++ b/docs/cd-guide.md
@@ -30,6 +30,8 @@ BACKEND_IMAGE=ghcr.io/OWNER/REPOSITORY:latest
 
 DB_NAME=dealit
 DB_USERNAME=dealit
+DB_HOST=your-rds-endpoint.ap-northeast-2.rds.amazonaws.com
+DB_PORT=5432
 DB_PASSWORD=change-me
 JWT_SECRET=change-me-to-long-random-secret
 
@@ -38,7 +40,6 @@ APP_IMAGES_PUBLIC_BASE_URL=https://api.dealit.site
 
 JPA_DDL_AUTO=validate
 SERVER_PORT=8080
-DB_BIND_HOST=127.0.0.1
 REDIS_BIND_HOST=127.0.0.1
 OPENSEARCH_BIND_HOST=127.0.0.1
 BACKEND_BIND_HOST=127.0.0.1
@@ -46,7 +47,9 @@ BACKEND_BIND_HOST=127.0.0.1
 
 AI는 현재 서버 구성과 동일하게 `../AI` 디렉터리의 Dockerfile로 빌드합니다. 따라서 `DEPLOY_PATH`의 부모 디렉터리에 `AI` 디렉터리가 있어야 합니다.
 
-PostgreSQL, Redis, OpenSearch, backend는 컨테이너 간 Docker 내부 네트워크 또는 서버 로컬 health check로 접근하므로 운영 compose에서는 기본적으로 호스트의 `127.0.0.1`에만 바인딩합니다. 외부 접속이 필요하면 AWS Security Group과 서비스 인증 설정을 먼저 점검한 뒤 별도 값으로 열어야 합니다.
+운영 PostgreSQL은 Docker Compose로 띄우지 않고 AWS RDS에 연결합니다. Redis, OpenSearch, backend는 컨테이너 간 Docker 내부 네트워크 또는 서버 로컬 health check로 접근하므로 운영 compose에서는 기본적으로 호스트의 `127.0.0.1`에만 바인딩합니다. 외부 접속이 필요하면 AWS Security Group과 서비스 인증 설정을 먼저 점검한 뒤 별도 값으로 열어야 합니다.
+
+RDS 보안 그룹은 EC2에서 RDS PostgreSQL 5432 포트로 접근할 수 있어야 합니다.
 
 운영 HTTPS는 Docker nginx가 아니라 EC2 host nginx가 담당합니다. host nginx는 `api.dealit.site` 요청을 `http://127.0.0.1:8080`의 backend 컨테이너로 proxy합니다.
 
@@ -60,6 +63,16 @@ DEPLOY_USER       # ec2-user
 DEPLOY_SSH_KEY    # private key 내용 전체
 DEPLOY_PORT       # 보통 22
 DEPLOY_PATH       # /home/ec2-user/Backend
+RDS_DB_HOST       # RDS endpoint
+RDS_DB_PASSWORD   # RDS database password
+```
+
+아래 secret은 선택 값입니다. 설정하면 배포 때 서버 `.env`의 동일한 DB 항목을 갱신합니다.
+
+```text
+RDS_DB_PORT       # 기본값 5432를 쓰면 생략 가능
+RDS_DB_NAME       # 서버 .env 값을 유지하면 생략 가능
+RDS_DB_USERNAME   # 서버 .env 값을 유지하면 생략 가능
 ```
 
 GHCR push는 기본 `GITHUB_TOKEN`을 사용하므로 별도 token이 필요 없습니다.
@@ -84,6 +97,7 @@ develop push/merge
 -> ghcr.io/...:latest push
 -> AWS 서버에 docker-compose.prod.yml 복사
 -> 서버 .env의 BACKEND_IMAGE 갱신
+-> 서버 .env의 DB_HOST, DB_PASSWORD 갱신
 -> docker compose pull backend
 -> docker compose up -d --build
 -> /actuator/health 확인


### PR DESCRIPTION
### 🚀 Summary

<!-- 작업 내용에 대한 간략한 설명을 써주세요. -->
- workflow수정
---

### ✨ Description

<!-- 상세한 설명, 기능의 사용법, 주의 사항 실행 결과(이미지 첨부 가능) 등을 보여주세요. -->

운영 배포 시 GitHub Actions에서 RDS DB 접속 정보를 EC2 `.env`에 안정적으로 반영하도록 CD 스크립트를 개선했습니다.

- `RDS_DB_HOST`, `RDS_DB_PASSWORD`를 EC2 `.env`의 `DB_HOST`, `DB_PASSWORD`로 자동 반영합니다.
- RDS 비밀번호에 특수문자가 포함되어도 깨지지 않도록 기존 `sed` 치환 방식 대신 `awk` 기반 `.env` 갱신 함수로 변경했습니다.
- 선택 Secret이 설정된 경우 아래 값도 함께 반영되도록 했습니다.
  - `RDS_DB_PORT`
  - `RDS_DB_NAME`
  - `RDS_DB_USERNAME`
- `docs/cd-guide.md`에 운영 PostgreSQL이 Docker 컨테이너가 아닌 AWS RDS로 연결된다는 내용을 반영했습니다.

---

### 🎲 Issue Number

<!-- Please enter {Issue Number} below to automatically close the connected issue. -->

close #113 
