### PR TITLE
[fix] 리뷰 평점 연동

### DIFF
--- a/src/main/java/com/dealit/dealit/domain/product/dto/ProductDetailResponse.java
+++ b/src/main/java/com/dealit/dealit/domain/product/dto/ProductDetailResponse.java
@@ -79,7 +79,10 @@ public record ProductDetailResponse(
 		String profileImageUrl,
 
 		@Schema(description = "거래 위치", example = "서울 강남구")
-		String location
+		String location,
+
+		@Schema(description = "판매자 평균 평점", example = "4.5")
+		double rating
 	) {
 	}
 

--- a/src/main/java/com/dealit/dealit/domain/product/service/ProductDetailService.java
+++ b/src/main/java/com/dealit/dealit/domain/product/service/ProductDetailService.java
@@ -13,6 +13,8 @@ import com.dealit.dealit.domain.product.entity.ProductImage;
 import com.dealit.dealit.domain.product.exception.ProductNotFoundException;
 import com.dealit.dealit.domain.product.repository.ProductRepository;
 import com.dealit.dealit.domain.recentproduct.service.RecentProductService;
+import com.dealit.dealit.domain.review.dto.ReviewRatingSummaryResponse;
+import com.dealit.dealit.domain.review.repository.ReviewRepository;
 import com.dealit.dealit.global.service.ImageUrlService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -36,6 +38,7 @@ public class ProductDetailService {
 	private final MemberRepository memberRepository;
 	private final ImageUrlService imageUrlService;
 	private final RecentProductService recentProductService;
+	private final ReviewRepository reviewRepository;
 
 	@Transactional
 	public ProductDetailResponse getProductDetail(Long memberId, Long productId) {
@@ -101,8 +104,14 @@ public class ProductDetailService {
 			seller.getMemberId(),
 			seller.getNickname(),
 			profileImageUrl,
-			product.getLocation()
+			product.getLocation(),
+			getSellerRating(seller.getMemberId())
 		);
+	}
+
+	private double getSellerRating(Long sellerId) {
+		ReviewRatingSummaryResponse summary = reviewRepository.getRatingSummaryByRevieweeId(sellerId);
+		return Math.round(summary.averageRating() * 10.0) / 10.0;
 	}
 
 	private List<String> toImageUrls(Product product) {

--- a/src/main/java/com/dealit/dealit/domain/product/service/ProductDetailService.java
+++ b/src/main/java/com/dealit/dealit/domain/product/service/ProductDetailService.java
@@ -111,6 +111,9 @@ public class ProductDetailService {
 
 	private double getSellerRating(Long sellerId) {
 		ReviewRatingSummaryResponse summary = reviewRepository.getRatingSummaryByRevieweeId(sellerId);
+		if (summary == null) {
+			return 0.0;
+		}
 		return Math.round(summary.averageRating() * 10.0) / 10.0;
 	}
 

--- a/src/test/java/com/dealit/dealit/domain/product/ProductDetailIntegrationTest.java
+++ b/src/test/java/com/dealit/dealit/domain/product/ProductDetailIntegrationTest.java
@@ -6,6 +6,8 @@ import com.dealit.dealit.domain.product.entity.Product;
 import com.dealit.dealit.domain.product.entity.ProductImage;
 import com.dealit.dealit.domain.product.repository.ProductImageRepository;
 import com.dealit.dealit.domain.product.repository.ProductRepository;
+import com.dealit.dealit.domain.review.entity.Review;
+import com.dealit.dealit.domain.review.repository.ReviewRepository;
 import com.dealit.dealit.global.security.AuthenticatedMember;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -42,11 +44,15 @@ class ProductDetailIntegrationTest {
 	@Autowired
 	private MemberRepository memberRepository;
 
+	@Autowired
+	private ReviewRepository reviewRepository;
+
 	private Member seller;
 	private Member viewer;
 
 	@BeforeEach
 	void setUp() {
+		reviewRepository.deleteAll();
 		productImageRepository.deleteAll();
 		productRepository.deleteAll();
 		memberRepository.deleteAll();
@@ -95,6 +101,7 @@ class ProductDetailIntegrationTest {
 			.andExpect(jsonPath("$.seller.memberId").value(seller.getMemberId()))
 			.andExpect(jsonPath("$.seller.nickname").value(seller.getNickname()))
 			.andExpect(jsonPath("$.seller.location").value("Seoul Gangnam"))
+			.andExpect(jsonPath("$.seller.rating").value(0.0))
 			.andExpect(jsonPath("$.generalSale.price").value(12000))
 			.andExpect(jsonPath("$.generalSale.viewCount").value(1))
 			.andExpect(jsonPath("$.generalSale.favoriteCount").value(0))
@@ -104,6 +111,41 @@ class ProductDetailIntegrationTest {
 			.andExpect(jsonPath("$.canPurchase").value(true))
 			.andExpect(jsonPath("$.purchaseBlockedReason").doesNotExist())
 			.andExpect(jsonPath("$.canFavorite").value(true));
+	}
+
+	@Test
+	@DisplayName("상품 상세 조회 시 판매자가 받은 리뷰 평균 평점을 반환한다")
+	void getRegularProductDetailReturnsSellerRating() throws Exception {
+		Product product = saveRegularProduct();
+		Member anotherBuyer = memberRepository.save(Member.create(
+			"detail-another-buyer",
+			"password",
+			"another-buyer@example.com",
+			null,
+			"Detail Another Buyer",
+			true
+		));
+		reviewRepository.save(Review.create(
+			viewer.getMemberId(),
+			seller.getMemberId(),
+			product.getProductId(),
+			null,
+			BigDecimal.valueOf(5.0),
+			"Great transaction."
+		));
+		reviewRepository.save(Review.create(
+			anotherBuyer.getMemberId(),
+			seller.getMemberId(),
+			product.getProductId(),
+			null,
+			BigDecimal.valueOf(4.0),
+			"Good transaction."
+		));
+
+		mockMvc.perform(get("/api/v1/products/{productId}", product.getProductId())
+				.with(authentication(authenticatedMember(viewer))))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.seller.rating").value(4.5));
 	}
 
 	@Test


### PR DESCRIPTION
### 🚀 Summary

<!-- 작업 내용에 대한 간략한 설명을 써주세요. -->

---

### ✨ Description
- 일반 상품 상세 응답의 `seller.rating` 필드 추가
- 판매자 ID 기준 리뷰 평균 평점을 조회해 상품 상세 응답에 매핑
- 상품 상세 통합 테스트에 판매자 평점 검증 추가
---

### 🎲 Issue Number

<!-- Please enter {Issue Number} below to automatically close the connected issue. -->

close #{Issue Number}
