### PR TITLE
[fix] 웹 푸시 중복 표시 방지 및 리뷰 알림 추가

### DIFF
--- a/src/main/java/com/dealit/dealit/domain/review/service/ReviewService.java
+++ b/src/main/java/com/dealit/dealit/domain/review/service/ReviewService.java
@@ -6,6 +6,10 @@ import com.dealit.dealit.domain.auction.repository.AuctionRepository;
 import com.dealit.dealit.domain.auth.exception.InvalidCredentialsException;
 import com.dealit.dealit.domain.member.entity.Member;
 import com.dealit.dealit.domain.member.repository.MemberRepository;
+import com.dealit.dealit.domain.notification.dto.NotificationCreateRequest;
+import com.dealit.dealit.domain.notification.entity.InAppNotificationType;
+import com.dealit.dealit.domain.notification.service.FcmNotificationService;
+import com.dealit.dealit.domain.notification.service.NotificationCenterService;
 import com.dealit.dealit.domain.product.ProductSaleType;
 import com.dealit.dealit.domain.product.entity.Product;
 import com.dealit.dealit.domain.product.repository.ProductRepository;
@@ -28,6 +32,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
@@ -37,17 +42,21 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
 
 @Service
+@Slf4j
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class ReviewService {
 
 	private static final ZoneId SEOUL_ZONE = ZoneId.of("Asia/Seoul");
+	private static final String REVIEW_TARGET_TYPE = "REVIEW";
 
 	private final ReviewRepository reviewRepository;
 	private final ProductRepository productRepository;
 	private final AuctionRepository auctionRepository;
 	private final MemberRepository memberRepository;
 	private final PurchaseRepository purchaseRepository;
+	private final NotificationCenterService notificationCenterService;
+	private final FcmNotificationService fcmNotificationService;
 
 	@Transactional
 	public ReviewResponse createReview(Long reviewerId, CreateReviewRequest request) {
@@ -68,6 +77,7 @@ public class ReviewService {
 			request.rating().setScale(1, RoundingMode.UNNECESSARY),
 			request.content().trim()
 		));
+		notifyReviewReceived(review, target.product());
 
 		Map<Long, Member> membersById = loadMembersById(Set.of(review.getReviewerId(), review.getRevieweeId()));
 		Map<Long, Product> productsById = loadProductsById(Set.of(review.getProductId()));
@@ -157,6 +167,43 @@ public class ReviewService {
 			: reviewRepository.existsByReviewerIdAndAuctionIdAndDeletedAtIsNull(reviewerId, target.auctionId());
 		if (exists) {
 			throw new ResponseStatusException(HttpStatus.CONFLICT, "Review already exists.");
+		}
+	}
+
+	private void notifyReviewReceived(Review review, Product product) {
+		String title = "리뷰가 등록되었습니다.";
+		String content = "'" + product.getName() + "' 구매자가 거래 리뷰를 작성했어요.";
+		String targetUrl = "/mypage/review";
+
+		notificationCenterService.create(
+			review.getRevieweeId(),
+			new NotificationCreateRequest(
+				InAppNotificationType.TRADE,
+				title,
+				content,
+				REVIEW_TARGET_TYPE,
+				review.getReviewId(),
+				targetUrl
+			)
+		);
+
+		try {
+			int sentCount = fcmNotificationService.sendToMember(
+				review.getRevieweeId(),
+				title,
+				content,
+				Map.of(
+					"type", "REVIEW_RECEIVED",
+					"reviewId", String.valueOf(review.getReviewId()),
+					"productId", String.valueOf(review.getProductId()),
+					"targetUrl", targetUrl
+				)
+			);
+			log.debug("Sent review push notification. reviewId={}, revieweeId={}, sentCount={}",
+				review.getReviewId(), review.getRevieweeId(), sentCount);
+		} catch (RuntimeException exception) {
+			log.warn("Failed to send review push notification. reviewId={}, revieweeId={}",
+				review.getReviewId(), review.getRevieweeId(), exception);
 		}
 	}
 

--- a/src/test/java/com/dealit/dealit/domain/purchase/PurchaseIntegrationTest.java
+++ b/src/test/java/com/dealit/dealit/domain/purchase/PurchaseIntegrationTest.java
@@ -735,6 +735,13 @@ class PurchaseIntegrationTest {
 			.andExpect(jsonPath("$.reviewerId").value(buyer.getMemberId()))
 			.andExpect(jsonPath("$.revieweeId").value(seller.getMemberId()));
 
+		assertThat(notificationRepository.findAll())
+			.anySatisfy(notification -> {
+				assertThat(notification.getTitle()).isEqualTo("리뷰가 등록되었습니다.");
+				assertThat(notification.getTargetType()).isEqualTo("REVIEW");
+				assertThat(notification.getTargetUrl()).isEqualTo("/mypage/review");
+			});
+
 		mockMvc.perform(get("/api/v1/mypage/purchases")
 				.with(authentication(authenticatedMember(buyer))))
 			.andExpect(status().isOk())


### PR DESCRIPTION
### 🚀 Summary

<!-- 작업 내용에 대한 간략한 설명을 써주세요. -->
  - FCM 백그라운드 푸시 알림이 두 번 표시될 수 있는 문제를 수정했습니다.
  - `notification` payload가 있는 푸시는 브라우저/FCM 자동 표시만 사용하고, `data-only` 푸시일 때만
  서비스워커가 직접 알림을 표시하도록 변경했습니다.
  - 기기별로 오래된 서비스워커가 남아 중복 알림 로직을 계속 사용할 가능성을 줄이기 위해 서비스워커
  업데이트 확인을 강화했습니다.
  - 구매자가 리뷰를 작성하면 판매자에게 리뷰 등록 알림이 가도록 추가했습니다.
---

### ✨ Description

<!-- 상세한 설명, 기능의 사용법, 주의 사항 실행 결과(이미지 첨부 가능) 등을 보여주세요. -->
  ## 변경 내용

  ### 푸시 알림 중복 표시 방지

  기존에는 백그라운드 FCM 메시지를 받을 때 서비스워커가 항상 `showNotification()`을 호출했습니다.

  FCM 메시지에 `notification` payload가 포함된 경우 브라우저/FCM이 이미 알림을 자동 표시할 수 있기
  때문에, 서비스워커가 다시 알림을 띄우면 같은 푸시가 두 번 표시될 수 있었습니다.

  이제는 `payload.notification`이 있으면 서비스워커가 직접 표시하지 않고 종료합니다.
  대신 `data-only` 메시지처럼 자동 표시가 되지 않는 경우에만 `showNotification()`을 fallback으로 호
  출합니다.

  ### 서비스워커 최신화 강화

  FCM 토큰 등록 시 서비스워커를 등록할 때 다음 옵션과 업데이트 호출을 추가했습니다.

  - `updateViaCache: "none"`
  - `registration.update()`

  이를 통해 브라우저가 캐시된 예전 서비스워커를 계속 사용하는 상황을 줄였습니다.

  ### 리뷰 작성 알림 추가
  구매자가 거래 리뷰를 작성하면 판매자에게 인앱 알림과 FCM 푸시가 전송되도록 추가했습니다.
  알림 클릭 대상은 `/mypage/review`입니다.

---

### 🎲 Issue Number

<!-- Please enter {Issue Number} below to automatically close the connected issue. -->

close #122 
