### PR TITLE
[fix] 경매 상세 페이지 리뷰 연동

### DIFF
--- a/src/main/java/com/dealit/dealit/domain/auction/dto/AuctionDetailResponse.java
+++ b/src/main/java/com/dealit/dealit/domain/auction/dto/AuctionDetailResponse.java
@@ -39,6 +39,7 @@ public record AuctionDetailResponse(
 		Long memberId,
 		String nickname,
 		String profileImageUrl,
+		String bio,
 		double rating
 	) {
 	}

--- a/src/main/java/com/dealit/dealit/domain/auction/dto/AuctionDetailResponse.java
+++ b/src/main/java/com/dealit/dealit/domain/auction/dto/AuctionDetailResponse.java
@@ -38,7 +38,8 @@ public record AuctionDetailResponse(
 	public record SellerResponse(
 		Long memberId,
 		String nickname,
-		String profileImageUrl
+		String profileImageUrl,
+		double rating
 	) {
 	}
 }

--- a/src/main/java/com/dealit/dealit/domain/auction/service/AuctionBidService.java
+++ b/src/main/java/com/dealit/dealit/domain/auction/service/AuctionBidService.java
@@ -407,7 +407,13 @@ public class AuctionBidService {
 		String profileImageUrl = seller.getProfileImage() == null || seller.getProfileImage().isBlank()
 			? null
 			: imageUrlService.toPublicUrl(seller.getProfileImage());
-		return new SellerResponse(seller.getMemberId(), seller.getNickname(), profileImageUrl, getSellerRating(seller.getMemberId()));
+		return new SellerResponse(
+			seller.getMemberId(),
+			seller.getNickname(),
+			profileImageUrl,
+			seller.getIntro(),
+			getSellerRating(seller.getMemberId())
+		);
 	}
 
 	private double getSellerRating(Long sellerId) {

--- a/src/main/java/com/dealit/dealit/domain/auction/service/AuctionBidService.java
+++ b/src/main/java/com/dealit/dealit/domain/auction/service/AuctionBidService.java
@@ -35,6 +35,8 @@ import com.dealit.dealit.domain.product.entity.Product;
 import com.dealit.dealit.domain.product.entity.ProductImage;
 import com.dealit.dealit.domain.purchase.service.PurchaseService;
 import com.dealit.dealit.domain.recentproduct.service.RecentProductService;
+import com.dealit.dealit.domain.review.dto.ReviewRatingSummaryResponse;
+import com.dealit.dealit.domain.review.repository.ReviewRepository;
 import com.dealit.dealit.domain.search.event.AuctionSearchDeleteRequestedEvent;
 import com.dealit.dealit.domain.search.event.AuctionSearchIndexRequestedEvent;
 import com.dealit.dealit.domain.wallet.service.WalletService;
@@ -76,6 +78,7 @@ public class AuctionBidService {
 	private final WishlistService wishlistService;
 	private final ImageUrlService imageUrlService;
 	private final RecentProductService recentProductService;
+	private final ReviewRepository reviewRepository;
 	private final Clock clock;
 
 	public AuctionDetailResponse getAuction(Long auctionId) {
@@ -404,7 +407,15 @@ public class AuctionBidService {
 		String profileImageUrl = seller.getProfileImage() == null || seller.getProfileImage().isBlank()
 			? null
 			: imageUrlService.toPublicUrl(seller.getProfileImage());
-		return new SellerResponse(seller.getMemberId(), seller.getNickname(), profileImageUrl);
+		return new SellerResponse(seller.getMemberId(), seller.getNickname(), profileImageUrl, getSellerRating(seller.getMemberId()));
+	}
+
+	private double getSellerRating(Long sellerId) {
+		ReviewRatingSummaryResponse summary = reviewRepository.getRatingSummaryByRevieweeId(sellerId);
+		if (summary == null) {
+			return 0.0;
+		}
+		return Math.round(summary.averageRating() * 10.0) / 10.0;
 	}
 
 	private String resolveBidderNickname(Member bidder, Long bidderId) {

--- a/src/main/java/com/dealit/dealit/domain/product/dto/ProductDetailResponse.java
+++ b/src/main/java/com/dealit/dealit/domain/product/dto/ProductDetailResponse.java
@@ -78,6 +78,9 @@ public record ProductDetailResponse(
 		@Schema(description = "판매자 프로필 이미지 URL", example = "https://api.dealit.site/uploads/profile/images/3-profile.png", nullable = true)
 		String profileImageUrl,
 
+		@Schema(description = "판매자 소개글", example = "Good seller.", nullable = true)
+		String bio,
+
 		@Schema(description = "거래 위치", example = "서울 강남구")
 		String location,
 

--- a/src/main/java/com/dealit/dealit/domain/product/service/ProductDetailService.java
+++ b/src/main/java/com/dealit/dealit/domain/product/service/ProductDetailService.java
@@ -104,6 +104,7 @@ public class ProductDetailService {
 			seller.getMemberId(),
 			seller.getNickname(),
 			profileImageUrl,
+			seller.getIntro(),
 			product.getLocation(),
 			getSellerRating(seller.getMemberId())
 		);

--- a/src/test/java/com/dealit/dealit/domain/auction/AuctionBidServiceTest.java
+++ b/src/test/java/com/dealit/dealit/domain/auction/AuctionBidServiceTest.java
@@ -38,6 +38,7 @@ import com.dealit.dealit.domain.product.ProductStatus;
 import com.dealit.dealit.domain.product.entity.Product;
 import com.dealit.dealit.domain.purchase.service.PurchaseService;
 import com.dealit.dealit.domain.recentproduct.service.RecentProductService;
+import com.dealit.dealit.domain.review.repository.ReviewRepository;
 import com.dealit.dealit.domain.wallet.service.WalletService;
 import com.dealit.dealit.domain.wishlist.service.WishlistService;
 import com.dealit.dealit.global.service.ImageUrlService;
@@ -81,6 +82,7 @@ class AuctionBidServiceTest {
 	private final WishlistService wishlistService = mock(WishlistService.class);
 	private final ImageUrlService imageUrlService = mock(ImageUrlService.class);
 	private final RecentProductService recentProductService = mock(RecentProductService.class);
+	private final ReviewRepository reviewRepository = mock(ReviewRepository.class);
 
 	private final AuctionBidService auctionBidService = new AuctionBidService(
 		auctionRepository,
@@ -98,6 +100,7 @@ class AuctionBidServiceTest {
 		wishlistService,
 		imageUrlService,
 		recentProductService,
+		reviewRepository,
 		FIXED_CLOCK
 	);
 

--- a/src/test/java/com/dealit/dealit/domain/auction/AuctionIntegrationTest.java
+++ b/src/test/java/com/dealit/dealit/domain/auction/AuctionIntegrationTest.java
@@ -95,6 +95,12 @@ class AuctionIntegrationTest {
 		);
 		Member savedMember = memberRepository.save(member);
 		savedMember.assignDefaultNickname();
+		savedMember.updateProfile(
+			savedMember.getName(),
+			savedMember.getNickname(),
+			"Auction seller bio.",
+			savedMember.getProfileImage()
+		);
 		savedMember.verifyEmail();
 		savedMember = memberRepository.save(savedMember);
 		accessToken = jwtService.generateAccessToken(savedMember);
@@ -662,6 +668,7 @@ class AuctionIntegrationTest {
 			.andExpect(jsonPath("$.images[0].sortOrder").value(1))
 			.andExpect(jsonPath("$.seller.memberId").isNumber())
 			.andExpect(jsonPath("$.seller.nickname").value(startsWith("Dealit#")))
+			.andExpect(jsonPath("$.seller.bio").value("Auction seller bio."))
 			.andExpect(jsonPath("$.seller.rating").value(4.5))
 			.andExpect(jsonPath("$.startPrice").value(180000))
 			.andExpect(jsonPath("$.currentPrice").value(180000))

--- a/src/test/java/com/dealit/dealit/domain/auction/AuctionIntegrationTest.java
+++ b/src/test/java/com/dealit/dealit/domain/auction/AuctionIntegrationTest.java
@@ -6,6 +6,8 @@ import com.dealit.dealit.domain.member.repository.MemberRepository;
 import com.dealit.dealit.domain.product.entity.ProductImage;
 import com.dealit.dealit.domain.product.repository.ProductImageRepository;
 import com.dealit.dealit.domain.product.repository.ProductRepository;
+import com.dealit.dealit.domain.review.entity.Review;
+import com.dealit.dealit.domain.review.repository.ReviewRepository;
 import com.dealit.dealit.global.security.jwt.JwtService;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -21,6 +23,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.io.IOException;
+import java.math.BigDecimal;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
@@ -60,6 +63,9 @@ class AuctionIntegrationTest {
 	private MemberRepository memberRepository;
 
 	@Autowired
+	private ReviewRepository reviewRepository;
+
+	@Autowired
 	private PasswordEncoder passwordEncoder;
 
 	@Autowired
@@ -73,6 +79,7 @@ class AuctionIntegrationTest {
 
 	@BeforeEach
 	void setUp() throws IOException {
+		reviewRepository.deleteAll();
 		auctionRepository.deleteAll();
 		productImageRepository.deleteAll();
 		productRepository.deleteAll();
@@ -617,6 +624,27 @@ class AuctionIntegrationTest {
 			.andExpect(status().isCreated());
 
 		Long auctionId = auctionRepository.findAll().getFirst().getAuctionId();
+		var product = productRepository.findAll().getFirst();
+		Long productId = product.getProductId();
+		Long sellerId = product.getMemberId();
+		Member firstReviewer = saveReviewMember("auction-reviewer-one", "auction-reviewer-one@dealit.com");
+		Member secondReviewer = saveReviewMember("auction-reviewer-two", "auction-reviewer-two@dealit.com");
+		reviewRepository.save(Review.create(
+			firstReviewer.getMemberId(),
+			sellerId,
+			productId,
+			auctionId,
+			BigDecimal.valueOf(5.0),
+			"Great auction transaction."
+		));
+		reviewRepository.save(Review.create(
+			secondReviewer.getMemberId(),
+			sellerId,
+			productId,
+			auctionId,
+			BigDecimal.valueOf(4.0),
+			"Good auction transaction."
+		));
 
 		mockMvc.perform(get("/api/v1/auctions/{auctionId}", auctionId)
 				.header("Authorization", "Bearer " + accessToken))
@@ -634,6 +662,7 @@ class AuctionIntegrationTest {
 			.andExpect(jsonPath("$.images[0].sortOrder").value(1))
 			.andExpect(jsonPath("$.seller.memberId").isNumber())
 			.andExpect(jsonPath("$.seller.nickname").value(startsWith("Dealit#")))
+			.andExpect(jsonPath("$.seller.rating").value(4.5))
 			.andExpect(jsonPath("$.startPrice").value(180000))
 			.andExpect(jsonPath("$.currentPrice").value(180000))
 			.andExpect(jsonPath("$.minimumBidAmount").value(1800))
@@ -729,6 +758,19 @@ class AuctionIntegrationTest {
 			.andExpect(status().isBadRequest())
 			.andExpect(jsonPath("$.code").value("INVALID_AUCTION_REQUEST"))
 			.andExpect(jsonPath("$.message").value("경매 판매에서는 진행 기간 또는 종료 시각이 필수입니다."));
+	}
+
+	private Member saveReviewMember(String loginId, String email) {
+		Member member = Member.create(
+			loginId,
+			passwordEncoder.encode("Password123!"),
+			email,
+			null,
+			loginId
+		);
+		Member saved = memberRepository.save(member);
+		saved.assignDefaultNickname();
+		return memberRepository.save(saved);
 	}
 
 	private void deleteStoredImages() throws IOException {

--- a/src/test/java/com/dealit/dealit/domain/product/ProductDetailIntegrationTest.java
+++ b/src/test/java/com/dealit/dealit/domain/product/ProductDetailIntegrationTest.java
@@ -66,6 +66,7 @@ class ProductDetailIntegrationTest {
 			true
 		));
 		seller.assignDefaultNickname();
+		seller.updateProfile(seller.getName(), seller.getNickname(), "Detail seller bio.", seller.getProfileImage());
 		seller.updateLocation("Seoul Gangnam");
 		seller = memberRepository.save(seller);
 
@@ -100,6 +101,7 @@ class ProductDetailIntegrationTest {
 			.andExpect(jsonPath("$.status").value("ON_SALE"))
 			.andExpect(jsonPath("$.seller.memberId").value(seller.getMemberId()))
 			.andExpect(jsonPath("$.seller.nickname").value(seller.getNickname()))
+			.andExpect(jsonPath("$.seller.bio").value("Detail seller bio."))
 			.andExpect(jsonPath("$.seller.location").value("Seoul Gangnam"))
 			.andExpect(jsonPath("$.seller.rating").value(0.0))
 			.andExpect(jsonPath("$.generalSale.price").value(12000))


### PR DESCRIPTION
### 📌 Summary

경매 상세 API 응답에 판매자 리뷰 평균 평점(`seller.rating`)을 추가했습니다.

---

### 📝Description

- `GET /api/v1/auctions/{auctionId}` 응답의 `seller` 객체에 `rating` 필드를 추가했습니다.
- 경매 상품 판매자 ID를 기준으로 기존 리뷰 평균 조회 로직을 사용해 평점을 계산합니다.
- 리뷰 평균 조회 결과가 없을 경우 `0.0`을 반환하도록 방어 처리했습니다.
- 경매 상세 응답 테스트에 `seller.rating` 검증을 추가했습니다.

응답 변경 예시:

```json
{
  "seller": {
    "memberId": 1,
    "nickname": "Dealit#1",
    "profileImageUrl": null,
    "rating": 4.5
  }
}

### 🎲 Issue Number


close #{Issue Number}
