### PR TITLE
[test] OpenSearch 인덱싱 비동기 처리 및 k6 측정 추가

### DIFF
--- a/scripts/k6/product-update.js
+++ b/scripts/k6/product-update.js
@@ -1,0 +1,51 @@
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+
+export const options = {
+  vus: Number(__ENV.VUS || 10),
+  duration: __ENV.DURATION || '30s',
+  thresholds: {
+    http_req_failed: ['rate<0.01'],
+  },
+};
+
+const BASE_URL = __ENV.BASE_URL || 'http://host.docker.internal:8080';
+const TOKEN = __ENV.TOKEN;
+const PRODUCT_ID = __ENV.PRODUCT_ID;
+const IMAGE_ID = __ENV.IMAGE_ID;
+const CATEGORY_ID = Number(__ENV.CATEGORY_ID || 19);
+
+if (!TOKEN || !PRODUCT_ID || !IMAGE_ID) {
+  throw new Error('TOKEN, PRODUCT_ID, and IMAGE_ID env vars are required.');
+}
+
+export default function () {
+  const payload = JSON.stringify({
+    name: `k6 updated product ${__VU}-${__ITER}`,
+    description: 'k6 OpenSearch indexing latency measurement',
+    categoryId: CATEGORY_ID,
+    price: 30000,
+    allowOffer: false,
+    location: 'Seoul',
+    images: [
+      {
+        imageId: Number(IMAGE_ID),
+        imageUrl: 'http://localhost:8080/uploads/product/images/test-image.jpg',
+        sortOrder: 1,
+      },
+    ],
+  });
+
+  const response = http.patch(`${BASE_URL}/api/v1/products/${PRODUCT_ID}`, payload, {
+    headers: {
+      Authorization: `Bearer ${TOKEN}`,
+      'Content-Type': 'application/json',
+    },
+  });
+
+  check(response, {
+    'status is 200': (r) => r.status === 200,
+  });
+
+  sleep(1);
+}

--- a/src/main/java/com/dealit/dealit/DealitApplication.java
+++ b/src/main/java/com/dealit/dealit/DealitApplication.java
@@ -4,7 +4,9 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.scheduling.annotation.EnableAsync;
 
+@EnableAsync
 @EnableCaching
 @SpringBootApplication
 @ConfigurationPropertiesScan

--- a/src/main/java/com/dealit/dealit/domain/search/event/SearchIndexEventListener.java
+++ b/src/main/java/com/dealit/dealit/domain/search/event/SearchIndexEventListener.java
@@ -3,6 +3,7 @@ package com.dealit.dealit.domain.search.event;
 import com.dealit.dealit.domain.search.service.SearchIndexService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
@@ -14,21 +15,25 @@ public class SearchIndexEventListener {
 
 	private final SearchIndexService searchIndexService;
 
+	@Async("searchIndexTaskExecutor")
 	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
 	public void handle(ProductSearchIndexRequestedEvent event) {
 		runSafely("product index", event.productId(), () -> searchIndexService.indexRegularProduct(event.productId()));
 	}
 
+	@Async("searchIndexTaskExecutor")
 	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
 	public void handle(ProductSearchDeleteRequestedEvent event) {
 		runSafely("product delete", event.productId(), () -> searchIndexService.deleteRegularProduct(event.productId()));
 	}
 
+	@Async("searchIndexTaskExecutor")
 	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
 	public void handle(AuctionSearchIndexRequestedEvent event) {
 		runSafely("auction index", event.auctionId(), () -> searchIndexService.indexAuction(event.auctionId()));
 	}
 
+	@Async("searchIndexTaskExecutor")
 	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
 	public void handle(AuctionSearchDeleteRequestedEvent event) {
 		runSafely("auction delete", event.auctionId(), () -> searchIndexService.deleteAuction(event.auctionId()));

--- a/src/main/java/com/dealit/dealit/global/config/SearchIndexTaskExecutorConfig.java
+++ b/src/main/java/com/dealit/dealit/global/config/SearchIndexTaskExecutorConfig.java
@@ -1,0 +1,26 @@
+package com.dealit.dealit.global.config;
+
+import java.util.concurrent.Executor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+@Configuration
+public class SearchIndexTaskExecutorConfig {
+
+	@Bean
+	public Executor searchIndexTaskExecutor(
+		@Value("${app.search.index.executor.core-pool-size:2}") int corePoolSize,
+		@Value("${app.search.index.executor.max-pool-size:8}") int maxPoolSize,
+		@Value("${app.search.index.executor.queue-capacity:500}") int queueCapacity
+	) {
+		ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+		executor.setThreadNamePrefix("search-index-");
+		executor.setCorePoolSize(corePoolSize);
+		executor.setMaxPoolSize(maxPoolSize);
+		executor.setQueueCapacity(queueCapacity);
+		executor.initialize();
+		return executor;
+	}
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -53,6 +53,11 @@ app:
     service-account-json: ${FIREBASE_SERVICE_ACCOUNT_JSON:}
     service-account-base64: ${FIREBASE_SERVICE_ACCOUNT_BASE64:}
   search:
+    index:
+      executor:
+        core-pool-size: ${APP_SEARCH_INDEX_EXECUTOR_CORE_POOL_SIZE:2}
+        max-pool-size: ${APP_SEARCH_INDEX_EXECUTOR_MAX_POOL_SIZE:8}
+        queue-capacity: ${APP_SEARCH_INDEX_EXECUTOR_QUEUE_CAPACITY:500}
     opensearch:
       enabled: ${OPENSEARCH_ENABLED:true}
       auto-reindex-on-startup: ${OPENSEARCH_AUTO_REINDEX_ON_STARTUP:false}


### PR DESCRIPTION
### 🚀 Summary

<!-- 작업 내용에 대한 간략한 설명을 써주세요. -->

---

### ✨ Description

<!-- 상세한 설명, 기능의 사용법, 주의 사항 실행 결과(이미지 첨부 가능) 등을 보여주세요. -->
## 개요

상품/경매 변경 이후 실행되는 OpenSearch 인덱싱을 전용 Executor 기반 비동기 처리로 분리했습니다.

기존에는 `@TransactionalEventListener(AFTER_COMMIT)` 이후 OpenSearch index/delete 호출이 요청 처리 흐름에 포함될 수 있어, OpenSearch 지연이 상품 수정 API 응답 시간에 직접 영향을 줄 수 있었습니다.

이번 변경으로 DB 커밋 이후 검색 인덱스 갱신은 백그라운드에서 수행되도록 분리했습니다.

## 작업 내용

- `@EnableAsync` 적용
- `searchIndexTaskExecutor` 전용 `ThreadPoolTaskExecutor` 추가
- `SearchIndexEventListener`에 `@Async("searchIndexTaskExecutor")` 적용
- 검색 인덱싱 executor 설정 추가
- 상품 수정 API 측정용 k6 스크립트 추가

## 측정 조건

- API: `PATCH /api/v1/products/{productId}`
- VUS: 10
- Duration: 30s
- OpenSearch indexing delay: 1000ms
- 참고: delay 주입 코드는 로컬 측정용으로만 사용했고 PR 코드에는 포함하지 않음

## 측정 결과

| 조건 | 요청 수 | avg | med | p90 | p95 | max | 실패율 |
|---|---:|---:|---:|---:|---:|---:|---:|
| 정상 상태 | 300 | 24ms | 19.81ms | 33.14ms | 40.43ms | 131.29ms | 0.00% |
| OpenSearch 1s 지연 + 동기 처리 | 110 | 2.15s | 1.04s | 5.05s | 5.37s | 5.37s | 0.00% |
| OpenSearch 1s 지연 + 비동기 처리 | 290 | 36.9ms | 17.8ms | 38.41ms | 59.6ms | 469.88ms | 0.00% |

## 개선 효과

OpenSearch 인덱싱 1초 지연 조건에서 상품 수정 API의 p95 응답 시간이 다음과 같이 개선되었습니다.

5.37s -> 59.6ms
p95 기준 약 98.9% 감소했습니다.
(5370ms - 59.6ms) / 5370ms * 100 = 약 98.9%

## 검증
k6 측정:
Get-Content -Raw scripts\k6\product-update.js | docker run --rm -i `
  -e BASE_URL=http://host.docker.internal:8080 `
  -e TOKEN="$TOKEN" `
  -e PRODUCT_ID="$PRODUCT_ID" `
  -e IMAGE_ID="$IMAGE_ID" `
  -e VUS=10 `
  -e DURATION=30s `
  grafana/k6 run -

---

### 🎲 Issue Number

<!-- Please enter {Issue Number} below to automatically close the connected issue. -->

close #{Issue Number}
